### PR TITLE
feat(W3.5-A): admin UI — auth + shell foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,12 @@ jobs:
           echo 'DA_DATABASE_URL=postgresql+asyncpg://da:changeme@postgres:5432/deep_analysis' >> .env
           echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" >> .env
           echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}" >> .env
+      - name: Generate JWT keypair for CI
+        run: |
+          mkdir -p /tmp/ci-jwt-keys
+          uv run python -m auth_service.keygen --out /tmp/ci-jwt-keys
+          chmod 644 /tmp/ci-jwt-keys/jwt_public.pem
+          chmod 600 /tmp/ci-jwt-keys/jwt_private.pem
       - name: Start postgres only (pre-migration)
         run: docker compose -f docker-compose.yml -f ci/docker-compose.ci.yml up -d --build postgres
       - name: Wait for postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,8 +232,8 @@ jobs:
           echo 'DA_DATABASE_URL=postgresql+asyncpg://da:changeme@postgres:5432/deep_analysis' >> .env
           echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" >> .env
           echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}" >> .env
-      - name: docker compose up
-        run: docker compose -f docker-compose.yml -f ci/docker-compose.ci.yml up -d --build
+      - name: Start postgres only (pre-migration)
+        run: docker compose -f docker-compose.yml -f ci/docker-compose.ci.yml up -d --build postgres
       - name: Wait for postgres
         run: |
           for i in $(seq 1 30); do
@@ -252,6 +252,8 @@ jobs:
         run: uv run alembic -c services/auth/alembic.ini upgrade head
       - name: alembic upgrade head (ingest)
         run: uv run alembic -c services/ingest/alembic.ini upgrade head
+      - name: docker compose up (full stack)
+        run: docker compose -f docker-compose.yml -f ci/docker-compose.ci.yml up -d --build
       - name: Wait for gateway + auth bootstrap
         run: |
           for i in $(seq 1 60); do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,13 @@ jobs:
     env:
       DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL: admin@ci.local
       DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD: CISmokeAdminPass2026!
+      DATABASE_URL: postgresql+psycopg://da:changeme@localhost:5432/deep_analysis
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: uv sync
+        run: uv sync --all-packages --dev
       - name: Map deepanalysis.local to loopback
         run: echo "127.0.0.1 deepanalysis.local" | sudo tee -a /etc/hosts
       - name: Seed .env for compose (with bootstrap admin)
@@ -229,6 +234,24 @@ jobs:
           echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}" >> .env
       - name: docker compose up
         run: docker compose -f docker-compose.yml -f ci/docker-compose.ci.yml up -d --build
+      - name: Wait for postgres
+        run: |
+          for i in $(seq 1 30); do
+            if docker compose exec -T postgres pg_isready -U da -d deep_analysis > /dev/null 2>&1; then
+              echo "postgres healthy after ${i} tries"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "postgres never became healthy"
+          docker compose ps
+          exit 1
+      - name: alembic upgrade head (root)
+        run: uv run alembic upgrade head
+      - name: alembic upgrade head (auth)
+        run: uv run alembic -c services/auth/alembic.ini upgrade head
+      - name: alembic upgrade head (ingest)
+        run: uv run alembic -c services/ingest/alembic.ini upgrade head
       - name: Wait for gateway + auth bootstrap
         run: |
           for i in $(seq 1 60); do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,63 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.yml -f ci/docker-compose.ci.yml down -v
 
+  smoke-ui:
+    name: smoke-ui
+    runs-on: ubuntu-latest
+    needs: [compose-smoke]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
+    env:
+      DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL: admin@ci.local
+      DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD: CISmokeAdminPass2026!
+    steps:
+      - uses: actions/checkout@v4
+      - name: Map deepanalysis.local to loopback
+        run: echo "127.0.0.1 deepanalysis.local" | sudo tee -a /etc/hosts
+      - name: Seed .env for compose (with bootstrap admin)
+        run: |
+          cp .env.example .env
+          echo 'GATEWAY_DOMAIN=deepanalysis.local' >> .env
+          echo 'DEEP_ANALYSIS_ACME_EMAIL=ci@example.com' >> .env
+          echo 'DA_DATABASE_URL=postgresql+asyncpg://da:changeme@postgres:5432/deep_analysis' >> .env
+          echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" >> .env
+          echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}" >> .env
+      - name: docker compose up
+        run: docker compose -f docker-compose.yml -f ci/docker-compose.ci.yml up -d --build
+      - name: Wait for gateway + auth bootstrap
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sk -o /dev/null -w "%{http_code}" https://deepanalysis.local/health | grep -q 200; then
+              break
+            fi
+            sleep 2
+          done
+          # Bootstrap admin is created during the auth container's
+          # lifespan startup — give it a few extra seconds after the
+          # gateway answers to finish the DB write.
+          for i in $(seq 1 30); do
+            code=$(curl -sk -o /dev/null -w "%{http_code}" \
+              -X POST https://deepanalysis.local/auth/login \
+              -H 'Content-Type: application/json' \
+              -d "{\"email\":\"${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}\",\"password\":\"${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}\"}")
+            if [ "$code" = "200" ]; then
+              echo "bootstrap admin ready after ${i} tries"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "bootstrap admin never came online"
+          docker compose ps
+          docker compose logs --tail=200
+          exit 1
+      - name: Run UI smoke
+        run: bash ci/smoke_ui.sh https://deepanalysis.local
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose logs --tail=200
+      - name: docker compose down
+        if: always()
+        run: docker compose -f docker-compose.yml -f ci/docker-compose.ci.yml down -v
+
   diagram-drift:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
         run: uv run pytest services/auth/tests/
       - name: pytest services/ingest/tests
         run: uv run pytest services/ingest/tests/
+      - name: pytest services/web/tests
+        run: uv run pytest services/web/tests/
 
   docker-build:
     name: docker-build (${{ matrix.service }})

--- a/ci/docker-compose.ci.yml
+++ b/ci/docker-compose.ci.yml
@@ -1,5 +1,14 @@
-# ci/docker-compose.ci.yml — CI override for compose-smoke
+# ci/docker-compose.ci.yml — CI override for compose-smoke and smoke-ui.
+#
 # Switches the gateway from ACME (needs public DNS) to tls internal for CI.
+#
+# JWT key handling for smoke-ui:
+# The auth service generates the RS256 keypair at container startup if the
+# private key is absent. In CI, we generate the keypair on the host before
+# docker compose up and bind-mount the key directory into every service that
+# needs JWT access (auth: both keys; all others: public key only).
+# The host-side path used in CI workflows is /tmp/ci-jwt-keys/ — set via
+# DA_JWT_KEYS_DIR in the CI environment (defaults to /tmp/ci-jwt-keys).
 services:
   gateway:
     environment:
@@ -7,3 +16,34 @@ services:
       DEEP_ANALYSIS_ACME_EMAIL: ""  # not used with tls internal
     volumes:
       - ./ci/Caddyfile.ci:/etc/caddy/Caddyfile:ro
+
+  auth:
+    environment:
+      DA_JWT_PRIVATE_KEY_PATH: /data/secrets/jwt_private.pem
+      DA_JWT_PUBLIC_KEY_PATH: /data/secrets/jwt_public.pem
+    volumes:
+      - /tmp/ci-jwt-keys:/data/secrets:ro
+
+  ingest:
+    environment:
+      DA_JWT_PUBLIC_KEY_PATH: /data/secrets/jwt_public.pem
+    volumes:
+      - /tmp/ci-jwt-keys:/data/secrets:ro
+
+  web:
+    environment:
+      DA_JWT_PUBLIC_KEY_PATH: /data/secrets/jwt_public.pem
+    volumes:
+      - /tmp/ci-jwt-keys:/data/secrets:ro
+
+  analytics:
+    environment:
+      DA_JWT_PUBLIC_KEY_PATH: /data/secrets/jwt_public.pem
+    volumes:
+      - /tmp/ci-jwt-keys:/data/secrets:ro
+
+  parser:
+    environment:
+      DA_JWT_PUBLIC_KEY_PATH: /data/secrets/jwt_public.pem
+    volumes:
+      - /tmp/ci-jwt-keys:/data/secrets:ro

--- a/ci/smoke_ui.sh
+++ b/ci/smoke_ui.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# ci/smoke_ui.sh — Browser-UI smoke test against the running compose stack.
+#
+# Covers the W3.5-A surface: login form render, credential submit →
+# cookie + redirect to /dashboard, dashboard requires auth (redirect
+# to /login when no cookie), password change → fresh cookie + redirect,
+# logout → cookie cleared + redirect to /login.
+#
+# Requires DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL and
+# DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD to be set (same bootstrap
+# admin the API smoke uses).
+#
+# Usage:
+#   DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=... \
+#   DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=... \
+#   bash ci/smoke_ui.sh https://deepanalysis.local
+#
+# Exit 0 = all checks passed. Exit 1 = one or more failed.
+
+set -euo pipefail
+
+BASE_URL="${1:-https://deepanalysis.local}"
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS: $label (got $actual)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected $expected, got $actual)" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_contains() {
+    local label="$1"
+    local needle="$2"
+    local haystack="$3"
+    if echo "$haystack" | grep -q -- "$needle"; then
+        echo "  PASS: $label (contains '$needle')"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (missing '$needle')" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Returns non-empty if the Netscape-format cookie jar contains a
+# live (non-expired, non-empty-value) da_session cookie.
+jar_has_live_session() {
+    local jar="$1"
+    [ -s "$jar" ] || return 1
+    # Netscape format: domain \t http_only \t path \t secure \t expires \t name \t value
+    awk -v now="$(date +%s)" '
+        $0 !~ /^#/ && $0 !~ /^$/ {
+            # Count real fields (tab-separated).
+            n = split($0, f, "\t")
+            if (n < 7) next
+            if (f[6] != "da_session") next
+            if (f[7] == "") next
+            if (f[5] != "0" && f[5]+0 <= now) next
+            print "live"
+            exit
+        }
+    ' "$jar" | grep -q live
+}
+
+if [ -z "${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL:-}" ] || \
+   [ -z "${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD:-}" ]; then
+    echo "FAIL: DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL and DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD must be set" >&2
+    exit 1
+fi
+
+COOKIE_JAR=$(mktemp)
+PW_COOKIE=$(mktemp)
+LOGOUT_COOKIE=$(mktemp)
+trap 'rm -f "$COOKIE_JAR" "$PW_COOKIE" "$LOGOUT_COOKIE"' EXIT
+
+echo "=== Deep Analysis UI smoke — $BASE_URL ==="
+
+# --------------------------------------------------------------------------
+# 1. GET /login — form renders
+# --------------------------------------------------------------------------
+echo ""
+echo "--- 1. GET /login ---"
+
+login_body=$(curl -sk -o - -w "\n%{http_code}" "$BASE_URL/login")
+login_status=$(echo "$login_body" | tail -n1)
+login_html=$(echo "$login_body" | sed '$d')
+check "GET /login → 200" "200" "$login_status"
+check_contains "GET /login contains <form" "<form" "$login_html"
+
+# --------------------------------------------------------------------------
+# 2. POST /login — valid creds → redirect + da_session cookie set
+# --------------------------------------------------------------------------
+echo ""
+echo "--- 2. POST /login (valid creds) ---"
+
+post_status=$(curl -sk -o /dev/null -w "%{http_code}" \
+    -c "$COOKIE_JAR" \
+    -X POST "$BASE_URL/login" \
+    --data-urlencode "email=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" \
+    --data-urlencode "password=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}")
+# 303 See Other — spec-preferred for POST→GET redirect after form submit.
+check "POST /login → 303" "303" "$post_status"
+
+if jar_has_live_session "$COOKIE_JAR"; then
+    check "da_session cookie set" "ok" "ok"
+else
+    check "da_session cookie set" "ok" "FAILED (no live cookie)"
+fi
+
+# --------------------------------------------------------------------------
+# 3. GET /dashboard with cookie → 200 + "Welcome"
+# --------------------------------------------------------------------------
+echo ""
+echo "--- 3. GET /dashboard (authenticated) ---"
+
+dash_out=$(curl -sk -b "$COOKIE_JAR" -o - -w "\n%{http_code}" "$BASE_URL/dashboard")
+dash_status=$(echo "$dash_out" | tail -n1)
+dash_html=$(echo "$dash_out" | sed '$d')
+check "GET /dashboard (with cookie) → 200" "200" "$dash_status"
+check_contains "GET /dashboard contains 'Welcome'" "Welcome" "$dash_html"
+
+# --------------------------------------------------------------------------
+# 4. GET /dashboard without cookie → 302 to /login?next=/dashboard
+# --------------------------------------------------------------------------
+echo ""
+echo "--- 4. GET /dashboard (unauthenticated) ---"
+
+noauth_head=$(curl -sk -D - -o /dev/null "$BASE_URL/dashboard")
+noauth_status=$(echo "$noauth_head" | head -n1 | awk '{print $2}')
+check "GET /dashboard (no cookie) → 302" "302" "$noauth_status"
+check_contains "Redirect targets /login?next=/dashboard" "/login?next=/dashboard" "$noauth_head"
+
+# --------------------------------------------------------------------------
+# 5. POST /settings/password — rotate + re-login → fresh cookie
+# --------------------------------------------------------------------------
+echo ""
+echo "--- 5. POST /settings/password (rotate) ---"
+
+NEW_PASSWORD="ui-smoke-${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}"
+
+pw_head=$(curl -sk -D - -o /dev/null \
+    -b "$COOKIE_JAR" \
+    -c "$PW_COOKIE" \
+    -X POST "$BASE_URL/settings/password" \
+    --data-urlencode "current_password=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}" \
+    --data-urlencode "new_password=${NEW_PASSWORD}" \
+    --data-urlencode "confirm_password=${NEW_PASSWORD}")
+pw_status=$(echo "$pw_head" | head -n1 | awk '{print $2}')
+check "POST /settings/password → 303" "303" "$pw_status"
+check_contains "Redirects to /dashboard" "Location: /dashboard" "$pw_head"
+
+if jar_has_live_session "$PW_COOKIE"; then
+    check "Fresh da_session cookie after password change" "ok" "ok"
+else
+    check "Fresh da_session cookie after password change" "ok" "FAILED (no live cookie)"
+fi
+
+# Restore the bootstrap password for any follow-up smoke runs.
+restore_status=$(curl -sk -o /dev/null -w "%{http_code}" \
+    -b "$PW_COOKIE" \
+    -c "$PW_COOKIE" \
+    -X POST "$BASE_URL/settings/password" \
+    --data-urlencode "current_password=${NEW_PASSWORD}" \
+    --data-urlencode "new_password=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}" \
+    --data-urlencode "confirm_password=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}")
+check "Restore bootstrap password → 303" "303" "$restore_status"
+
+# --------------------------------------------------------------------------
+# 6. POST /logout → 303 to /login, cookie cleared
+# --------------------------------------------------------------------------
+echo ""
+echo "--- 6. POST /logout ---"
+
+# First log in fresh so we have a live cookie to logout with.
+curl -sk -o /dev/null -c "$LOGOUT_COOKIE" \
+    -X POST "$BASE_URL/login" \
+    --data-urlencode "email=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" \
+    --data-urlencode "password=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}"
+
+logout_head=$(curl -sk -D - -o /dev/null \
+    -b "$LOGOUT_COOKIE" \
+    -c "$LOGOUT_COOKIE" \
+    -X POST "$BASE_URL/logout")
+logout_status=$(echo "$logout_head" | head -n1 | awk '{print $2}')
+check "POST /logout → 303" "303" "$logout_status"
+check_contains "Logout redirects to /login" "Location: /login" "$logout_head"
+
+if jar_has_live_session "$LOGOUT_COOKIE"; then
+    check "da_session cookie cleared" "ok" "FAILED (cookie still live)"
+else
+    check "da_session cookie cleared" "ok" "ok"
+fi
+
+# --------------------------------------------------------------------------
+# Result
+# --------------------------------------------------------------------------
+echo ""
+echo "=== UI smoke result: $PASS PASS, $FAIL FAIL ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/ci/smoke_ui.sh
+++ b/ci/smoke_ui.sh
@@ -101,18 +101,27 @@ check_contains "GET /login contains <form" "<form" "$login_html"
 echo ""
 echo "--- 2. POST /login (valid creds) ---"
 
-post_status=$(curl -sk -o /dev/null -w "%{http_code}" \
+post_head=$(curl -sk -D - -o /dev/null \
     -c "$COOKIE_JAR" \
     -X POST "$BASE_URL/login" \
     --data-urlencode "email=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" \
     --data-urlencode "password=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}")
+post_status=$(echo "$post_head" | head -n1 | awk '{print $2}')
 # 303 See Other — spec-preferred for POST→GET redirect after form submit.
 check "POST /login → 303" "303" "$post_status"
+# Location may be absolute (https://host/dashboard) or relative (/dashboard).
+check_contains "POST /login redirects to /dashboard" "/dashboard" "$post_head"
 
 if jar_has_live_session "$COOKIE_JAR"; then
     check "da_session cookie set" "ok" "ok"
 else
-    check "da_session cookie set" "ok" "FAILED (no live cookie)"
+    # Cookie jar check can be flaky with self-signed TLS and Secure flag;
+    # fall back to verifying the header directly.
+    if echo "$post_head" | grep -qi "set-cookie:.*da_session="; then
+        check "da_session cookie set" "ok" "ok"
+    else
+        check "da_session cookie set" "ok" "FAILED (no live cookie)"
+    fi
 fi
 
 # --------------------------------------------------------------------------
@@ -155,12 +164,17 @@ pw_head=$(curl -sk -D - -o /dev/null \
     --data-urlencode "confirm_password=${NEW_PASSWORD}")
 pw_status=$(echo "$pw_head" | head -n1 | awk '{print $2}')
 check "POST /settings/password → 303" "303" "$pw_status"
-check_contains "Redirects to /dashboard" "Location: /dashboard" "$pw_head"
+# Location may be absolute (https://host/dashboard) or relative (/dashboard).
+check_contains "Redirects to /dashboard" "/dashboard" "$pw_head"
 
 if jar_has_live_session "$PW_COOKIE"; then
     check "Fresh da_session cookie after password change" "ok" "ok"
 else
-    check "Fresh da_session cookie after password change" "ok" "FAILED (no live cookie)"
+    if echo "$pw_head" | grep -qi "set-cookie:.*da_session="; then
+        check "Fresh da_session cookie after password change" "ok" "ok"
+    else
+        check "Fresh da_session cookie after password change" "ok" "FAILED (no live cookie)"
+    fi
 fi
 
 # Restore the bootstrap password for any follow-up smoke runs.
@@ -191,7 +205,8 @@ logout_head=$(curl -sk -D - -o /dev/null \
     -X POST "$BASE_URL/logout")
 logout_status=$(echo "$logout_head" | head -n1 | awk '{print $2}')
 check "POST /logout → 303" "303" "$logout_status"
-check_contains "Logout redirects to /login" "Location: /login" "$logout_head"
+# Location may be absolute (https://host/login) or relative (/login).
+check_contains "Logout redirects to /login" "/login" "$logout_head"
 
 if jar_has_live_session "$LOGOUT_COOKIE"; then
     check "da_session cookie cleared" "ok" "FAILED (cookie still live)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ ignore = []
 "services/auth/auth_service/admin.py" = ["B008"]
 "services/ingest/ingest_service/main.py" = ["B008"]
 "services/ingest/ingest_service/deps.py" = ["B008"]
+"services/web/web_service/main.py" = ["B008"]
+"services/web/web_service/deps.py" = ["B008"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/services/auth/auth_service/jwt_issue.py
+++ b/services/auth/auth_service/jwt_issue.py
@@ -33,6 +33,7 @@ class JWTIssuer:
         session_id: uuid.UUID,
         scope: str | None = None,
         override_ttl_seconds: int | None = None,
+        email: str | None = None,
     ) -> str:
         now = datetime.now(UTC)
         ttl = override_ttl_seconds if override_ttl_seconds is not None else self._access_ttl
@@ -47,6 +48,8 @@ class JWTIssuer:
         }
         if scope is not None:
             claims["scope"] = scope
+        if email is not None:
+            claims["email"] = email
         return jwt.encode(claims, self._private_key, algorithm="RS256")
 
 
@@ -72,9 +75,15 @@ def issue_access_token(
     session_id: uuid.UUID,
     scope: str | None = None,
     override_ttl_seconds: int | None = None,
+    email: str | None = None,
 ) -> str:
     return get_issuer().issue_access_token(
-        user_id, role, session_id, scope=scope, override_ttl_seconds=override_ttl_seconds
+        user_id,
+        role,
+        session_id,
+        scope=scope,
+        override_ttl_seconds=override_ttl_seconds,
+        email=email,
     )
 
 

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -164,10 +164,11 @@ async def login(
             session_row.id,
             scope=PASSWORD_CHANGE_SCOPE,
             override_ttl_seconds=settings.password_change_token_ttl_seconds,
+            email=user.email,
         )
         expires_in = settings.password_change_token_ttl_seconds
     else:
-        access = issue_access_token(user.id, user.role, session_row.id)
+        access = issue_access_token(user.id, user.role, session_row.id, email=user.email)
         expires_in = settings.access_token_ttl_seconds
 
     return TokenResponse(
@@ -218,7 +219,7 @@ async def refresh(
     await db.commit()
     await db.refresh(new_session)
 
-    access = issue_access_token(user.id, user.role, new_session.id)
+    access = issue_access_token(user.id, user.role, new_session.id, email=user.email)
     return TokenResponse(
         access_token=access,
         refresh_token=new_refresh,

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -4,7 +4,16 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir fastapi "uvicorn[standard]" structlog prometheus-client
+RUN pip install --no-cache-dir \
+    fastapi \
+    "uvicorn[standard]" \
+    structlog \
+    prometheus-client \
+    pydantic-settings \
+    "pyjwt[crypto]" \
+    jinja2 \
+    python-multipart \
+    httpx
 
 COPY common/ ./common/
 RUN pip install --no-cache-dir ./common/

--- a/services/web/pyproject.toml
+++ b/services/web/pyproject.toml
@@ -11,7 +11,16 @@ dependencies = [
     "uvicorn[standard]>=0.30",
     "structlog>=24.2",
     "prometheus-client>=0.20",
+    "pydantic-settings>=2.3",
+    "pyjwt[crypto]>=2.8",
+    "jinja2>=3.1",
+    "python-multipart>=0.0.9",
+    "httpx>=0.27",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["web_service"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"web_service/templates" = "web_service/templates"
+"web_service/static" = "web_service/static"

--- a/services/web/tests/conftest.py
+++ b/services/web/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Web service test fixtures.
+
+The web service is a thin HTTP shim — it doesn't open Postgres or
+Redis connections itself. We only need a JWT public key on disk so
+``BaseServiceSettings`` validates, plus placeholder DB/Redis URLs the
+settings model requires by type but the code never dials.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _web_test_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    out = tmp_path_factory.mktemp("web-jwt-keys")
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pub_path = out / "jwt_public.pem"
+    pub_path.write_bytes(pub_pem)
+
+    os.environ["DA_JWT_PUBLIC_KEY_PATH"] = str(pub_path)
+    os.environ.setdefault(
+        "DA_DATABASE_URL",
+        "postgresql+asyncpg://x:x@localhost:5432/x",
+    )
+    os.environ.setdefault("DA_REDIS_URL", "redis://localhost:6379/0")
+
+    yield pub_path

--- a/services/web/tests/test_auth_client_transport_errors.py
+++ b/services/web/tests/test_auth_client_transport_errors.py
@@ -1,0 +1,133 @@
+"""Auth-boundary transport-error translation in the web service.
+
+These tests verify two behaviors:
+
+1. ``auth_client.login`` and ``auth_client.change_password`` translate
+   raw ``httpx`` transport errors into ``AuthClientError`` so callers
+   get a uniform exception type at the boundary.
+2. The ``POST /login`` and ``POST /settings/password`` handlers catch
+   ``AuthClientError`` and render a 503 page in the appropriate
+   template instead of bubbling a 500.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest.mark.asyncio
+async def test_login_translates_transport_error_to_auth_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import auth_client
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise httpx.ConnectError("auth unreachable")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", boom)
+
+    with pytest.raises(auth_client.AuthClientError):
+        await auth_client.login("http://auth:8000", "u@example.com", "pw")
+
+
+@pytest.mark.asyncio
+async def test_change_password_translates_transport_error_to_auth_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import auth_client
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise httpx.ConnectError("auth unreachable")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", boom)
+
+    with pytest.raises(auth_client.AuthClientError):
+        await auth_client.change_password("http://auth:8000", "tok", "old-pw", "new-pw-9876")
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_post_login_returns_503_when_auth_unreachable(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import auth_client
+
+    async def raise_unreachable(*_a: Any, **_kw: Any) -> Any:
+        raise auth_client.AuthClientError("simulated outage")
+
+    monkeypatch.setattr(auth_client, "login", raise_unreachable)
+
+    r = await app_client.post(
+        "/login",
+        data={"email": "u@example.com", "password": "pw", "next": ""},
+    )
+    assert r.status_code == 503
+    assert "Authentication service unavailable" in r.text
+    # Login template marker — confirms the failure rendered the right page.
+    assert 'name="password"' in r.text
+    assert 'action="/login"' in r.text
+
+
+@pytest.mark.asyncio
+async def test_post_password_change_returns_503_when_auth_unreachable(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import auth_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def raise_unreachable(*_a: Any, **_kw: Any) -> Any:
+        raise auth_client.AuthClientError("simulated outage")
+
+    monkeypatch.setattr(auth_client, "change_password", raise_unreachable)
+
+    fake_user = _deps.BrowserUser(
+        user_id=1,
+        email="u@example.com",
+        role="user",
+        must_change_password=True,
+        scope=_deps.PASSWORD_CHANGE_SCOPE,
+        token="fake-token",
+    )
+
+    async def fake_user_dep() -> _deps.BrowserUser:
+        return fake_user
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user_any_scope] = fake_user_dep
+    try:
+        r = await app_client.post(
+            "/settings/password",
+            data={
+                "current_password": "old-pw",
+                "new_password": "new-pw-9876",
+                "confirm_password": "new-pw-9876",
+            },
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 503
+    assert "Authentication service unavailable" in r.text
+    # Password template marker — confirms the failure rendered the right page.
+    assert 'name="new_password"' in r.text
+    assert 'action="/settings/password"' in r.text

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -1,0 +1,94 @@
+"""Thin HTTP client over the internal auth service.
+
+The web service calls auth directly over the backend compose network
+(``http://auth:8000``) rather than looping through the Caddy gateway.
+This module centralizes those calls so handlers don't re-implement
+URL formatting or error translation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+
+@dataclass
+class LoginResult:
+    access_token: str
+    refresh_token: str
+    expires_in: int
+    must_change_password: bool
+
+
+class AuthClientError(Exception):
+    """Auth call failed for reasons other than bad credentials."""
+
+
+class InvalidCredentials(Exception):
+    """Auth rejected the login as invalid credentials."""
+
+
+async def login(base_url: str, email: str, password: str) -> LoginResult:
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            f"{base_url}/auth/login",
+            json={"email": email, "password": password},
+        )
+    if resp.status_code == 401:
+        raise InvalidCredentials()
+    if resp.status_code >= 400:
+        raise AuthClientError(f"auth /login returned {resp.status_code}: {resp.text}")
+    data = resp.json()
+    return LoginResult(
+        access_token=data["access_token"],
+        refresh_token=data["refresh_token"],
+        expires_in=int(data["expires_in"]),
+        must_change_password=bool(data["must_change_password"]),
+    )
+
+
+async def change_password(
+    base_url: str,
+    token: str,
+    current_password: str,
+    new_password: str,
+) -> tuple[bool, str | None]:
+    """Try to change the password. Returns (ok, error_code).
+
+    On 204, returns (True, None). On a validation/auth failure, returns
+    (False, <error-code-from-auth>) so the caller can render an inline
+    message.
+    """
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            f"{base_url}/auth/password/change",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"current_password": current_password, "new_password": new_password},
+        )
+    if resp.status_code == 204:
+        return True, None
+    if resp.status_code in (400, 401):
+        try:
+            detail = resp.json().get("detail") or {}
+            code = detail.get("error") if isinstance(detail, dict) else None
+        except ValueError:
+            code = None
+        return False, code or "password_change_failed"
+    raise AuthClientError(f"auth /password/change returned {resp.status_code}: {resp.text}")
+
+
+async def logout(base_url: str, token: str) -> None:
+    """Best-effort server-side session revoke.
+
+    Errors are swallowed — the cookie clear is the real logout from
+    the browser's perspective, and auth /logout is idempotent.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            await client.post(
+                f"{base_url}/auth/logout",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError:
+        return

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -30,11 +30,14 @@ class InvalidCredentials(Exception):
 
 
 async def login(base_url: str, email: str, password: str) -> LoginResult:
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.post(
-            f"{base_url}/auth/login",
-            json={"email": email, "password": password},
-        )
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{base_url}/auth/login",
+                json={"email": email, "password": password},
+            )
+    except httpx.HTTPError as exc:
+        raise AuthClientError(f"auth /login transport error: {exc}") from exc
     if resp.status_code == 401:
         raise InvalidCredentials()
     if resp.status_code >= 400:
@@ -60,12 +63,15 @@ async def change_password(
     (False, <error-code-from-auth>) so the caller can render an inline
     message.
     """
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.post(
-            f"{base_url}/auth/password/change",
-            headers={"Authorization": f"Bearer {token}"},
-            json={"current_password": current_password, "new_password": new_password},
-        )
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{base_url}/auth/password/change",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"current_password": current_password, "new_password": new_password},
+            )
+    except httpx.HTTPError as exc:
+        raise AuthClientError(f"auth /password/change transport error: {exc}") from exc
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (400, 401):

--- a/services/web/web_service/deps.py
+++ b/services/web/web_service/deps.py
@@ -1,0 +1,163 @@
+"""Browser-session auth for the web service.
+
+The web service authenticates browsers via the ``da_session`` cookie
+which carries the same RS256 access-token JWT that API consumers pass
+as a Bearer header. Verification is local-only (public-key) — no
+network call to auth. If the token is expired, missing, or otherwise
+invalid, the user is bounced to /login.
+
+This coexists with the API's Bearer-header auth path; the two never
+share a request lifecycle. Browser routes depend on
+``get_current_browser_user`` or ``get_current_browser_user_any_scope``;
+the /auth/* API routes remain unchanged on the auth service.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import quote
+
+from fastapi import Depends, Request
+from fastapi.responses import RedirectResponse
+
+from common.jwt_verify import InvalidTokenError, JWTVerifier
+from web_service.settings import WebSettings, get_settings
+
+PASSWORD_CHANGE_SCOPE = "password-change-only"
+PASSWORD_CHANGE_PATH = "/settings/password"
+
+
+@dataclass
+class BrowserUser:
+    user_id: int
+    email: str
+    role: str
+    must_change_password: bool
+    scope: str | None
+    # Raw JWT — needed for service-to-service calls (password change,
+    # logout) where we forward the user's token as a Bearer header.
+    token: str
+
+
+class BrowserAuthRedirect(Exception):
+    """Signal a redirect instead of a 401.
+
+    Raised by the browser-auth dependency so FastAPI returns a
+    RedirectResponse to /login (or the password-change page) instead
+    of surfacing a JSON 401. Handled by the app-level exception
+    handler registered in main.py.
+    """
+
+    def __init__(self, location: str) -> None:
+        super().__init__(location)
+        self.location = location
+
+
+_verifier: JWTVerifier | None = None
+
+
+def get_verifier() -> JWTVerifier:
+    global _verifier
+    if _verifier is None:
+        s = get_settings()
+        _verifier = JWTVerifier(s.jwt_public_key_path, s.jwt_issuer, s.jwt_audience)
+    return _verifier
+
+
+def reset_verifier() -> None:
+    global _verifier
+    _verifier = None
+
+
+def _login_redirect_for(path: str) -> str:
+    # ``next`` echoes the originally-requested path so the login
+    # handler can send the user back where they tried to go. The
+    # path is URL-encoded (quoted) so exotic bytes can't split the
+    # query string. The login handler re-validates with
+    # ``_safe_next`` before issuing its own redirect, so an attacker
+    # crafting a malicious ``next`` only bounces back to /dashboard.
+    if path and path != "/":
+        return f"/login?next={quote(path, safe='/')}"
+    return "/login"
+
+
+def _resolve_browser_user(request: Request, settings: WebSettings) -> BrowserUser:
+    token = request.cookies.get(settings.session_cookie_name)
+    if not token:
+        raise BrowserAuthRedirect(_login_redirect_for(request.url.path))
+
+    try:
+        claims = get_verifier().verify(token)
+    except InvalidTokenError as exc:
+        raise BrowserAuthRedirect(_login_redirect_for(request.url.path)) from exc
+
+    try:
+        user_id = int(claims["sub"])
+        role = str(claims["role"])
+    except (KeyError, ValueError) as exc:
+        raise BrowserAuthRedirect(_login_redirect_for(request.url.path)) from exc
+
+    raw_scope = claims.get("scope")
+    scope = raw_scope if isinstance(raw_scope, str) else None
+    # The auth service includes an ``email`` claim in tokens it
+    # issues; older tokens without it fall back to empty-string and
+    # the UI shows "user #<id>" until the next login rotates to a
+    # current-format token.
+    email_claim = claims.get("email")
+    email = str(email_claim) if email_claim else ""
+
+    return BrowserUser(
+        user_id=user_id,
+        email=email,
+        role=role,
+        must_change_password=scope == PASSWORD_CHANGE_SCOPE,
+        scope=scope,
+        token=token,
+    )
+
+
+async def get_current_browser_user(
+    request: Request,
+    settings: WebSettings = Depends(get_settings),
+) -> BrowserUser:
+    """Browser-session auth dep for normal app pages.
+
+    If the session cookie is missing / invalid: redirect to /login.
+    If the JWT carries password-change scope AND the caller is not on
+    the password-change page: redirect to /settings/password.
+    """
+    user = _resolve_browser_user(request, settings)
+    if user.must_change_password and request.url.path != PASSWORD_CHANGE_PATH:
+        raise BrowserAuthRedirect(PASSWORD_CHANGE_PATH)
+    return user
+
+
+async def get_current_browser_user_any_scope(
+    request: Request,
+    settings: WebSettings = Depends(get_settings),
+) -> BrowserUser:
+    """Browser-session auth dep that tolerates password-change scope.
+
+    Only the password-change page should use this. Everything else
+    depends on ``get_current_browser_user`` which redirects
+    password-change-scope sessions to /settings/password.
+    """
+    return _resolve_browser_user(request, settings)
+
+
+def browser_auth_redirect_handler(_request: Request, exc: Exception) -> RedirectResponse:
+    """Convert BrowserAuthRedirect into a 302.
+
+    Registered on the FastAPI app in main.py. Kept out-of-line from
+    the deps module so main.py can import it without dragging in
+    FastAPI response imports at dep-resolution time.
+    """
+    # 303 would force GET semantics, which is the correct choice after
+    # a POST. For GET-based redirects (e.g. an expired cookie on
+    # /dashboard) both 302 and 303 work; 302 is the conventional
+    # choice and matches how the login handler redirects.
+    if isinstance(exc, BrowserAuthRedirect):
+        return RedirectResponse(url=exc.location, status_code=302)
+    # Should never happen — the handler is registered for this exc
+    # type only. Defensive fallback to keep types clean.
+    return RedirectResponse(url="/login", status_code=302)

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -201,12 +201,19 @@ async def password_submit(
     if not new_password:
         return _render_error("New password is required.")
 
-    ok, err = await auth_client.change_password(
-        settings.auth_service_url,
-        user.token,
-        current_password,
-        new_password,
-    )
+    try:
+        ok, err = await auth_client.change_password(
+            settings.auth_service_url,
+            user.token,
+            current_password,
+            new_password,
+        )
+    except auth_client.AuthClientError:
+        _log.exception("auth service change_password call failed")
+        return _render_error(
+            "Authentication service unavailable. Please try again.",
+            code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
     if not ok:
         if err == "weak_password":
             return _render_error("New password does not meet policy requirements.")

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -1,14 +1,248 @@
-from fastapi import FastAPI
+"""Web service — admin UI shell + browser auth.
+
+This service serves the browser-facing admin UI. Browser sessions use
+a cookie-carried JWT (``da_session``); API consumers continue to hit
+/auth/* on the auth service with a Bearer header. The two paths are
+independent and coexist in the compose stack.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Form, Request, Response, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
 from common.logging import configure_logging
 from common.metrics import mount_metrics
+from web_service import auth_client
+from web_service.deps import (
+    BrowserAuthRedirect,
+    BrowserUser,
+    browser_auth_redirect_handler,
+    get_current_browser_user,
+    get_current_browser_user_any_scope,
+)
+from web_service.settings import WebSettings, get_settings
 
 SERVICE_NAME = "web"
 configure_logging(SERVICE_NAME)
+_log = logging.getLogger("web.main")
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent
+_TEMPLATES_DIR = _PACKAGE_ROOT / "templates"
+_STATIC_DIR = _PACKAGE_ROOT / "static"
+
 app = FastAPI(title=f"deep-analysis-{SERVICE_NAME}")
 mount_metrics(app, SERVICE_NAME)
 
+templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
+
+# Browser-auth redirect handler — converts BrowserAuthRedirect into a
+# 302 to /login (or /settings/password for password-change scope).
+app.add_exception_handler(BrowserAuthRedirect, browser_auth_redirect_handler)
+
 
 @app.get("/healthz")
+@app.get("/web/healthz")
 async def healthz() -> dict[str, str]:
     return {"status": "ok", "service": SERVICE_NAME}
+
+
+def _safe_next(next_value: str | None) -> str:
+    """Only allow internal absolute paths as post-login destinations.
+
+    Rejects anything that could render as protocol-relative or
+    scheme-prefixed after browser URL-normalization. Anything
+    suspicious falls back to /dashboard.
+    """
+    if not next_value:
+        return "/dashboard"
+    if not next_value.startswith("/"):
+        return "/dashboard"
+    # Protocol-relative (``//host``) or backslash-smuggled variants
+    # (``/\host``) — Chrome and others normalize ``\`` to ``/`` in
+    # URL paths, so ``/\\evil.com`` becomes ``//evil.com`` when the
+    # browser follows the redirect.
+    if next_value.startswith("//") or next_value.startswith("/\\"):
+        return "/dashboard"
+    if "\\" in next_value:
+        return "/dashboard"
+    return next_value
+
+
+def _set_session_cookie(response: Response, token: str, ttl_seconds: int) -> None:
+    response.set_cookie(
+        key=get_settings().session_cookie_name,
+        value=token,
+        max_age=ttl_seconds,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        path="/",
+    )
+
+
+def _clear_session_cookie(response: Response) -> None:
+    # Match the attributes used on set_cookie so intermediaries /
+    # browsers that attribute-match the deletion find the right
+    # cookie to expire.
+    response.delete_cookie(
+        key=get_settings().session_cookie_name,
+        path="/",
+        httponly=True,
+        secure=True,
+        samesite="lax",
+    )
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_form(request: Request, next: str | None = None) -> HTMLResponse:
+    return templates.TemplateResponse(
+        request,
+        "login.html",
+        {"next": next or "", "error": None, "email": ""},
+    )
+
+
+@app.post("/login")
+async def login_submit(
+    request: Request,
+    email: Annotated[str, Form()],
+    password: Annotated[str, Form()],
+    next: Annotated[str, Form()] = "",
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    try:
+        result = await auth_client.login(settings.auth_service_url, email, password)
+    except auth_client.InvalidCredentials:
+        return templates.TemplateResponse(
+            request,
+            "login.html",
+            {"next": next, "error": "Invalid credentials", "email": email},
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
+    except auth_client.AuthClientError:
+        _log.exception("auth service login call failed")
+        return templates.TemplateResponse(
+            request,
+            "login.html",
+            {
+                "next": next,
+                "error": "Authentication service unavailable. Please try again.",
+                "email": email,
+            },
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    # must_change_password sessions get a short-scoped token; send
+    # them straight to the password page regardless of ?next=.
+    if result.must_change_password:
+        redirect = RedirectResponse(url="/settings/password", status_code=status.HTTP_303_SEE_OTHER)
+    else:
+        redirect = RedirectResponse(url=_safe_next(next), status_code=status.HTTP_303_SEE_OTHER)
+
+    _set_session_cookie(redirect, result.access_token, result.expires_in)
+    return redirect
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard(
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+) -> HTMLResponse:
+    return templates.TemplateResponse(
+        request,
+        "dashboard.html",
+        {"user": user},
+    )
+
+
+@app.get("/settings/password", response_class=HTMLResponse)
+async def password_form(
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user_any_scope),
+) -> HTMLResponse:
+    return templates.TemplateResponse(
+        request,
+        "password.html",
+        {"user": user, "must_change": user.must_change_password, "error": None},
+    )
+
+
+@app.post("/settings/password")
+async def password_submit(
+    request: Request,
+    current_password: Annotated[str, Form()],
+    new_password: Annotated[str, Form()],
+    confirm_password: Annotated[str, Form()],
+    user: BrowserUser = Depends(get_current_browser_user_any_scope),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    def _render_error(message: str, code: int = status.HTTP_400_BAD_REQUEST) -> Response:
+        return templates.TemplateResponse(
+            request,
+            "password.html",
+            {
+                "user": user,
+                "must_change": user.must_change_password,
+                "error": message,
+            },
+            status_code=code,
+        )
+
+    if new_password != confirm_password:
+        return _render_error("New password and confirmation do not match.")
+    if not new_password:
+        return _render_error("New password is required.")
+
+    ok, err = await auth_client.change_password(
+        settings.auth_service_url,
+        user.token,
+        current_password,
+        new_password,
+    )
+    if not ok:
+        if err == "weak_password":
+            return _render_error("New password does not meet policy requirements.")
+        return _render_error("Current password is incorrect.")
+
+    # Auth revokes all sessions on successful password change, so the
+    # current cookie is now dead. Re-login to get a fresh full-scope
+    # token and set a new cookie before bouncing to the dashboard.
+    try:
+        fresh = await auth_client.login(settings.auth_service_url, user.email or "", new_password)
+    except (auth_client.InvalidCredentials, auth_client.AuthClientError):
+        # Fall back to /login; user can re-enter credentials. Happens
+        # when the JWT didn't carry an email claim (rolling upgrade)
+        # or the auth service is briefly unreachable.
+        _log.warning("post-password-change re-login failed; clearing cookie and bouncing to /login")
+        redirect = RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+        _clear_session_cookie(redirect)
+        return redirect
+
+    redirect = RedirectResponse(url="/dashboard", status_code=status.HTTP_303_SEE_OTHER)
+    _set_session_cookie(redirect, fresh.access_token, fresh.expires_in)
+    return redirect
+
+
+@app.post("/logout")
+async def logout(
+    request: Request,
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    # Best-effort server-side revoke if a valid-looking token is
+    # present. We don't require full browser-auth here — if the
+    # cookie is corrupt, the user still gets a clean logout.
+    token = request.cookies.get(settings.session_cookie_name)
+    if token:
+        await auth_client.logout(settings.auth_service_url, token)
+
+    redirect = RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+    _clear_session_cookie(redirect)
+    return redirect

--- a/services/web/web_service/settings.py
+++ b/services/web/web_service/settings.py
@@ -1,0 +1,43 @@
+"""Web-service-specific settings."""
+
+from __future__ import annotations
+
+from pydantic_settings import SettingsConfigDict
+
+from common.settings import BaseServiceSettings
+
+
+class WebSettings(BaseServiceSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="DA_",
+        env_nested_delimiter="__",
+        populate_by_name=True,
+    )
+
+    # Internal compose-network URL for the auth service. The web
+    # service talks directly to auth over the backend network — it
+    # does not go through the Caddy gateway.
+    auth_service_url: str = "http://auth:8000"
+
+    # Matches auth.access_token_ttl_seconds default. If auth is
+    # reconfigured, set DA_SESSION_COOKIE_TTL_SECONDS to match.
+    session_cookie_ttl_seconds: int = 900
+
+    # Session cookie name. Kept here so the whole service uses one
+    # constant rather than string-literal sprinkling.
+    session_cookie_name: str = "da_session"
+
+
+_settings: WebSettings | None = None
+
+
+def get_settings() -> WebSettings:
+    global _settings
+    if _settings is None:
+        _settings = WebSettings(service_name="web")  # type: ignore[call-arg]
+    return _settings
+
+
+def reset_settings() -> None:
+    global _settings
+    _settings = None

--- a/services/web/web_service/static/style.css
+++ b/services/web/web_service/static/style.css
@@ -1,0 +1,171 @@
+/* Deep Analysis — admin UI baseline.
+ * Dark text on light background. Clean, admin-tool register.
+ */
+
+:root {
+    --bg: #f5f6f8;
+    --surface: #ffffff;
+    --border: #d9dde2;
+    --text: #1b1f23;
+    --text-muted: #5b636c;
+    --accent: #1e5fbf;
+    --accent-hover: #174aa1;
+    --danger: #a4252b;
+    --danger-bg: #fbeaea;
+    --info-bg: #eaf0fa;
+    --focus: #2f82ff;
+    --radius: 4px;
+    --shadow: 0 1px 2px rgba(17, 24, 33, 0.05);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 "Helvetica Neue", Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1 { font-size: 20px; margin: 0 0 16px; font-weight: 600; }
+h2 { font-size: 16px; margin: 0 0 12px; font-weight: 600; }
+p  { margin: 0 0 12px; }
+
+.site-header {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+}
+
+.site-header-inner {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 12px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.site-logo {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--text);
+    letter-spacing: 0.2px;
+}
+
+.site-nav {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    font-size: 13px;
+    color: var(--text-muted);
+}
+
+.nav-user { color: var(--text-muted); }
+
+.nav-logout { margin: 0; }
+
+.linklike {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--accent);
+    cursor: pointer;
+    font: inherit;
+}
+.linklike:hover { text-decoration: underline; }
+
+.site-main {
+    flex: 1;
+    max-width: 960px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 32px 24px;
+}
+
+.site-footer {
+    border-top: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 12px 24px;
+    text-align: center;
+}
+
+.panel, .auth-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+    box-shadow: var(--shadow);
+}
+
+.auth-card {
+    max-width: 420px;
+    margin: 40px auto;
+}
+
+.auth-form { display: flex; flex-direction: column; gap: 14px; }
+
+.field { display: flex; flex-direction: column; gap: 4px; }
+.field > span { font-size: 12px; color: var(--text-muted); font-weight: 500; }
+
+input[type="email"],
+input[type="password"],
+input[type="text"] {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 8px 10px;
+    font-size: 14px;
+    background: #fff;
+    color: var(--text);
+}
+input:focus { outline: 2px solid var(--focus); outline-offset: 0; border-color: var(--focus); }
+
+.btn {
+    display: inline-block;
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    background: var(--surface);
+    color: var(--text);
+}
+.btn-primary { background: var(--accent); color: #fff; }
+.btn-primary:hover { background: var(--accent-hover); }
+
+.form-actions { margin-top: 4px; }
+
+.form-error {
+    background: var(--danger-bg);
+    color: var(--danger);
+    border: 1px solid #e7b9bc;
+    border-radius: var(--radius);
+    padding: 8px 12px;
+    font-size: 13px;
+    margin: 0 0 14px;
+}
+
+.form-banner {
+    background: var(--info-bg);
+    color: var(--accent-hover);
+    border: 1px solid #c4d4ef;
+    border-radius: var(--radius);
+    padding: 8px 12px;
+    font-size: 13px;
+    margin: 0 0 14px;
+}

--- a/services/web/web_service/templates/base.html
+++ b/services/web/web_service/templates/base.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Deep Analysis{% endblock %}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <header class="site-header">
+        <div class="site-header-inner">
+            <a class="site-logo" href="/dashboard">Deep Analysis</a>
+            <nav class="site-nav">
+                {% if user %}
+                    {% if user.email %}
+                        <span class="nav-user">{{ user.email }}</span>
+                    {% else %}
+                        <span class="nav-user">user #{{ user.user_id }}</span>
+                    {% endif %}
+                    <form class="nav-logout" method="post" action="/logout">
+                        <button type="submit" class="linklike">Log out</button>
+                    </form>
+                {% endif %}
+            </nav>
+        </div>
+    </header>
+
+    <main class="site-main">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+        <span>Deep Analysis &middot; self-hosted match analytics</span>
+    </footer>
+</body>
+</html>

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard &middot; Deep Analysis{% endblock %}
+
+{% block content %}
+<section class="panel">
+    <h1>Dashboard</h1>
+    {% if user.email %}
+        <p>Welcome, {{ user.email }}. Profile and agents coming soon.</p>
+    {% else %}
+        <p>Welcome, user #{{ user.user_id }}. Profile and agents coming soon.</p>
+    {% endif %}
+</section>
+{% endblock %}

--- a/services/web/web_service/templates/login.html
+++ b/services/web/web_service/templates/login.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Log in &middot; Deep Analysis{% endblock %}
+
+{% block content %}
+<section class="auth-card">
+    <h1>Log in</h1>
+    {% if error %}
+        <p class="form-error" role="alert">{{ error }}</p>
+    {% endif %}
+    <form method="post" action="/login" class="auth-form">
+        {% if next %}
+            <input type="hidden" name="next" value="{{ next }}">
+        {% endif %}
+        <label class="field">
+            <span>Email</span>
+            <input type="email" name="email" autocomplete="username" required autofocus
+                   value="{{ email or '' }}">
+        </label>
+        <label class="field">
+            <span>Password</span>
+            <input type="password" name="password" autocomplete="current-password" required>
+        </label>
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">Log in</button>
+        </div>
+    </form>
+</section>
+{% endblock %}

--- a/services/web/web_service/templates/password.html
+++ b/services/web/web_service/templates/password.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}Change password &middot; Deep Analysis{% endblock %}
+
+{% block content %}
+<section class="auth-card">
+    <h1>Change password</h1>
+    {% if must_change %}
+        <p class="form-banner" role="status">
+            You must change your password before continuing.
+        </p>
+    {% endif %}
+    {% if error %}
+        <p class="form-error" role="alert">{{ error }}</p>
+    {% endif %}
+    <form method="post" action="/settings/password" class="auth-form">
+        <label class="field">
+            <span>Current password</span>
+            <input type="password" name="current_password" autocomplete="current-password" required autofocus>
+        </label>
+        <label class="field">
+            <span>New password</span>
+            <input type="password" name="new_password" autocomplete="new-password" required>
+        </label>
+        <label class="field">
+            <span>Confirm new password</span>
+            <input type="password" name="confirm_password" autocomplete="new-password" required>
+        </label>
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">Change password</button>
+        </div>
+    </form>
+</section>
+{% endblock %}

--- a/tests/test_route_prefix_convention.py
+++ b/tests/test_route_prefix_convention.py
@@ -16,6 +16,11 @@ Allowed paths per service:
 Auth additionally owns ``/admin/*`` until W6 (see ``gateway/Caddyfile``
 and the temp-route note from commit fac34b2). Remove the carve-out
 when the web service takes over /admin.
+
+The web service owns the Caddy catch-all, so end-user-facing browser
+routes (``/login``, ``/logout``, ``/dashboard``, ``/settings/*``)
+intentionally live at the top level — they're user-typed URLs, not
+service-namespaced API routes.
 """
 
 from __future__ import annotations
@@ -37,6 +42,18 @@ _SERVICES: dict[str, tuple[str, ...]] = {
 }
 
 _INFRA_PATHS = frozenset({"/healthz", "/metrics"})
+
+# Web-service browser routes that Caddy routes via the catch-all — they
+# sit outside the /web/ namespace on purpose because they are URLs a
+# human types or lands on, not service API paths.
+_WEB_BROWSER_PATHS = frozenset(
+    {
+        "/login",
+        "/logout",
+        "/dashboard",
+        "/settings/password",
+    }
+)
 
 
 def _ensure_import_env() -> None:
@@ -70,6 +87,8 @@ def test_all_routes_are_prefixed(service: str) -> None:
             continue
         path = route.path
         if path in _INFRA_PATHS:
+            continue
+        if service == "web" and path in _WEB_BROWSER_PATHS:
             continue
         if any(path.startswith(p) for p in allowed_prefixes):
             continue

--- a/uv.lock
+++ b/uv.lock
@@ -482,7 +482,12 @@ version = "0.4.0.dev0"
 source = { editable = "services/web" }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
+    { name = "jinja2" },
     { name = "prometheus-client" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -490,7 +495,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "jinja2", specifier = ">=3.1" },
     { name = "prometheus-client", specifier = ">=0.20" },
+    { name = "pydantic-settings", specifier = ">=2.3" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "structlog", specifier = ">=24.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
@@ -640,6 +650,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First layer of W3.5: the browser-facing admin UI shell. Lands the Jinja2 templating infrastructure, a cookie-backed browser session, and the skeletal login / dashboard / password / logout surface. Session B will fill in the dashboard content on top of this.

**Coexistence strategy — Bearer header vs. cookie:** API consumers (the Windows agent) continue hitting `/auth/*` with an `Authorization: Bearer` header routed by Caddy to the auth service — that path is untouched. Browsers land on the web service via Caddy's catch-all, log in through `/login` (which calls auth internally over the compose network), and carry an httpOnly, Secure, SameSite=Lax `da_session` cookie containing the same RS256 access-token JWT. The web service verifies it locally using the shared `common.JWTVerifier`. The two lifecycles never share a request.

### What landed

- **Routes** (on the web service, top-level because Caddy catch-all): `/login` (GET+POST), `/logout` (POST), `/dashboard` (GET), `/settings/password` (GET+POST). `/web/healthz` and `/healthz` unchanged.
- **Templating:** `Jinja2Templates` wired, `web_service/templates/` + `web_service/static/` packaged into the wheel via `hatch.force-include`. ~180-line minimal stylesheet (dark text on light background, admin-tool register — no marketing flourish).
- **Browser-session auth dep:** `get_current_browser_user` (normal pages) + `get_current_browser_user_any_scope` (password-change page). Redirects via a `BrowserAuthRedirect` exception + handler — missing/expired cookies bounce to `/login?next=<path>`; `password-change-only` scope bounces to `/settings/password`.
- **Password-change flow:** After `auth /auth/password/change` succeeds (auth revokes all active sessions), the web service re-logs in with the new password to mint a fresh full-scope cookie, then redirects to `/dashboard`.
- **Auth service change (additive, non-breaking):** `issue_access_token` gained an optional `email` kwarg; login + refresh pass the user's email so the UI can render it in the nav without a separate `/auth/me` round-trip (needed because password-change-only tokens can't call `/auth/me`). Existing tokens without the claim still verify; no Bearer callers affected.
- **Route-prefix test:** added a web-service carve-out for the top-level browser paths — service-namespaced routes (`/web/*`) still enforced.

### Smoke test (ci/smoke_ui.sh)

1. `GET /login` → 200, body contains `<form`
2. `POST /login` with bootstrap admin creds → 303, `da_session` cookie set
3. `GET /dashboard` with cookie → 200, body contains "Welcome"
4. `GET /dashboard` without cookie → 302 to `/login?next=/dashboard`
5. `POST /settings/password` (rotate) → 303 to `/dashboard`, fresh cookie; restore password for idempotency
6. `POST /logout` → 303 to `/login`, cookie cleared

Runs as a new `smoke-ui` CI job after `compose-smoke`, fork-gated same as the existing 11 jobs.

### Security considerations addressed

- `?next=` param only accepts internal absolute paths; rejects `//host`, `/\host`, and any backslash-containing value (Chrome normalizes `\` → `/`).
- Cookie deletion re-uses all set attributes (`httponly`, `secure`, `samesite`, `path`) for attribute-matching on intermediaries.
- Login error returns generic "Invalid credentials" (no email-vs-password distinction).
- Independent code review verified the must_change redirect cannot be bypassed, expired cookies redirect cleanly, and the Bearer path is unaffected.

## Test plan

- [ ] `compose-smoke` still green (no regression to existing probes)
- [ ] `smoke-ui` job passes end-to-end against the full stack
- [ ] `lint`, `typecheck`, `test-common`, `test-integration`, `docker-build (web)` all green
- [ ] Manual: log in with a browser, rotate password, log out, confirm cookie behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)