### PR TITLE
chore: bump to v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to the Deep Analysis server are recorded here. The
+project follows [Semantic Versioning](https://semver.org/) loosely while
+in pre-1.0; expect minor versions to introduce breaking changes until the
+API surface stabilizes.
+
+## v0.4.3 — 2026-04-26
+
+### Added
+
+- **W3.5-A: admin UI auth shell.** Login page, dashboard stub, password-change
+  flow, and logout for the `web` service. Sessions are tracked via the
+  auth service's session cookie (HTTP-only, secure when behind the gateway).
+  Templates, static styles, and the `auth_client` HTTP wrapper all land in
+  `services/web/`.
+- **`smoke-ui` CI job.** End-to-end UI smoke covering login, dashboard
+  redirect, password change, and logout against the full compose stack.
+  Runs alongside the existing `smoke-e2e` gate.
+
+### Fixed
+
+- **`auth_client` transport-error translation (web service).** `auth_client.login`
+  and `auth_client.change_password` now wrap `httpx` transport errors
+  (timeouts, connection refused, DNS failures) as `AuthClientError` so the
+  caller can distinguish "auth service unreachable" from "credentials wrong"
+  without leaking httpx exceptions through the request handler. The
+  `password_submit` view catches `AuthClientError` and renders a 503 page
+  instead of a 500 stack trace.
+
+## v0.4.2 — 2026-04-24
+
+### Fixed
+
+- **Ingest route prefix.** `/upload` → `/ingest/upload` on the ingest service,
+  so requests through the gateway resolve correctly.
+- **Service-prefix convention test.** `tests/test_route_prefix_convention.py`
+  imports each HTTP service's FastAPI app and asserts every route sits under
+  the service's namespace; catches this bug class at unit-test time.
+
+### Added
+
+- **`smoke-e2e` CI gate.** `ci/smoke_e2e.sh` walks the auth + ingest happy
+  path through the gateway. The full compose stack runs in CI; PRs only
+  merge when this gate is green.
+- **PR discipline on `main`.** Non-trivial work lands via feature branch + PR.
+  Direct pushes to `main` are reserved for urgent fixes.
+
+## v0.4.1 — 2026-04-24
+
+### Fixed
+
+- **JWT key path config drift.** Aligned `docker-compose.yml`, `.env.example`,
+  and `docs/deploy.md` on `/data/secrets/` (the actual mount) instead of
+  `/run/secrets/` (Docker secrets syntax that this stack does not use). Added
+  `ci/check-compose-paths.sh` as a drift guard.
+
+## v0.4.0 — 2026-04-23
+
+- Initial v0.4.x release. Six-service compose stack
+  (gateway, auth, ingest, parser, analytics, web), single Postgres with
+  per-service logical schemas, Redis event bus, short-lived JWTs for
+  service-to-service auth. Greenfield rewrite — no code carried forward
+  from the manalog proof-of-concept.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "deep-analysis-server"
-version = "0.4.2"
+version = "0.4.3"
 description = "Deep Analysis server — AGPL-3.0 open-source core"
 requires-python = ">=3.12"
 license = {text = "AGPL-3.0-only"}

--- a/uv.lock
+++ b/uv.lock
@@ -425,7 +425,7 @@ requires-dist = [
 
 [[package]]
 name = "deep-analysis-server"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Version bump to v0.4.3. Wraps W3.5-A admin UI auth shell (PR #1) and the auth_client transport-error translation fix.

- `pyproject.toml`: 0.4.2 → 0.4.3
- `uv.lock`: regenerate (`deep-analysis-server` entry, no other dependency changes)
- `CHANGELOG.md`: new file. v0.4.3 + retrospective entries for v0.4.0 / v0.4.1 / v0.4.2

## Test plan

- [ ] CI green (lint, typecheck, test-common, test-integration, smoke-e2e, smoke-ui, compose-smoke)
- [ ] After merge, tag v0.4.3 and verify the Release workflow publishes auth/ingest/parser/analytics/web GHCR images

🤖 Generated with [Claude Code](https://claude.com/claude-code)