### PR TITLE
chore: bump to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ project follows [Semantic Versioning](https://semver.org/) loosely while
 in pre-1.0; expect minor versions to introduce breaking changes until the
 API surface stabilizes.
 
-## Unreleased
+## v0.5.0 — 2026-04-26
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "deep-analysis-server"
-version = "0.4.3"
+version = "0.5.0"
 description = "Deep Analysis server — AGPL-3.0 open-source core"
 requires-python = ">=3.12"
 license = {text = "AGPL-3.0-only"}

--- a/uv.lock
+++ b/uv.lock
@@ -425,7 +425,7 @@ requires-dist = [
 
 [[package]]
 name = "deep-analysis-server"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Version bump to v0.5.0. Wraps W3.5-B self-service dashboard + W3.5-C admin panel (PR #3).

- pyproject.toml: 0.4.3 -> 0.5.0
- uv.lock: regenerate (deep-analysis-server entry, no other dependency changes)
- CHANGELOG.md: promote Unreleased -> v0.5.0. Deferred follow-ups: issue #4 (change_password inline error), issue #5 (auth-outage template fidelity)

## Test plan

- [ ] CI green (lint, typecheck, test-common, test-integration, smoke-e2e, smoke-ui, compose-smoke)
- [ ] After merge, tag v0.5.0 and verify the Release workflow publishes auth/ingest/parser/analytics/web GHCR images

Generated with Claude Code