### PR TITLE
chore: install self-review pattern

### DIFF
--- a/.claude/agents/self-reviewer.md
+++ b/.claude/agents/self-reviewer.md
@@ -1,0 +1,68 @@
+---
+name: self-reviewer
+description: Reviews the current branch's diff against work-item context. Approves with marker or requests changes with specific findings. Invoked by /self-review slash command before push.
+model: sonnet
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+---
+
+You are this workspace's self-reviewer. You evaluate a diff
+about to be pushed against four criteria. Output is a
+structured verdict the calling slash command parses.
+
+## Inputs (read these first)
+
+1. **Diff:** run `git diff $(jq -r .self_reviewer.diff_base .claude/review-config.json)...HEAD`
+2. **Config:** read `.claude/review-config.json`
+3. **Work-item context:** the calling session passes spec ID
+   + summary as the prompt body. If absent, infer from the
+   most recent commit message.
+4. **Lint result:** run config's `self_reviewer.lint_command`.
+5. **Test result:** run config's `self_reviewer.test_command`.
+
+## Criteria
+
+1. **Work-item alignment** — diff matches the stated work
+   item. Out-of-scope changes flagged.
+2. **Test coverage** — tests modified or added where
+   behavior changed. Pure refactors and doc-only changes
+   exempt.
+3. **Quality** — no debug detritus (`print()`, `console.log`,
+   commented-out code), no secret-shaped strings (long hex,
+   base64 blobs, `password=`, `api_key=`), no unintentional
+   file deletions, no large binary additions.
+4. **Conventions** — lint passes, tests pass, file layout
+   matches repo norms.
+
+## Output format
+
+Two possible verdicts. Always emit in this exact shape:
+
+**APPROVED:**
+```
+VERDICT: APPROVED
+SUMMARY: <one-line summary of what landed>
+```
+
+**REQUEST_CHANGES:**
+```
+VERDICT: REQUEST_CHANGES
+FINDINGS:
+1. <file:line> — <what's wrong, what to do>
+2. <file:line> — <what's wrong, what to do>
+…
+```
+
+If lint or tests failed, emit REQUEST_CHANGES with the failure
+output as finding #1.
+
+## What you do NOT do
+
+- Do not write `.review-passed`. The calling slash command does
+  that, only on APPROVED.
+- Do not commit. Do not push. Do not modify code.
+- Do not approve with caveats. APPROVED means the diff is
+  ready to push as-is.

--- a/.claude/commands/self-review.md
+++ b/.claude/commands/self-review.md
@@ -1,0 +1,23 @@
+---
+description: Run self-reviewer against current diff; write .review-passed marker on approval.
+---
+
+You are running the self-review pre-push gate.
+
+1. Dispatch the `self-reviewer` agent with this conversation's
+   work-item context (spec ID, summary, anything the
+   implementer was working on). If you don't have explicit
+   context, pass "infer from most recent commit."
+2. Capture the agent's verdict.
+3. Branch on verdict:
+   - `VERDICT: APPROVED` → write `git rev-parse HEAD` to
+     `.review-passed` at the repo root. Report: "Review
+     approved; marker written. Push allowed for $(git rev-parse --short HEAD)."
+   - `VERDICT: REQUEST_CHANGES` → do NOT write the marker.
+     Report the findings to the user verbatim. The user (or
+     calling session) will rework and re-run /self-review.
+4. If the rework loop has hit 4 iterations on the same diff
+   without approval, halt and write a stuck-report to
+   `scott/reports/<YYYY-MM-DD>-stuck-on-review-<branch>.md`
+   with `needs-scott: true` frontmatter, including all 4
+   rounds of findings. Do not loop further.

--- a/.claude/hooks/check-review-passed.sh
+++ b/.claude/hooks/check-review-passed.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Pre-push gate: blocks `git push` unless .review-passed marker
+# exists at repo root and its SHA matches HEAD. Generic — no
+# repo-specific assumptions.
+set -euo pipefail
+
+# Read PreToolUse JSON input from stdin
+input="$(cat)"
+cmd="$(echo "$input" | jq -r '.tool_input.command // ""')"
+
+# Only gate `git push` invocations. Allow everything else.
+if ! echo "$cmd" | grep -qE '(^|;|&&|\|\|)\s*git\s+push'; then
+  exit 0
+fi
+
+# Find repo root. If we're not in a git repo, fail closed.
+if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "self-review hook: not a git repo, blocking push." >&2
+  exit 2
+fi
+
+marker="$repo_root/.review-passed"
+
+if [[ ! -f "$marker" ]]; then
+  echo "Push blocked: no .review-passed marker. Run /self-review before pushing." >&2
+  exit 2
+fi
+
+marker_sha="$(tr -d '[:space:]' < "$marker")"
+head_sha="$(git -C "$repo_root" rev-parse HEAD)"
+
+if [[ "$marker_sha" != "$head_sha" ]]; then
+  echo "Push blocked: review marker is stale (marker=$marker_sha, HEAD=$head_sha). Re-run /self-review." >&2
+  exit 2
+fi
+
+# Push allowed. Audit-log the approval consumption.
+mkdir -p "$repo_root/.claude"
+audit_log="$repo_root/.claude/.review-audit.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) push-allowed sha=$head_sha" >> "$audit_log"
+
+exit 0

--- a/.claude/review-config.json
+++ b/.claude/review-config.json
@@ -1,0 +1,18 @@
+{
+  "self_reviewer": {
+    "loop_limit": 4,
+    "diff_base": "origin/main",
+    "lint_command": "ruff check && mypy .",
+    "test_command": "pytest",
+    "ignore_paths": []
+  },
+  "codex_address": {
+    "loop_limit": 4
+  },
+  "release": {
+    "tool": "python-semantic-release",
+    "version_file": "pyproject.toml",
+    "branch": "main",
+    "major_on_zero": false
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-review-passed.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: publish (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [auth, ingest, parser, analytics, web]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build ${{ matrix.service }} image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/${{ matrix.service }}/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/sentania-labs/deep-analysis-${{ matrix.service }}:${{ github.ref_name }}
+            ghcr.io/sentania-labs/deep-analysis-${{ matrix.service }}:latest
+
+  create-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          body: |
+            Images published to GHCR (public, pullable without auth):
+
+            - `ghcr.io/sentania-labs/deep-analysis-auth:${{ github.ref_name }}`
+            - `ghcr.io/sentania-labs/deep-analysis-ingest:${{ github.ref_name }}`
+            - `ghcr.io/sentania-labs/deep-analysis-parser:${{ github.ref_name }}`
+            - `ghcr.io/sentania-labs/deep-analysis-analytics:${{ github.ref_name }}`
+            - `ghcr.io/sentania-labs/deep-analysis-web:${{ github.ref_name }}`
+
+            Also tagged as `:latest`.
+
+            See the compose stack and deploy guide in the repo for self-hosting.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,60 +2,40 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    branches: [main]
 
 permissions:
-  contents: read
-  packages: write
+  contents: write
+  id-token: write
 
 jobs:
-  publish:
-    name: publish (${{ matrix.service }})
+  release:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        service: [auth, ingest, parser, analytics, web]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build ${{ matrix.service }} image
-        uses: docker/build-push-action@v5
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
         with:
-          context: .
-          file: services/${{ matrix.service }}/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/sentania-labs/deep-analysis-${{ matrix.service }}:${{ github.ref_name }}
-            ghcr.io/sentania-labs/deep-analysis-${{ matrix.service }}:latest
+          python-version: "3.12"
 
-  create-release:
-    name: Create GitHub Release
-    needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          body: |
-            Images published to GHCR (public, pullable without auth):
+      - name: Install python-semantic-release
+        run: pip install python-semantic-release
 
-            - `ghcr.io/sentania-labs/deep-analysis-auth:${{ github.ref_name }}`
-            - `ghcr.io/sentania-labs/deep-analysis-ingest:${{ github.ref_name }}`
-            - `ghcr.io/sentania-labs/deep-analysis-parser:${{ github.ref_name }}`
-            - `ghcr.io/sentania-labs/deep-analysis-analytics:${{ github.ref_name }}`
-            - `ghcr.io/sentania-labs/deep-analysis-web:${{ github.ref_name }}`
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-            Also tagged as `:latest`.
-
-            See the compose stack and deploy guide in the repo for self-hosting.
+      - name: Run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          semantic-release version --no-vcs-release
+          semantic-release publish || true

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ Thumbs.db
 *.swp
 *.swo
 docker-compose.override.yml
+# self-review pre-push gate
+.review-passed
+.claude/.review-audit.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,7 @@ members = [
     "services/analytics",
     "services/web",
 ]
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+branch = "main"


### PR DESCRIPTION
## Summary

Installs the PKA self-review + auto-release pattern in this workspace via `/home/scott/pka/.claude/templates/self-review/install.sh`.

## What was installed

- **self-reviewer agent** — `.claude/agents/self-reviewer.md`
- **`/self-review` slash command** — `.claude/commands/self-review.md`
- **PreToolUse Bash hook** — `.claude/hooks/check-review-passed.sh`, wired through `.claude/settings.json` to run before any Bash tool call (this is the gate)
- **`.claude/review-config.json`** — lint=`ruff check && mypy .`, test=`pytest`, release tool=`python-semantic-release`, version file=`pyproject.toml`, branch=`main`, `major_on_zero=false`
- **PSR release workflow** at `.github/workflows/release.yml` — triggers on `push: branches: [main]` only (no PR triggers, so no fork-gate condition needed)
- **`[tool.semantic_release]` config in `pyproject.toml`** — `version_toml = ["pyproject.toml:project.version"]`, `branch = "main"` so PSR reads the version from `[project].version`
- **`.gitignore` patch** — adds `.review-passed` and `.claude/.review-audit.log`

## Workflow rename — collision handling

The repo already had `.github/workflows/release.yml` as a Docker image publish + GitHub Release workflow (push to `v*` tags). The installer's PSR template lands a new file at the same path, so the existing file was renamed first:

- `.github/workflows/release.yml` → `.github/workflows/release-docker.yml` (via `git mv`)
- New PSR workflow now lives at `.github/workflows/release.yml`

Both workflows currently have `name: Release` in their YAML headers — GitHub will distinguish them by file path. If the duplicate display name ends up confusing in the Actions UI, follow-up commit can rename the docker workflow's display name; left as-is here to keep this PR scoped to the install.

## Bootstrap exception

This PR uses the existing pre-gate flow. The PreToolUse hook can't block its own bootstrap push, so the install commit predates the gate. **Future PRs from this branch will go through the self-review gate before push.**

## Quality gates run locally before push

- `ruff check` — All checks passed
- `ruff format --check` — 83 files already formatted
- `mypy .` — 8 pre-existing errors in `tests/common/test_settings.py`; none introduced by this PR (no Python source modified)
- `pytest` (unit suite, `--ignore=tests/integration`) — 14 passed

Per task scope: did not run `docker compose` or integration tests locally.

## Test plan

- [ ] CI green on this PR (compose-smoke E2E gate runs the integration suite)
- [ ] Confirm `/self-review` command discoverable in a fresh Claude Code session in this workspace
- [ ] Confirm PreToolUse hook blocks Bash unless `.review-passed` is fresh (manually exercise on a follow-up branch)
- [ ] Confirm PSR workflow renders correctly in Actions tab (no syntax errors), then validate version bump on a future merge to main
- [ ] Confirm renamed `release-docker.yml` still publishes images on the next `v*` tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)