### PR TITLE
fix: revert PSR misfire to 0.5.0 + harden semantic-release config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "deep-analysis-server"
-version = "1.0.0"
+version = "0.5.0"
 description = "Deep Analysis server — AGPL-3.0 open-source core"
 requires-python = ">=3.12"
 license = {text = "AGPL-3.0-only"}
@@ -80,4 +80,24 @@ members = [
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-branch = "main"
+commit_parser = "conventional"
+major_on_zero = false
+allow_zero_version = true
+tag_format = "v{version}"
+commit_message = "chore(release): {version} [skip ci]"
+build_command = ""
+
+[tool.semantic_release.branches.main]
+match = "^(main)$"
+prerelease = false
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["feat", "fix", "perf", "build", "ci", "docs", "refactor", "style", "test", "chore"]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf"]
+default_bump_level = 0
+parse_squash_commits = true
+ignore_merge_commits = true
+
+[tool.semantic_release.publish]
+upload_to_vcs_release = false


### PR DESCRIPTION
## Summary

Recovery from the python-semantic-release (PSR) misfire on PR #7.
PR #7 was a chore-only \`chore: install self-review pattern\` PR;
when it merged, the PSR workflow on \`main\` bumped the project from
\`0.5.0\` to \`1.0.0\` and committed \`66dfa91 1.0.0\` to \`main\`. The
\`v1.0.0\` tag has already been removed from origin.

This PR:
1. Reverts \`pyproject.toml\` \`version\` from \`1.0.0\` back to \`0.5.0\`.
2. Replaces the minimal \`[tool.semantic_release]\` block (which had
   only \`version_toml\` and a non-existent \`branch\` key) with an
   explicit, defensive PSR 10.5.3 config so the same misfire cannot
   recur.

## Root cause

PSR 10.5.3 default behavior, with no overrides, is:

- \`allow_zero_version = false\` — PSR refuses to remain on a 0.x
  version. On its first managed release run, it auto-graduates the
  project to \`1.0.0\` regardless of commit type.
- \`major_on_zero = true\` — would also have caused future \`feat:\`
  commits on 0.x to bump major instead of minor.
- \`commit_parser = "conventional"\`, \`parse_squash_commits = true\`,
  \`default_bump_level = no_release\` — these are sane, but offered no
  protection against the version-graduation rule above.

The \`chore:\` commit alone wouldn't have triggered a release. The
\`allow_zero_version = false\` rule is what fired.

The pre-existing PSR config block was:
\`\`\`toml
[tool.semantic_release]
version_toml = ["pyproject.toml:project.version"]
branch = "main"   # NOTE: \`branch\` is not a valid PSR 10 key
\`\`\`
So all defaults applied unmitigated.

## Config landed

\`\`\`toml
[tool.semantic_release]
version_toml = ["pyproject.toml:project.version"]
commit_parser = "conventional"
major_on_zero = false
allow_zero_version = true
tag_format = "v{version}"
commit_message = "chore(release): {version} [skip ci]"
build_command = ""

[tool.semantic_release.branches.main]
match = "^(main)$"
prerelease = false

[tool.semantic_release.commit_parser_options]
allowed_tags = ["feat", "fix", "perf", "build", "ci", "docs", "refactor", "style", "test", "chore"]
minor_tags = ["feat"]
patch_tags = ["fix", "perf"]
default_bump_level = 0
parse_squash_commits = true
ignore_merge_commits = true

[tool.semantic_release.publish]
upload_to_vcs_release = false
\`\`\`

Every key was validated against the installed PSR 10.5.3 schema
(\`semantic_release.cli.config.RawConfig\`). Invalid PSR 7/8/9-era
keys (\`branch\` top-level, \`upload_to_pypi\`, \`upload_to_release\`)
were dropped — they no longer exist.

## Verification

- \`semantic-release --noop version --print\` (with a temp config
  swapping the branch matcher to test on this branch) →
  \`No release will be made, 0.5.0 has already been released!\`
  Confirms the hardening prevents another auto-bump.
- \`ruff check .\` — clean
- \`ruff format --check .\` — 83 files formatted
- \`pytest --ignore=tests/integration -x\` — 14/14 pass
- \`mypy .\` — 8 pre-existing errors in
  \`tests/common/test_settings.py\` (verified pre-existing on this
  diff via stash; not introduced by this change)

## Self-review gate

\`/self-review\` ran twice — once pre-commit, once post-commit (the
PreToolUse hook checks marker SHA == HEAD, so the marker had to be
re-issued for the post-commit HEAD). Both reviews returned
\`VERDICT: APPROVED\`. The hook then permitted the push and wrote
\`push-allowed sha=9ac6ca7...\` to \`.claude/.review-audit.log\`.

## Test plan

- [ ] CI compose-smoke E2E gate is green on this PR
- [ ] After merge, the next PSR run on \`main\` reports
      "no release" (no qualifying \`feat\`/\`fix\`/\`perf\` commits in
      this PR)
- [ ] First subsequent \`feat:\` PR cleanly bumps to \`0.6.0\`
      (not \`1.0.0\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)