### PR TITLE
docs: add Charter section — codify workspace-author lane discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,14 @@ This is the server half of a three-repo split:
 
 **Origin:** v0.4.0 is a clean greenfield rewrite. The predecessor (`manalog` through v0.3.8) was a proof-of-concept. No code from manalog is ported. You may read manalog source at `workspaces/manalog/` for design patterns, but do not copy it wholesale.
 
+## Charter
+
+This workspace is software. The "What this is" / product
+scope above is the charter. Software authors don't touch
+infrastructure outside their charter — even with credentials
+available. For work that needs out-of-charter access, use a
+sanctioned cross-system channel.
+
 ## Tech stack
 
 - **Language:** Python 3.12+


### PR DESCRIPTION
## Summary

Adds a four-line discipline statement clarifying that workspace sessions are software authors and don't touch infrastructure outside their charter. Part of a 2026-04-27 PKA tightening pass that is adding this to all Claude-enabled workspaces (except vcf-content-factory).

## Changes

- `CLAUDE.md` — new `## Charter` section inserted between "What this is" and "## Tech stack". Eight added lines (heading + blank line + 5-line body + blank line).

## Test plan

- [x] Docs-only change; no code, tests, or config touched.
- [x] Markdown well-formed (verified via diff review).
- [x] `/self-review` APPROVED.
- [ ] CI smoke gate runs (no Python changes; expected pass).