### PR TITLE
fix: parser format + size ceiling + atomic persist (W4 follow-up)

### DIFF
--- a/services/parser/parser_service/consumer.py
+++ b/services/parser/parser_service/consumer.py
@@ -31,7 +31,7 @@ from common.events import FILE_INGESTED, MATCH_PARSED, FileIngestedPayload, Matc
 from common.redis_client import EventPublisher
 from parser_service.parsing import LogParser, ParsedMatch
 from parser_service.persistence import persist_match
-from parser_service.storage import RawFileNotFoundError, read_raw
+from parser_service.storage import RawFileNotFoundError, RawFileTooLargeError, read_raw
 
 _log = logging.getLogger("parser.consumer")
 
@@ -44,12 +44,14 @@ class ParserConsumer:
         raw_root: Path,
         parser: LogParser | None = None,
         publisher: EventPublisher | None = None,
+        max_log_bytes: int | None = None,
     ) -> None:
         self._redis = redis_client
         self._sessionmaker = sessionmaker
         self._raw_root = raw_root
         self._parser = parser or LogParser()
         self._publisher = publisher or EventPublisher(redis_client)
+        self._max_log_bytes = max_log_bytes
         self._stop_event = asyncio.Event()
 
     def stop(self) -> None:
@@ -116,9 +118,12 @@ class ParserConsumer:
     async def handle_event(self, sha256: str, user_id: int) -> ParsedMatch | None:
         """Test-friendly entry point — reads, parses, persists, publishes."""
         try:
-            content = read_raw(sha256, self._raw_root)
+            content = read_raw(sha256, self._raw_root, max_bytes=self._max_log_bytes)
         except RawFileNotFoundError:
             _log.warning("raw file missing for sha=%s; skipping", sha256)
+            return None
+        except RawFileTooLargeError:
+            _log.warning("raw file exceeds size ceiling sha=%s; skipping", sha256)
             return None
         except OSError:
             _log.exception("failed to read raw file sha=%s", sha256)

--- a/services/parser/parser_service/main.py
+++ b/services/parser/parser_service/main.py
@@ -51,6 +51,7 @@ async def _start_consumer() -> None:
         raw_root=settings.parser_raw_path,
         parser=LogParser(),
         publisher=EventPublisher(client),
+        max_log_bytes=settings.parser_max_log_bytes,
     )
     _consumer_task = asyncio.create_task(_consumer.run(), name="parser-consumer")
     _log.info("parser consumer task started")

--- a/services/parser/parser_service/parsing/parser.py
+++ b/services/parser/parser_service/parsing/parser.py
@@ -179,7 +179,7 @@ class MTGOTextLogStrategy(LogFormatStrategy):
             return False
         # Heuristic: looks like text and contains at least one MTGO marker.
         try:
-            sample = content[:64 * 1024].decode("utf-8", errors="ignore")
+            sample = content[: 64 * 1024].decode("utf-8", errors="ignore")
         except UnicodeDecodeError:
             return False
         if not sample:
@@ -228,12 +228,7 @@ class MTGOTextLogStrategy(LogFormatStrategy):
 
         # Synthesize "wins-losses" if we have per-game winners and know the
         # player set but the log never spelled out the score.
-        if (
-            not match.match_result
-            and match.games
-            and match.winner
-            and match.players
-        ):
+        if not match.match_result and match.games and match.winner and match.players:
             opp = next((p for p in match.players if p != match.winner), None)
             wins = sum(1 for g in match.games if g.winner == match.winner)
             losses = sum(1 for g in match.games if g.winner == opp) if opp else 0
@@ -267,9 +262,7 @@ class MTGOTextLogStrategy(LogFormatStrategy):
     ) -> ParsedGame:
         game = ParsedGame(game_number=game_number)
 
-        if (m := _GAME_WIN_RE.search(block)) is not None and int(
-            m.group("num")
-        ) == game_number:
+        if (m := _GAME_WIN_RE.search(block)) is not None and int(m.group("num")) == game_number:
             game.winner = _normalize_player(m.group("player"))
             game.result = "win"
         if not game.result and (m := _GAME_RESULT_RE.search(block)) is not None:
@@ -280,8 +273,7 @@ class MTGOTextLogStrategy(LogFormatStrategy):
 
     def _parse_turns(self, block: str, players: list[str]) -> list[TurnSnapshot]:
         turn_marks = [
-            (m.start(), int(m.group("num")), m.group("player"))
-            for m in _TURN_RE.finditer(block)
+            (m.start(), int(m.group("num")), m.group("player")) for m in _TURN_RE.finditer(block)
         ]
         if not turn_marks:
             return []
@@ -317,13 +309,9 @@ class MTGOTextLogStrategy(LogFormatStrategy):
             life_events.append((m.start(), f"set:{m.group('player')}:{m.group('life')}"))
         for m in _LIFE_DELTA_RE.finditer(window):
             sign = "+" if m.group("verb").lower().startswith("gain") else "-"
-            life_events.append(
-                (m.start(), f"delta:{m.group('player')}:{sign}{m.group('amt')}")
-            )
+            life_events.append((m.start(), f"delta:{m.group('player')}:{sign}{m.group('amt')}"))
         for m in _DAMAGE_RE.finditer(window):
-            life_events.append(
-                (m.start(), f"dmg:{m.group('target')}:{m.group('amt')}")
-            )
+            life_events.append((m.start(), f"dmg:{m.group('target')}:{m.group('amt')}"))
         life_events.sort(key=lambda e: e[0])
         for _, encoded in life_events:
             kind, who, value = encoded.split(":", 2)

--- a/services/parser/parser_service/persistence.py
+++ b/services/parser/parser_service/persistence.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import UTC, datetime
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from parser_service.models import Game, GameState, Match
@@ -20,35 +21,48 @@ async def persist_match(
 ) -> Match:
     """Insert a parsed match (plus games and per-turn states).
 
-    Idempotent on ``(sha256, user_id)`` — re-parsing the same upload
-    for the same user returns the existing row without duplicating.
+    Idempotent on ``(sha256, user_id)`` at the database layer — uses
+    ``INSERT ... ON CONFLICT (sha256, user_id) DO NOTHING RETURNING id``
+    so two consumers racing on the same upload cannot both create child
+    rows. If the conflict path is hit, we resolve the existing row and
+    skip the child writes entirely (they were already persisted by the
+    winner).
     """
-    existing = (
-        await session.execute(
-            select(Match).where(Match.sha256 == sha256, Match.user_id == user_id)
+    new_id = uuid.uuid4()
+    insert_stmt = (
+        pg_insert(Match)
+        .values(
+            id=new_id,
+            sha256=sha256,
+            user_id=user_id,
+            format=parsed.format,
+            event_type=parsed.event_type,
+            players=parsed.players,
+            match_result=parsed.match_result,
+            winner=parsed.winner,
+            game_count=parsed.game_count,
+            parsed_at=datetime.now(UTC),
         )
-    ).scalar_one_or_none()
-    if existing is not None:
-        return existing
-
-    match = Match(
-        sha256=sha256,
-        user_id=user_id,
-        format=parsed.format,
-        event_type=parsed.event_type,
-        players=parsed.players,
-        match_result=parsed.match_result,
-        winner=parsed.winner,
-        game_count=parsed.game_count,
-        parsed_at=datetime.now(UTC),
+        .on_conflict_do_nothing(constraint="uq_matches_sha256_user")
+        .returning(Match.id)
     )
-    session.add(match)
-    await session.flush()  # populate match.id
+    inserted_id = (await session.execute(insert_stmt)).scalar_one_or_none()
+
+    if inserted_id is None:
+        # Another worker won the race — return the canonical row, do not
+        # re-insert children.
+        existing = (
+            await session.execute(
+                select(Match).where(Match.sha256 == sha256, Match.user_id == user_id)
+            )
+        ).scalar_one()
+        await session.commit()
+        return existing
 
     for parsed_game in parsed.games:
         game = Game(
             id=uuid.uuid4(),
-            match_id=match.id,
+            match_id=inserted_id,
             game_number=parsed_game.game_number,
             winner=parsed_game.winner,
             result=parsed_game.result,
@@ -62,12 +76,11 @@ async def persist_match(
                     game_id=game.id,
                     turn_number=turn.turn_number,
                     active_player=turn.active_player,
-                    player_states={
-                        name: snap.model_dump() for name, snap in turn.players.items()
-                    },
+                    player_states={name: snap.model_dump() for name, snap in turn.players.items()},
                     stack=[entry.model_dump() for entry in turn.stack],
                 )
             )
 
     await session.commit()
+    match = (await session.execute(select(Match).where(Match.id == inserted_id))).scalar_one()
     return match

--- a/services/parser/parser_service/storage.py
+++ b/services/parser/parser_service/storage.py
@@ -20,6 +20,10 @@ class RawFileNotFoundError(FileNotFoundError):
     """Raised when no raw file can be located for a given sha256."""
 
 
+class RawFileTooLargeError(OSError):
+    """Raised when a raw file exceeds the configured in-memory ceiling."""
+
+
 def resolve_path(sha256: str, root: Path, hint_ext: str | None = None) -> Path:
     """Return the on-disk path for ``sha256``, trying common extensions.
 
@@ -35,10 +39,26 @@ def resolve_path(sha256: str, root: Path, hint_ext: str | None = None) -> Path:
         candidate = shard / f"{sha256}{ext}"
         if candidate.exists():
             return candidate
-    raise RawFileNotFoundError(
-        f"no raw file found for sha {sha256} under {shard}"
-    )
+    raise RawFileNotFoundError(f"no raw file found for sha {sha256} under {shard}")
 
 
-def read_raw(sha256: str, root: Path, hint_ext: str | None = None) -> bytes:
-    return resolve_path(sha256, root, hint_ext).read_bytes()
+def read_raw(
+    sha256: str,
+    root: Path,
+    hint_ext: str | None = None,
+    max_bytes: int | None = None,
+) -> bytes:
+    """Read a raw archived file. Refuses to buffer more than ``max_bytes``.
+
+    A ``None`` ceiling means no limit (matches historical behavior). The
+    consumer wires the configured ``parser_max_log_bytes`` so a single
+    pathologically large upload cannot exhaust process memory.
+    """
+    path = resolve_path(sha256, root, hint_ext)
+    if max_bytes is not None:
+        size = path.stat().st_size
+        if size > max_bytes:
+            raise RawFileTooLargeError(
+                f"raw file for sha {sha256} is {size} bytes; exceeds ceiling {max_bytes}"
+            )
+    return path.read_bytes()

--- a/services/parser/tests/test_storage.py
+++ b/services/parser/tests/test_storage.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from parser_service.storage import RawFileNotFoundError, read_raw, resolve_path
+from parser_service.storage import (
+    RawFileNotFoundError,
+    RawFileTooLargeError,
+    read_raw,
+    resolve_path,
+)
 
 
 def _write_shard(root: Path, sha: str, ext: str, content: bytes) -> Path:
@@ -43,3 +48,16 @@ def test_read_raw_returns_bytes(tmp_path: Path) -> None:
     sha = "e" * 64
     _write_shard(tmp_path, sha, ".dat", b"hello")
     assert read_raw(sha, tmp_path) == b"hello"
+
+
+def test_read_raw_under_ceiling(tmp_path: Path) -> None:
+    sha = "f" * 64
+    _write_shard(tmp_path, sha, ".dat", b"hello")
+    assert read_raw(sha, tmp_path, max_bytes=1024) == b"hello"
+
+
+def test_read_raw_rejects_oversize(tmp_path: Path) -> None:
+    sha = "0" * 64
+    _write_shard(tmp_path, sha, ".dat", b"x" * 1024)
+    with pytest.raises(RawFileTooLargeError):
+        read_raw(sha, tmp_path, max_bytes=512)


### PR DESCRIPTION
## Summary

Three follow-ups to the W4 parser service merge (PR #13). Main is currently failing CI on `ruff format --check` because the squash dropped the format commit; this PR re-applies the format and folds in the two outstanding self-review findings.

- **Format:** Re-apply `ruff format` to `parser.py`, `persistence.py`, `storage.py` so `main` goes green again.
- **`parser_max_log_bytes` is now actually enforced.** `storage.read_raw` accepts a `max_bytes` ceiling, `stat()`s the file before buffering, and raises a new `RawFileTooLargeError` if over. The consumer wires the configured 50 MB default (`ParserSettings.parser_max_log_bytes`) and skips-and-logs on overflow, matching the existing raw-file-missing handling. Previously the setting was declared but never read — a misleading safety knob.
- **`persist_match` is now atomically idempotent.** Replaces the prior select-then-insert with `INSERT ... ON CONFLICT (sha256, user_id) DO NOTHING RETURNING id` (Postgres-specific). On conflict, the function looks up and returns the existing row without re-inserting children. The previous pattern advertised idempotency in its docstring but only delivered it at the unique-constraint level — a TOCTOU race could fire `IntegrityError`, which the consumer's broad `except` would swallow, silently dropping the `match.parsed` publish.

Single-worker pub/sub makes the race rare in practice today, but when the parser ever scales horizontally the new shape holds up.

## Test plan

- [x] `uv run ruff check services/parser/ common/` — clean
- [x] `uv run ruff format --check services/parser/ common/` — clean
- [x] `uv run mypy services/parser/ common/` — Success: no issues found in 24 source files
- [x] `uv run pytest services/parser/tests/ -x -q` — 26 passed (24 prior + 2 new for size ceiling)
- [ ] CI green on PR (lint / typecheck / test-common / docker-build / compose-smoke)
- [ ] Once merged, confirm main CI is back to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)