### PR TITLE
feat: archetype catalog + user stats dashboard — see your match performance

### DIFF
--- a/alembic/versions/004_archetype_catalog.py
+++ b/alembic/versions/004_archetype_catalog.py
@@ -1,0 +1,100 @@
+"""archetypes catalog table — analytics.archetypes.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-05-09
+
+The archetype catalog is admin-managed reference data: a list of MTG
+archetypes (Burn, Murktide, Tron, …) with format and a list of
+"defining cards" used by the rule-based classifier in the analytics
+service. ``defining_cards`` is JSONB-encoded as a list of strings so
+the editing UX can stay simple (one card per line, joined client-side).
+
+Owning the table here (root alembic) rather than in a per-service
+alembic keeps the cross-schema FK from ``parser.matches.archetype_id``
+in 005 declarable on a guaranteed-existing target, regardless of which
+service heads have run.
+
+This is a deliberate exception to "analytics owns no tables" — the
+archetype catalog *is* analytics reference data, not operational state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "004"
+down_revision: str | None = "003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto;")
+
+    op.create_table(
+        "archetypes",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("format", sa.Text(), nullable=False),
+        sa.Column(
+            "defining_cards",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "sample_decklists",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        schema="analytics",
+    )
+    op.create_index(
+        "ix_archetypes_format",
+        "archetypes",
+        ["format"],
+        schema="analytics",
+    )
+
+    # Analytics owns this table — grant the analytics role full
+    # privileges. The base 001 migration only grants SELECT on analytics
+    # because at that point the schema had no tables; this catalog is
+    # the first analytics-owned table and needs ALL.
+    op.execute(
+        "GRANT ALL PRIVILEGES ON TABLE analytics.archetypes "
+        "TO deep_analysis_analytics;"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "REVOKE ALL PRIVILEGES ON TABLE analytics.archetypes "
+        "FROM deep_analysis_analytics;"
+    )
+    op.drop_index(
+        "ix_archetypes_format", table_name="archetypes", schema="analytics"
+    )
+    op.drop_table("archetypes", schema="analytics")

--- a/alembic/versions/005_parser_archetype_fk.py
+++ b/alembic/versions/005_parser_archetype_fk.py
@@ -1,0 +1,98 @@
+"""parser.matches.archetype_id — FK to analytics.archetypes.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-05-09
+
+Adds a nullable ``archetype_id`` column to ``parser.matches`` with a
+foreign key into ``analytics.archetypes.id``. The parser fills this in
+opportunistically by calling the analytics classifier endpoint after
+persisting a match — null means "not classified yet" or "classifier
+returned no match".
+
+Cross-schema FK: PostgreSQL needs both SELECT (so the parser role can
+look up the target row) and REFERENCES (to declare the constraint
+itself) on the analytics schema. We grant SELECT directly and use
+ALTER DEFAULT PRIVILEGES for REFERENCES so any future tables added to
+the analytics schema by the analytics role will also be referenceable.
+``ON DELETE SET NULL`` on the FK so an admin deleting an archetype
+doesn't cascade-wipe match rows; the match just loses its
+classification until re-run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Cross-schema grants — parser needs SELECT to read archetype rows
+    # at FK-validate time, and REFERENCES to declare the constraint.
+    op.execute("GRANT USAGE ON SCHEMA analytics TO deep_analysis_parser;")
+    op.execute(
+        "GRANT SELECT, REFERENCES ON ALL TABLES IN SCHEMA analytics "
+        "TO deep_analysis_parser;"
+    )
+    op.execute(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA analytics "
+        "GRANT SELECT, REFERENCES ON TABLES TO deep_analysis_parser;"
+    )
+
+    op.add_column(
+        "matches",
+        sa.Column(
+            "archetype_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        schema="parser",
+    )
+    op.create_foreign_key(
+        "fk_matches_archetype_id",
+        source_table="matches",
+        referent_table="archetypes",
+        local_cols=["archetype_id"],
+        remote_cols=["id"],
+        ondelete="SET NULL",
+        source_schema="parser",
+        referent_schema="analytics",
+    )
+    op.create_index(
+        "ix_matches_archetype_id",
+        "matches",
+        ["archetype_id"],
+        schema="parser",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_matches_archetype_id", table_name="matches", schema="parser"
+    )
+    op.drop_constraint(
+        "fk_matches_archetype_id",
+        "matches",
+        type_="foreignkey",
+        schema="parser",
+    )
+    op.drop_column("matches", "archetype_id", schema="parser")
+
+    op.execute(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA analytics "
+        "REVOKE SELECT, REFERENCES ON TABLES FROM deep_analysis_parser;"
+    )
+    op.execute(
+        "REVOKE SELECT, REFERENCES ON ALL TABLES IN SCHEMA analytics "
+        "FROM deep_analysis_parser;"
+    )
+    op.execute("REVOKE USAGE ON SCHEMA analytics FROM deep_analysis_parser;")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ ignore = []
 "services/ingest/ingest_service/deps.py" = ["B008"]
 "services/web/web_service/main.py" = ["B008"]
 "services/web/web_service/deps.py" = ["B008"]
+"services/analytics/analytics_service/archetypes.py" = ["B008"]
+"services/analytics/analytics_service/stats.py" = ["B008"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/services/analytics/analytics_service/archetypes.py
+++ b/services/analytics/analytics_service/archetypes.py
@@ -1,0 +1,173 @@
+"""Archetype catalog router.
+
+Read endpoints (list, classify) and admin CRUD on the
+``analytics.archetypes`` catalog table. The classifier is a thin route
+over :func:`analytics_service.classifier.classify` — the algorithm
+itself is unit-tested in isolation.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from analytics_service.classifier import classify
+from analytics_service.db import get_session
+from analytics_service.deps import AuthenticatedUser, require_admin, require_user
+from analytics_service.models import Archetype
+from analytics_service.schemas import (
+    ArchetypeListView,
+    ArchetypeRecord,
+    ArchetypeWriteRequest,
+    ClassifyRequest,
+    ClassifyResult,
+)
+
+router = APIRouter(prefix="/analytics/archetypes", tags=["archetypes"])
+
+
+def _record(row: Archetype) -> ArchetypeRecord:
+    return ArchetypeRecord(
+        id=row.id,
+        name=row.name,
+        format=row.format,
+        defining_cards=list(row.defining_cards or []),
+        sample_decklists=row.sample_decklists,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+@router.get("", response_model=ArchetypeListView)
+async def list_archetypes(
+    _user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> ArchetypeListView:
+    rows = (
+        (await db.execute(select(Archetype).order_by(Archetype.format, Archetype.name)))
+        .scalars()
+        .all()
+    )
+    total = int((await db.execute(select(func.count()).select_from(Archetype))).scalar_one())
+    return ArchetypeListView(archetypes=[_record(r) for r in rows], total=total)
+
+
+@router.post("/classify", response_model=ClassifyResult)
+async def classify_endpoint(
+    body: ClassifyRequest,
+    db: AsyncSession = Depends(get_session),
+) -> ClassifyResult:
+    """Classify a decklist against the catalog.
+
+    No auth — the endpoint is a stateless utility intended for the
+    parser worker (which holds no JWT) and any internal caller. It
+    leaks no information beyond what GET /archetypes already exposes.
+    """
+    if not body.card_names:
+        return ClassifyResult()
+    rows = (await db.execute(select(Archetype))).scalars().all()
+    if not rows:
+        return ClassifyResult()
+    outcome = classify(body.card_names, rows)
+    if outcome.archetype is None:
+        return ClassifyResult()
+    arch = outcome.archetype
+    # The archetype here is one of the SQLAlchemy rows we just loaded,
+    # so the attribute access is safe; type narrowing via the protocol
+    # in classifier.py keeps it duck-typed for unit tests.
+    assert isinstance(arch, Archetype)
+    return ClassifyResult(
+        archetype_id=arch.id,
+        archetype_name=arch.name,
+        format=arch.format,
+        confidence=outcome.confidence,
+    )
+
+
+@router.post(
+    "",
+    response_model=ArchetypeRecord,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_archetype(
+    body: ArchetypeWriteRequest,
+    _admin: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> ArchetypeRecord:
+    row = Archetype(
+        id=uuid.uuid4(),
+        name=body.name,
+        format=body.format,
+        defining_cards=list(body.defining_cards),
+        sample_decklists=body.sample_decklists,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return _record(row)
+
+
+@router.get("/{archetype_id}", response_model=ArchetypeRecord)
+async def get_archetype(
+    archetype_id: uuid.UUID,
+    _admin: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> ArchetypeRecord:
+    row = (
+        await db.execute(select(Archetype).where(Archetype.id == archetype_id))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "archetype_not_found"},
+        )
+    return _record(row)
+
+
+@router.put("/{archetype_id}", response_model=ArchetypeRecord)
+async def update_archetype(
+    archetype_id: uuid.UUID,
+    body: ArchetypeWriteRequest,
+    _admin: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> ArchetypeRecord:
+    row = (
+        await db.execute(select(Archetype).where(Archetype.id == archetype_id))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "archetype_not_found"},
+        )
+    row.name = body.name
+    row.format = body.format
+    row.defining_cards = list(body.defining_cards)
+    row.sample_decklists = body.sample_decklists
+    row.updated_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(row)
+    return _record(row)
+
+
+@router.delete("/{archetype_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_archetype(
+    archetype_id: uuid.UUID,
+    _admin: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    result = await db.execute(delete(Archetype).where(Archetype.id == archetype_id))
+    await db.commit()
+    # SQLAlchemy's async ``execute`` returns ``Result``; for DML the
+    # underlying object is a ``CursorResult`` carrying ``rowcount``.
+    # Cast through ``Any`` to keep mypy quiet without disabling checks.
+    rowcount: int = result.rowcount  # type: ignore[attr-defined]
+    if rowcount == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "archetype_not_found"},
+        )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/services/analytics/analytics_service/classifier.py
+++ b/services/analytics/analytics_service/classifier.py
@@ -1,0 +1,81 @@
+"""Rule-based archetype classifier.
+
+Pure-function implementation kept separate from the FastAPI route so
+unit tests can exercise the algorithm against an in-memory list of
+archetypes without standing up a database session. The algorithm is
+intentionally simple — overlap fraction of defining cards — and is
+expected to be replaced by a richer scorer in a later milestone.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class _ArchetypeLike(Protocol):
+    """Structural type the classifier needs from an archetype.
+
+    Both the SQLAlchemy ``Archetype`` model and the Pydantic
+    ``ArchetypeRecord`` schema satisfy this — the route hands in
+    whichever is convenient at the call site.
+    """
+
+    @property
+    def id(self) -> object: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def format(self) -> str: ...
+
+    @property
+    def defining_cards(self) -> list[str]: ...
+
+
+@dataclass
+class ClassificationOutcome:
+    """In-process result. The route layer maps this to the API shape."""
+
+    archetype: _ArchetypeLike | None
+    confidence: float
+
+
+def _norm(name: str) -> str:
+    """Normalize for case- and whitespace-insensitive comparison."""
+    return name.strip().casefold()
+
+
+def classify(
+    card_names: Iterable[str],
+    archetypes: Iterable[_ArchetypeLike],
+) -> ClassificationOutcome:
+    """Pick the archetype with the highest defining-card overlap.
+
+    Overlap is ``|defining ∩ played| / |defining|`` — the fraction of
+    an archetype's defining cards that appeared in ``card_names``.
+    Ties resolve to the archetype seen first in ``archetypes``.
+    Returns a ``ClassificationOutcome`` with ``archetype=None`` and
+    ``confidence=0.0`` if nothing scores above zero.
+    """
+    played = {_norm(c) for c in card_names if c and c.strip()}
+    if not played:
+        return ClassificationOutcome(archetype=None, confidence=0.0)
+
+    best: _ArchetypeLike | None = None
+    best_score = 0.0
+    for arch in archetypes:
+        defining = [c for c in arch.defining_cards if c and c.strip()]
+        if not defining:
+            continue
+        defining_normed = {_norm(c) for c in defining}
+        overlap = len(defining_normed & played) / len(defining_normed)
+        if overlap > best_score:
+            best = arch
+            best_score = overlap
+
+    if best is None or best_score <= 0.0:
+        return ClassificationOutcome(archetype=None, confidence=0.0)
+    return ClassificationOutcome(archetype=best, confidence=best_score)

--- a/services/analytics/analytics_service/db.py
+++ b/services/analytics/analytics_service/db.py
@@ -1,0 +1,54 @@
+"""Async SQLAlchemy engine + session factory for analytics."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from analytics_service.settings import get_settings
+
+_engine: AsyncEngine | None = None
+_sessionmaker: async_sessionmaker[AsyncSession] | None = None
+
+
+def _async_url(url: str) -> str:
+    if url.startswith("postgresql+asyncpg://"):
+        return url
+    if url.startswith("postgresql+psycopg://"):
+        return "postgresql+asyncpg://" + url.removeprefix("postgresql+psycopg://")
+    if url.startswith("postgresql://"):
+        return "postgresql+asyncpg://" + url.removeprefix("postgresql://")
+    return url
+
+
+def get_engine() -> AsyncEngine:
+    global _engine, _sessionmaker
+    if _engine is None:
+        url = _async_url(get_settings().database_url)
+        _engine = create_async_engine(url, future=True, pool_pre_ping=True)
+        _sessionmaker = async_sessionmaker(_engine, expire_on_commit=False)
+    return _engine
+
+
+def get_sessionmaker() -> async_sessionmaker[AsyncSession]:
+    get_engine()
+    assert _sessionmaker is not None
+    return _sessionmaker
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    sm = get_sessionmaker()
+    async with sm() as session:
+        yield session
+
+
+def reset_engine() -> None:
+    global _engine, _sessionmaker
+    _engine = None
+    _sessionmaker = None

--- a/services/analytics/analytics_service/deps.py
+++ b/services/analytics/analytics_service/deps.py
@@ -1,0 +1,91 @@
+"""FastAPI dependencies for the analytics service.
+
+Auth is JWT-based (the same RS256 access tokens auth issues for users).
+Analytics doesn't carry an authoritative session check the way auth
+does — the access token's signature + expiry is enough for read-only
+catalog access. Mutation endpoints additionally require the ``admin``
+role claim.
+
+The classify endpoint is intentionally unauthenticated: it is a
+stateless utility so the parser worker (which holds no JWT of its own)
+can call it after persisting a match. The endpoint surfaces no data
+from the catalog beyond the matched archetype's id/name/format, all of
+which are already enumerable by any logged-in user via GET /archetypes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import HTTPException, Request, status
+
+from analytics_service.settings import get_settings
+from common.jwt_verify import InvalidTokenError, JWTVerifier
+
+
+@dataclass
+class AuthenticatedUser:
+    user_id: int
+    role: str
+
+
+_verifier: JWTVerifier | None = None
+
+
+def get_verifier() -> JWTVerifier:
+    global _verifier
+    if _verifier is None:
+        s = get_settings()
+        _verifier = JWTVerifier(s.jwt_public_key_path, s.jwt_issuer, s.jwt_audience)
+    return _verifier
+
+
+def reset_verifier() -> None:
+    global _verifier
+    _verifier = None
+
+
+def _unauthorized() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail={"error": "unauthorized"},
+    )
+
+
+def _forbidden() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={"error": "forbidden"},
+    )
+
+
+def _resolve_user(request: Request) -> AuthenticatedUser:
+    auth = request.headers.get("authorization") or ""
+    if not auth.lower().startswith("bearer "):
+        raise _unauthorized()
+    token = auth[7:].strip()
+    if not token:
+        raise _unauthorized()
+    try:
+        claims = get_verifier().verify(token)
+    except InvalidTokenError as exc:
+        raise _unauthorized() from exc
+    try:
+        user_id = int(claims["sub"])
+        role = str(claims["role"])
+    except (KeyError, ValueError) as exc:
+        raise _unauthorized() from exc
+    return AuthenticatedUser(user_id=user_id, role=role)
+
+
+async def require_user(request: Request) -> AuthenticatedUser:
+    """Any authenticated caller (user or admin)."""
+    return _resolve_user(request)
+
+
+async def require_admin(request: Request) -> AuthenticatedUser:
+    """Authenticated caller with role=admin."""
+    user = _resolve_user(request)
+    if user.role != "admin":
+        raise _forbidden()
+    return user

--- a/services/analytics/analytics_service/main.py
+++ b/services/analytics/analytics_service/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 
+from analytics_service.archetypes import router as archetypes_router
 from common.logging import configure_logging
 from common.metrics import mount_metrics
 
@@ -7,6 +8,7 @@ SERVICE_NAME = "analytics"
 configure_logging(SERVICE_NAME)
 app = FastAPI(title=f"deep-analysis-{SERVICE_NAME}")
 mount_metrics(app, SERVICE_NAME)
+app.include_router(archetypes_router)
 
 
 @app.get("/healthz")

--- a/services/analytics/analytics_service/main.py
+++ b/services/analytics/analytics_service/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from analytics_service.archetypes import router as archetypes_router
+from analytics_service.stats import router as stats_router
 from common.logging import configure_logging
 from common.metrics import mount_metrics
 
@@ -9,6 +10,7 @@ configure_logging(SERVICE_NAME)
 app = FastAPI(title=f"deep-analysis-{SERVICE_NAME}")
 mount_metrics(app, SERVICE_NAME)
 app.include_router(archetypes_router)
+app.include_router(stats_router)
 
 
 @app.get("/healthz")

--- a/services/analytics/analytics_service/models.py
+++ b/services/analytics/analytics_service/models.py
@@ -1,0 +1,44 @@
+"""SQLAlchemy models for the analytics service.
+
+The archetype catalog (``analytics.archetypes``) is the only table the
+analytics service owns. Everything else analytics queries lives in
+other schemas (``parser.matches``, ``parser.games``, ``parser.game_states``,
+``ingest.user_uploads``, ``auth.users``); analytics holds no models for
+those, only ad-hoc SELECTs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, MetaData, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+metadata = MetaData(schema="analytics")
+
+
+class Base(DeclarativeBase):
+    metadata = metadata
+
+
+class Archetype(Base):
+    __tablename__ = "archetypes"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.gen_random_uuid(),
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    format: Mapped[str] = mapped_column(Text, nullable=False)
+    defining_cards: Mapped[list[str]] = mapped_column(JSONB, nullable=False, server_default="[]")
+    sample_decklists: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/services/analytics/analytics_service/schemas.py
+++ b/services/analytics/analytics_service/schemas.py
@@ -1,0 +1,57 @@
+"""Pydantic schemas for the analytics service."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ArchetypeRecord(BaseModel):
+    """A single row from ``analytics.archetypes``."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    format: str
+    defining_cards: list[str] = Field(default_factory=list)
+    sample_decklists: list[Any] | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class ArchetypeListView(BaseModel):
+    archetypes: list[ArchetypeRecord]
+    total: int
+
+
+class ArchetypeWriteRequest(BaseModel):
+    """Body for create + update — admin-only routes."""
+
+    name: str = Field(..., min_length=1, max_length=200)
+    format: str = Field(..., min_length=1, max_length=64)
+    defining_cards: list[str] = Field(default_factory=list)
+    sample_decklists: list[Any] | None = None
+
+
+class ClassifyRequest(BaseModel):
+    card_names: list[str] = Field(default_factory=list)
+
+
+class ClassifyResult(BaseModel):
+    """Best-matching archetype and its overlap-based confidence.
+
+    ``archetype_id`` and ``archetype_name`` / ``format`` are null when
+    the catalog is empty, when the request carries no card names, or
+    when no defining-card overlap exists with any catalog entry.
+    ``confidence`` is the share of an archetype's defining cards that
+    appeared in the request — a float in [0.0, 1.0].
+    """
+
+    archetype_id: uuid.UUID | None = None
+    archetype_name: str | None = None
+    format: str | None = None
+    confidence: float = 0.0

--- a/services/analytics/analytics_service/settings.py
+++ b/services/analytics/analytics_service/settings.py
@@ -1,0 +1,30 @@
+"""Analytics-service-specific settings."""
+
+from __future__ import annotations
+
+from pydantic_settings import SettingsConfigDict
+
+from common.settings import BaseServiceSettings
+
+
+class AnalyticsSettings(BaseServiceSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="DA_",
+        env_nested_delimiter="__",
+        populate_by_name=True,
+    )
+
+
+_settings: AnalyticsSettings | None = None
+
+
+def get_settings() -> AnalyticsSettings:
+    global _settings
+    if _settings is None:
+        _settings = AnalyticsSettings(service_name="analytics")  # type: ignore[call-arg]
+    return _settings
+
+
+def reset_settings() -> None:
+    global _settings
+    _settings = None

--- a/services/analytics/analytics_service/stats.py
+++ b/services/analytics/analytics_service/stats.py
@@ -1,0 +1,269 @@
+"""User-facing stats endpoints.
+
+Reads ``parser.matches`` and ``parser.games`` cross-schema (analytics
+holds no parser tables — see CLAUDE.md design decision #2). All endpoints
+filter by ``user_id`` from the verified JWT and return empty data
+gracefully when the user has no matches yet.
+
+The "user perspective" within a match is currently inferred from
+``match.players[0]`` — MTGO logs are uploaded by one of the two players
+and the parser's player-ordering convention puts the uploader-side
+account first. If the upstream parser ever changes that convention,
+this module is the only consumer that needs to be updated.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from analytics_service.db import get_session
+from analytics_service.deps import AuthenticatedUser, require_user
+
+router = APIRouter(prefix="/analytics/stats", tags=["stats"])
+
+
+_RECENT_MATCH_LIMIT = 20
+
+
+class RecentMatch(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    match_id: str
+    played_at: datetime | None = None
+    opponent: str | None = None
+    result: str = ""
+    format_: str | None = Field(default=None, alias="format")
+    player_wins: int = 0
+    player_losses: int = 0
+
+
+class StatsSummary(BaseModel):
+    total_matches: int = 0
+    wins: int = 0
+    losses: int = 0
+    draws: int = 0
+    win_rate: float = 0.0
+    recent_matches: list[RecentMatch] = Field(default_factory=list)
+
+
+class FormatStat(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    format_: str = Field(alias="format")
+    matches: int = 0
+    wins: int = 0
+    losses: int = 0
+    draws: int = 0
+    win_rate: float = 0.0
+
+
+class OpponentStat(BaseModel):
+    opponent: str
+    matches: int = 0
+    wins: int = 0
+    losses: int = 0
+    draws: int = 0
+    win_rate: float = 0.0
+
+
+def _classify_match(
+    players: list[Any] | None,
+    game_wins_by_player: dict[str, int],
+) -> tuple[str, str | None, int, int]:
+    """Return (result, opponent, player_wins, player_losses).
+
+    - The "user" within the match is taken to be ``players[0]``.
+    - W/L/D is derived from per-game wins, not the match-level
+      ``winner`` column, so ties and unknowns produce the right shape.
+    """
+    if not players:
+        return "", None, 0, 0
+    user = str(players[0]) if players else None
+    opponent = str(players[1]) if len(players) > 1 else None
+    if user is None:
+        return "", opponent, 0, 0
+    user_wins = game_wins_by_player.get(user, 0)
+    opp_wins = sum(v for k, v in game_wins_by_player.items() if k != user)
+    if user_wins == 0 and opp_wins == 0:
+        return "", opponent, 0, 0
+    if user_wins > opp_wins:
+        return "W", opponent, user_wins, opp_wins
+    if user_wins < opp_wins:
+        return "L", opponent, user_wins, opp_wins
+    return "D", opponent, user_wins, opp_wins
+
+
+async def _load_user_matches(db: AsyncSession, user_id: int) -> list[dict[str, Any]]:
+    """Fetch a user's matches plus per-match game-winner counts."""
+    rows = (
+        await db.execute(
+            text(
+                """
+                SELECT id, format, players, parsed_at
+                FROM parser.matches
+                WHERE user_id = :user_id
+                ORDER BY parsed_at DESC
+                """
+            ),
+            {"user_id": user_id},
+        )
+    ).all()
+    if not rows:
+        return []
+    match_ids = [r[0] for r in rows]
+    game_rows = (
+        await db.execute(
+            text(
+                """
+                SELECT match_id, winner, COUNT(*) AS n
+                FROM parser.games
+                WHERE match_id = ANY(:match_ids)
+                  AND winner IS NOT NULL
+                GROUP BY match_id, winner
+                """
+            ),
+            {"match_ids": match_ids},
+        )
+    ).all()
+    by_match: dict[Any, dict[str, int]] = {}
+    for match_id, winner, n in game_rows:
+        by_match.setdefault(match_id, {})[str(winner)] = int(n)
+    out: list[dict[str, Any]] = []
+    for match_id, fmt, players, parsed_at in rows:
+        out.append(
+            {
+                "id": match_id,
+                "format": fmt,
+                "players": list(players or []),
+                "parsed_at": parsed_at,
+                "wins_by_player": by_match.get(match_id, {}),
+            }
+        )
+    return out
+
+
+def _summarize(matches: list[dict[str, Any]]) -> StatsSummary:
+    if not matches:
+        return StatsSummary()
+    wins = losses = draws = 0
+    recent: list[RecentMatch] = []
+    for m in matches:
+        result, opponent, pw, pl = _classify_match(m["players"], m["wins_by_player"])
+        if result == "W":
+            wins += 1
+        elif result == "L":
+            losses += 1
+        elif result == "D":
+            draws += 1
+        if len(recent) < _RECENT_MATCH_LIMIT:
+            recent.append(
+                RecentMatch(
+                    match_id=str(m["id"]),
+                    played_at=m["parsed_at"],
+                    opponent=opponent,
+                    result=result,
+                    format=m["format"],
+                    player_wins=pw,
+                    player_losses=pl,
+                )
+            )
+    decided = wins + losses
+    win_rate = (wins / decided) * 100.0 if decided else 0.0
+    return StatsSummary(
+        total_matches=len(matches),
+        wins=wins,
+        losses=losses,
+        draws=draws,
+        win_rate=win_rate,
+        recent_matches=recent,
+    )
+
+
+@router.get("/summary", response_model=StatsSummary)
+async def get_summary(
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> StatsSummary:
+    matches = await _load_user_matches(db, user.user_id)
+    return _summarize(matches)
+
+
+@router.get("/by-format", response_model=list[FormatStat])
+async def get_by_format(
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> list[FormatStat]:
+    matches = await _load_user_matches(db, user.user_id)
+    if not matches:
+        return []
+    buckets: dict[str, dict[str, int]] = {}
+    for m in matches:
+        fmt = m["format"] or "Unknown"
+        bucket = buckets.setdefault(fmt, {"matches": 0, "wins": 0, "losses": 0, "draws": 0})
+        bucket["matches"] += 1
+        result, _opp, _pw, _pl = _classify_match(m["players"], m["wins_by_player"])
+        if result == "W":
+            bucket["wins"] += 1
+        elif result == "L":
+            bucket["losses"] += 1
+        elif result == "D":
+            bucket["draws"] += 1
+    out: list[FormatStat] = []
+    for fmt, b in sorted(buckets.items(), key=lambda kv: -kv[1]["matches"]):
+        decided = b["wins"] + b["losses"]
+        win_rate = (b["wins"] / decided) * 100.0 if decided else 0.0
+        out.append(
+            FormatStat(
+                format=fmt,
+                matches=b["matches"],
+                wins=b["wins"],
+                losses=b["losses"],
+                draws=b["draws"],
+                win_rate=win_rate,
+            )
+        )
+    return out
+
+
+@router.get("/by-opponent", response_model=list[OpponentStat])
+async def get_by_opponent(
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> list[OpponentStat]:
+    matches = await _load_user_matches(db, user.user_id)
+    if not matches:
+        return []
+    buckets: dict[str, dict[str, int]] = {}
+    for m in matches:
+        result, opponent, _pw, _pl = _classify_match(m["players"], m["wins_by_player"])
+        if not opponent:
+            continue
+        bucket = buckets.setdefault(opponent, {"matches": 0, "wins": 0, "losses": 0, "draws": 0})
+        bucket["matches"] += 1
+        if result == "W":
+            bucket["wins"] += 1
+        elif result == "L":
+            bucket["losses"] += 1
+        elif result == "D":
+            bucket["draws"] += 1
+    out: list[OpponentStat] = []
+    for opp, b in sorted(buckets.items(), key=lambda kv: -kv[1]["matches"]):
+        decided = b["wins"] + b["losses"]
+        win_rate = (b["wins"] / decided) * 100.0 if decided else 0.0
+        out.append(
+            OpponentStat(
+                opponent=opp,
+                matches=b["matches"],
+                wins=b["wins"],
+                losses=b["losses"],
+                draws=b["draws"],
+                win_rate=win_rate,
+            )
+        )
+    return out

--- a/services/analytics/tests/test_archetype_classifier.py
+++ b/services/analytics/tests/test_archetype_classifier.py
@@ -1,0 +1,127 @@
+"""Unit tests for the rule-based archetype classifier.
+
+Exercises :func:`analytics_service.classifier.classify` against an
+in-memory list of archetypes — no DB or HTTP — so it stays fast and
+self-contained.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from analytics_service.classifier import classify
+
+
+@dataclass
+class _FakeArchetype:
+    """Stand-in for the SQLAlchemy ``Archetype`` row.
+
+    The classifier only reads ``id``, ``name``, ``format``, and
+    ``defining_cards`` — anything that satisfies the structural
+    protocol works.
+    """
+
+    id: int
+    name: str
+    format: str = "Modern"
+    defining_cards: list[str] = field(default_factory=list)
+
+
+def test_returns_none_when_card_names_empty() -> None:
+    archs = [_FakeArchetype(1, "Burn", defining_cards=["Lightning Bolt"])]
+    out = classify([], archs)
+    assert out.archetype is None
+    assert out.confidence == 0.0
+
+
+def test_returns_none_when_archetypes_empty() -> None:
+    out = classify(["Lightning Bolt"], [])
+    assert out.archetype is None
+    assert out.confidence == 0.0
+
+
+def test_returns_none_when_no_overlap() -> None:
+    archs = [
+        _FakeArchetype(
+            1,
+            "Burn",
+            defining_cards=["Lightning Bolt", "Goblin Guide"],
+        ),
+    ]
+    out = classify(["Counterspell", "Brainstorm"], archs)
+    assert out.archetype is None
+    assert out.confidence == 0.0
+
+
+def test_picks_archetype_with_highest_overlap_ratio() -> None:
+    burn = _FakeArchetype(
+        1,
+        "Burn",
+        defining_cards=["Lightning Bolt", "Goblin Guide", "Lava Spike"],
+    )
+    tron = _FakeArchetype(
+        2,
+        "Tron",
+        defining_cards=["Urza's Tower", "Urza's Mine", "Karn Liberated"],
+    )
+
+    out = classify(["Lightning Bolt", "Goblin Guide"], [burn, tron])
+    assert out.archetype is burn
+    # 2 of 3 burn defining cards present.
+    assert out.confidence == 2 / 3
+
+
+def test_full_overlap_yields_confidence_one() -> None:
+    burn = _FakeArchetype(1, "Burn", defining_cards=["Lightning Bolt", "Lava Spike"])
+    out = classify(["Lightning Bolt", "Lava Spike", "Mountain"], [burn])
+    assert out.archetype is burn
+    assert out.confidence == 1.0
+
+
+def test_match_is_case_insensitive_and_trimmed() -> None:
+    burn = _FakeArchetype(1, "Burn", defining_cards=["Lightning Bolt", "Goblin Guide"])
+    out = classify(["  lightning bolt  ", "GOBLIN GUIDE"], [burn])
+    assert out.archetype is burn
+    assert out.confidence == 1.0
+
+
+def test_blank_card_names_are_ignored() -> None:
+    burn = _FakeArchetype(1, "Burn", defining_cards=["Lightning Bolt", "Goblin Guide"])
+    out = classify(["", "   ", "Lightning Bolt"], [burn])
+    assert out.archetype is burn
+    assert out.confidence == 0.5
+
+
+def test_archetype_with_empty_defining_cards_is_skipped() -> None:
+    empty = _FakeArchetype(1, "EmptyCatalogEntry", defining_cards=[])
+    burn = _FakeArchetype(2, "Burn", defining_cards=["Lightning Bolt"])
+    out = classify(["Lightning Bolt"], [empty, burn])
+    assert out.archetype is burn
+    assert out.confidence == 1.0
+
+
+def test_tie_resolves_to_first_seen() -> None:
+    a = _FakeArchetype(1, "A", defining_cards=["Card X"])
+    b = _FakeArchetype(2, "B", defining_cards=["Card X"])
+    out = classify(["Card X"], [a, b])
+    # Both score 1.0; first iteration wins.
+    assert out.archetype is a
+
+
+def test_confidence_is_float_in_unit_interval() -> None:
+    archs = [
+        _FakeArchetype(
+            1,
+            "Burn",
+            defining_cards=[
+                "Lightning Bolt",
+                "Goblin Guide",
+                "Lava Spike",
+                "Eidolon of the Great Revel",
+            ],
+        ),
+    ]
+    out = classify(["Lightning Bolt"], archs)
+    assert isinstance(out.confidence, float)
+    assert 0.0 <= out.confidence <= 1.0
+    assert out.confidence == 0.25

--- a/services/analytics/tests/test_stats.py
+++ b/services/analytics/tests/test_stats.py
@@ -1,0 +1,313 @@
+"""Stats endpoint tests.
+
+The cross-schema queries against ``parser.matches`` / ``parser.games``
+need a real Postgres to exercise; here we focus on handler/aggregation
+behavior by overriding the DB-session dependency with a fake that
+returns prefab rows. The aggregation logic itself (``_classify_match``
++ ``_summarize``) is exercised through the route so the assertions
+also cover the wiring.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _analytics_test_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    out = tmp_path_factory.mktemp("analytics-jwt-keys")
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pub_path = out / "jwt_public.pem"
+    pub_path.write_bytes(pub_pem)
+    os.environ["DA_JWT_PUBLIC_KEY_PATH"] = str(pub_path)
+    os.environ.setdefault("DA_DATABASE_URL", "postgresql+asyncpg://x:x@localhost:5432/x")
+    os.environ.setdefault("DA_REDIS_URL", "redis://localhost:6379/0")
+    yield pub_path
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from analytics_service import main as _main
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 7) -> Any:
+    from analytics_service import deps as _deps
+
+    fake = _deps.AuthenticatedUser(user_id=user_id, role="user")
+
+    async def _dep() -> _deps.AuthenticatedUser:
+        return fake
+
+    return _dep
+
+
+def _patch_loader(monkeypatch: pytest.MonkeyPatch, matches: list[dict[str, Any]]) -> None:
+    from analytics_service import stats as _stats
+
+    async def fake_loader(_db: Any, _user_id: int) -> list[dict[str, Any]]:
+        return matches
+
+    monkeypatch.setattr(_stats, "_load_user_matches", fake_loader)
+
+
+# ---------------------------------------------------------------------------
+# /summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summary_empty_state(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    _patch_loader(monkeypatch, [])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get("/analytics/stats/summary")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total_matches"] == 0
+    assert body["wins"] == 0
+    assert body["losses"] == 0
+    assert body["draws"] == 0
+    assert body["win_rate"] == 0.0
+    assert body["recent_matches"] == []
+
+
+@pytest.mark.asyncio
+async def test_summary_counts_wins_losses_draws(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    m1 = uuid.uuid4()
+    m2 = uuid.uuid4()
+    m3 = uuid.uuid4()
+    matches = [
+        {  # win 2-1
+            "id": m1,
+            "format": "Modern",
+            "players": ["alice", "bob"],
+            "parsed_at": datetime(2026, 5, 9, 10, 0, tzinfo=UTC),
+            "wins_by_player": {"alice": 2, "bob": 1},
+        },
+        {  # loss 0-2
+            "id": m2,
+            "format": "Modern",
+            "players": ["alice", "carol"],
+            "parsed_at": datetime(2026, 5, 8, 10, 0, tzinfo=UTC),
+            "wins_by_player": {"carol": 2},
+        },
+        {  # draw 1-1
+            "id": m3,
+            "format": "Pioneer",
+            "players": ["alice", "dan"],
+            "parsed_at": datetime(2026, 5, 7, 10, 0, tzinfo=UTC),
+            "wins_by_player": {"alice": 1, "dan": 1},
+        },
+    ]
+    _patch_loader(monkeypatch, matches)
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get("/analytics/stats/summary")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total_matches"] == 3
+    assert body["wins"] == 1
+    assert body["losses"] == 1
+    assert body["draws"] == 1
+    # 1 win / (1 win + 1 loss) = 50%
+    assert body["win_rate"] == 50.0
+    assert len(body["recent_matches"]) == 3
+    first = body["recent_matches"][0]
+    assert first["match_id"] == str(m1)
+    assert first["opponent"] == "bob"
+    assert first["result"] == "W"
+    assert first["format"] == "Modern"
+    assert first["player_wins"] == 2
+    assert first["player_losses"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_unauth_returns_401(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get("/analytics/stats/summary")
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /by-format
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_by_format_empty_state(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    _patch_loader(monkeypatch, [])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get("/analytics/stats/by-format")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+@pytest.mark.asyncio
+async def test_by_format_buckets_by_format(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    matches = [
+        {
+            "id": uuid.uuid4(),
+            "format": "Modern",
+            "players": ["alice", "bob"],
+            "parsed_at": datetime(2026, 5, 9, tzinfo=UTC),
+            "wins_by_player": {"alice": 2, "bob": 0},
+        },
+        {
+            "id": uuid.uuid4(),
+            "format": "Modern",
+            "players": ["alice", "bob"],
+            "parsed_at": datetime(2026, 5, 8, tzinfo=UTC),
+            "wins_by_player": {"bob": 2},
+        },
+        {
+            "id": uuid.uuid4(),
+            "format": "Pioneer",
+            "players": ["alice", "carol"],
+            "parsed_at": datetime(2026, 5, 7, tzinfo=UTC),
+            "wins_by_player": {"alice": 2, "carol": 1},
+        },
+    ]
+    _patch_loader(monkeypatch, matches)
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get("/analytics/stats/by-format")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    rows = r.json()
+    assert len(rows) == 2
+    by_fmt = {row["format"]: row for row in rows}
+    assert by_fmt["Modern"]["matches"] == 2
+    assert by_fmt["Modern"]["wins"] == 1
+    assert by_fmt["Modern"]["losses"] == 1
+    assert by_fmt["Modern"]["win_rate"] == 50.0
+    assert by_fmt["Pioneer"]["matches"] == 1
+    assert by_fmt["Pioneer"]["wins"] == 1
+    assert by_fmt["Pioneer"]["win_rate"] == 100.0
+
+
+# ---------------------------------------------------------------------------
+# /by-opponent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_by_opponent_empty_state(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    _patch_loader(monkeypatch, [])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get("/analytics/stats/by-opponent")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+@pytest.mark.asyncio
+async def test_by_opponent_buckets_by_opponent(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    matches = [
+        {
+            "id": uuid.uuid4(),
+            "format": "Modern",
+            "players": ["alice", "bob"],
+            "parsed_at": datetime(2026, 5, 9, tzinfo=UTC),
+            "wins_by_player": {"alice": 2, "bob": 0},
+        },
+        {
+            "id": uuid.uuid4(),
+            "format": "Modern",
+            "players": ["alice", "bob"],
+            "parsed_at": datetime(2026, 5, 8, tzinfo=UTC),
+            "wins_by_player": {"bob": 2, "alice": 1},
+        },
+        {
+            "id": uuid.uuid4(),
+            "format": "Pioneer",
+            "players": ["alice", "carol"],
+            "parsed_at": datetime(2026, 5, 7, tzinfo=UTC),
+            "wins_by_player": {"alice": 2},
+        },
+    ]
+    _patch_loader(monkeypatch, matches)
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get("/analytics/stats/by-opponent")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    rows = r.json()
+    by_opp = {row["opponent"]: row for row in rows}
+    assert by_opp["bob"]["matches"] == 2
+    assert by_opp["bob"]["wins"] == 1
+    assert by_opp["bob"]["losses"] == 1
+    assert by_opp["bob"]["win_rate"] == 50.0
+    assert by_opp["carol"]["matches"] == 1
+    assert by_opp["carol"]["wins"] == 1
+    assert by_opp["carol"]["win_rate"] == 100.0

--- a/services/parser/parser_service/analytics_client.py
+++ b/services/parser/parser_service/analytics_client.py
@@ -1,0 +1,67 @@
+"""Thin HTTP client over the analytics classify endpoint.
+
+The parser calls ``POST /analytics/archetypes/classify`` after a match
+is persisted to opportunistically tag the row with an archetype. The
+endpoint is unauthenticated by design — the classifier is a stateless
+utility and the parser holds no JWT of its own.
+
+Failures (transport, HTTP non-2xx, malformed payload) are caller-
+swallowed: classification is best-effort and must never fail the parse.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Iterable
+
+import httpx
+
+_log = logging.getLogger("parser.analytics_client")
+
+
+async def classify(
+    base_url: str,
+    card_names: Iterable[str],
+    *,
+    timeout_seconds: float = 5.0,
+) -> uuid.UUID | None:
+    """Call analytics' classify endpoint, return the matched archetype id.
+
+    Returns ``None`` if:
+    - ``base_url`` is empty (classify disabled in this environment),
+    - the analytics call fails for any reason (network, 5xx, bad JSON),
+    - or the classifier returned no archetype.
+    """
+    if not base_url:
+        return None
+    payload = {"card_names": list(card_names)}
+    try:
+        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+            resp = await client.post(
+                f"{base_url}/analytics/archetypes/classify",
+                json=payload,
+            )
+    except httpx.HTTPError:
+        _log.exception("analytics classify transport error url=%s", base_url)
+        return None
+    if resp.status_code >= 400:
+        _log.warning(
+            "analytics classify returned %s: %s",
+            resp.status_code,
+            resp.text[:200],
+        )
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        _log.warning("analytics classify returned non-JSON body")
+        return None
+    raw_id = data.get("archetype_id")
+    if not raw_id:
+        return None
+    try:
+        return uuid.UUID(str(raw_id))
+    except ValueError:
+        _log.warning("analytics classify returned malformed archetype_id=%r", raw_id)
+        return None

--- a/services/web/tests/test_admin_archetypes_routes.py
+++ b/services/web/tests/test_admin_archetypes_routes.py
@@ -1,0 +1,526 @@
+"""Web admin route tests for the archetype catalog.
+
+Mirrors the structure of ``test_admin_routes.py`` (the admin user
+tests) — bypasses browser auth via FastAPI dependency overrides and
+patches ``analytics_client`` so we can focus on handler behavior +
+client wiring.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_admin(user_id: int = 1, token: str = "admin-tok") -> Any:
+    from web_service import deps as _deps
+
+    fake_admin = _deps.BrowserUser(
+        user_id=user_id,
+        email="admin@local",
+        role="admin",
+        must_change_password=False,
+        scope=None,
+        token=token,
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_admin
+
+    return _dep, fake_admin
+
+
+def _override_non_admin() -> Any:
+    from web_service import deps as _deps
+
+    fake_user = _deps.BrowserUser(
+        user_id=42,
+        email="u@example.com",
+        role="user",
+        must_change_password=False,
+        scope=None,
+        token="user-tok",
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_user
+
+    return _dep, fake_user
+
+
+def _sample_archetype(name: str = "Burn") -> Any:
+    from web_service import analytics_client
+
+    return analytics_client.ArchetypeItem(
+        id=str(uuid.uuid4()),
+        name=name,
+        format="Modern",
+        defining_cards=["Lightning Bolt", "Goblin Guide"],
+        sample_decklists=None,
+        created_at=datetime(2026, 5, 9, 12, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 9, 12, 0, tzinfo=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/archetypes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_archetypes_lists_for_admin(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    items = [_sample_archetype("Burn"), _sample_archetype("Tron")]
+
+    async def fake_list(_url: str, _token: str) -> tuple[list[Any], int]:
+        return items, 2
+
+    monkeypatch.setattr(analytics_client, "admin_list_archetypes", fake_list)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/admin/archetypes")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Burn" in r.text
+    assert "Tron" in r.text
+    assert "/admin/archetypes/new" in r.text
+
+
+@pytest.mark.asyncio
+async def test_get_archetypes_forbidden_for_non_admin(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    dep, _ = _override_non_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/admin/archetypes")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_archetypes_unauth_redirects(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get("/admin/archetypes")
+    assert r.status_code == 302
+    assert r.headers["location"].startswith("/login")
+
+
+@pytest.mark.asyncio
+async def test_get_archetypes_503_when_analytics_unreachable(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("simulated outage")
+
+    monkeypatch.setattr(analytics_client, "admin_list_archetypes", boom)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/admin/archetypes")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/archetypes/new
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_new_form_renders_for_admin(app_client: httpx.AsyncClient) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/admin/archetypes/new")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "<form" in r.text
+    assert 'name="name"' in r.text
+    assert 'name="format"' in r.text
+    assert 'name="defining_cards"' in r.text
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/archetypes/create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_create_succeeds_and_redirects(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create(
+        _url: str,
+        _token: str,
+        *,
+        name: str,
+        format_: str,
+        defining_cards: list[str],
+    ) -> tuple[Any, str | None]:
+        captured["name"] = name
+        captured["format"] = format_
+        captured["defining_cards"] = defining_cards
+        return _sample_archetype(name=name), None
+
+    monkeypatch.setattr(analytics_client, "admin_create_archetype", fake_create)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(
+            "/admin/archetypes/create",
+            data={
+                "name": "Burn",
+                "format": "Modern",
+                "defining_cards": "Lightning Bolt\nGoblin Guide\n\n  Lava Spike  ",
+            },
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 303
+    assert r.headers["location"].endswith("/admin/archetypes")
+    assert captured["name"] == "Burn"
+    assert captured["format"] == "Modern"
+    # Whitespace and blank lines should have been stripped, order preserved.
+    assert captured["defining_cards"] == ["Lightning Bolt", "Goblin Guide", "Lava Spike"]
+
+
+@pytest.mark.asyncio
+async def test_post_create_rejects_blank_name(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(
+            "/admin/archetypes/create",
+            data={
+                "name": "   ",
+                "format": "Modern",
+                "defining_cards": "Lightning Bolt",
+            },
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 400
+    assert "required" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_post_create_forbidden_for_non_admin(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    dep, _ = _override_non_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(
+            "/admin/archetypes/create",
+            data={"name": "Burn", "format": "Modern", "defining_cards": ""},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/archetypes/{id}/edit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_edit_form_pre_fills_existing_data(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    item = _sample_archetype("Murktide")
+
+    async def fake_get(_url: str, _token: str, archetype_id: str) -> Any:
+        assert archetype_id == item.id
+        return item
+
+    monkeypatch.setattr(analytics_client, "admin_get_archetype", fake_get)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get(f"/admin/archetypes/{item.id}/edit")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Murktide" in r.text
+    assert "Lightning Bolt" in r.text
+
+
+@pytest.mark.asyncio
+async def test_get_edit_form_404_when_archetype_missing(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_get(_url: str, _token: str, _archetype_id: str) -> Any:
+        return None
+
+    monkeypatch.setattr(analytics_client, "admin_get_archetype", fake_get)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get(f"/admin/archetypes/{uuid.uuid4()}/edit")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/archetypes/{id}/edit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_edit_succeeds_and_redirects(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    item = _sample_archetype("Burn")
+    captured: dict[str, Any] = {}
+
+    async def fake_update(
+        _url: str,
+        _token: str,
+        archetype_id: str,
+        *,
+        name: str,
+        format_: str,
+        defining_cards: list[str],
+    ) -> tuple[Any, str | None]:
+        captured["id"] = archetype_id
+        captured["name"] = name
+        captured["defining_cards"] = defining_cards
+        return item, None
+
+    monkeypatch.setattr(analytics_client, "admin_update_archetype", fake_update)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(
+            f"/admin/archetypes/{item.id}/edit",
+            data={
+                "name": "Burn",
+                "format": "Modern",
+                "defining_cards": "Lightning Bolt\nGoblin Guide",
+            },
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 303
+    assert r.headers["location"].endswith("/admin/archetypes")
+    assert captured["id"] == item.id
+    assert captured["defining_cards"] == ["Lightning Bolt", "Goblin Guide"]
+
+
+@pytest.mark.asyncio
+async def test_post_edit_handles_not_found_inline(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_update(*_a: Any, **_kw: Any) -> tuple[Any, str | None]:
+        return None, "archetype_not_found"
+
+    monkeypatch.setattr(analytics_client, "admin_update_archetype", fake_update)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(
+            f"/admin/archetypes/{uuid.uuid4()}/edit",
+            data={"name": "Burn", "format": "Modern", "defining_cards": ""},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 404
+    assert "no longer exists" in r.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/archetypes/{id}/delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_delete_succeeds_and_redirects(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_delete(_url: str, _token: str, archetype_id: str) -> tuple[bool, str | None]:
+        captured["id"] = archetype_id
+        return True, None
+
+    monkeypatch.setattr(analytics_client, "admin_delete_archetype", fake_delete)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        target = uuid.uuid4()
+        r = await app_client.post(f"/admin/archetypes/{target}/delete")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 303
+    assert r.headers["location"].endswith("/admin/archetypes")
+    assert captured["id"] == str(target)
+
+
+@pytest.mark.asyncio
+async def test_post_delete_propagates_not_found_inline(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_list(_url: str, _token: str) -> tuple[list[Any], int]:
+        return [], 0
+
+    async def fake_delete(*_a: Any, **_kw: Any) -> tuple[bool, str | None]:
+        return False, "archetype_not_found"
+
+    monkeypatch.setattr(analytics_client, "admin_list_archetypes", fake_list)
+    monkeypatch.setattr(analytics_client, "admin_delete_archetype", fake_delete)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(f"/admin/archetypes/{uuid.uuid4()}/delete")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 404
+    assert "no longer exists" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_post_delete_forbidden_for_non_admin(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    dep, _ = _override_non_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(f"/admin/archetypes/{uuid.uuid4()}/delete")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# AnalyticsForbidden — analytics rejected the call. Should render 403,
+# not 503.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_archetypes_analytics_forbidden_renders_403(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsForbidden("demoted mid-session")
+
+    monkeypatch.setattr(analytics_client, "admin_list_archetypes", boom)
+    dep, _ = _override_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/admin/archetypes")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 403

--- a/services/web/tests/test_dashboard_stats.py
+++ b/services/web/tests/test_dashboard_stats.py
@@ -1,0 +1,256 @@
+"""Tests for the user-facing /dashboard stats view.
+
+Bypasses browser auth via FastAPI dependency overrides and patches
+the analytics client so we can exercise template rendering and the
+error-banner branch without a live analytics service.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 42, token: str = "user-tok") -> Any:
+    from web_service import deps as _deps
+
+    fake_user = _deps.BrowserUser(
+        user_id=user_id,
+        email="alice@example.com",
+        role="user",
+        must_change_password=False,
+        scope=None,
+        token=token,
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_user
+
+    return _dep
+
+
+def _sample_summary(*, total: int = 0) -> Any:
+    from web_service import analytics_client
+
+    if total == 0:
+        return analytics_client.StatsSummary(
+            total_matches=0,
+            wins=0,
+            losses=0,
+            draws=0,
+            win_rate=0.0,
+            recent_matches=[],
+        )
+    recent = [
+        analytics_client.RecentMatchItem(
+            match_id="abc-123",
+            played_at=datetime(2026, 5, 9, 12, 0, tzinfo=UTC),
+            opponent="bob",
+            result="W",
+            format_="Modern",
+            player_wins=2,
+            player_losses=1,
+        ),
+    ]
+    return analytics_client.StatsSummary(
+        total_matches=total,
+        wins=4,
+        losses=2,
+        draws=1,
+        win_rate=66.7,
+        recent_matches=recent,
+    )
+
+
+def _sample_format_stats() -> list[Any]:
+    from web_service import analytics_client
+
+    return [
+        analytics_client.FormatStatItem(
+            format_="Modern",
+            matches=5,
+            wins=3,
+            losses=2,
+            draws=0,
+            win_rate=60.0,
+        ),
+    ]
+
+
+def _sample_opponent_stats() -> list[Any]:
+    from web_service import analytics_client
+
+    return [
+        analytics_client.OpponentStatItem(
+            opponent="bob",
+            matches=3,
+            wins=2,
+            losses=1,
+            draws=0,
+            win_rate=66.7,
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dashboard_renders_with_stats(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_summary(_url: str, _token: str) -> Any:
+        return _sample_summary(total=7)
+
+    async def fake_format(_url: str, _token: str) -> Any:
+        return _sample_format_stats()
+
+    async def fake_opponent(_url: str, _token: str) -> Any:
+        return _sample_opponent_stats()
+
+    monkeypatch.setattr(analytics_client, "get_stats_summary", fake_summary)
+    monkeypatch.setattr(analytics_client, "get_stats_by_format", fake_format)
+    monkeypatch.setattr(analytics_client, "get_stats_by_opponent", fake_opponent)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/dashboard")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    text = r.text
+    assert "Total matches" in text
+    assert "Win rate" in text
+    assert "66.7%" in text
+    # Recent match table should include the sample row
+    assert "bob" in text
+    assert "Modern" in text
+    # Format/opponent breakdowns
+    assert "By format" in text
+    assert "By opponent" in text
+    # No error banner
+    assert "Stats unavailable" not in text
+
+
+@pytest.mark.asyncio
+async def test_dashboard_empty_state_no_matches(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_summary(_url: str, _token: str) -> Any:
+        return _sample_summary(total=0)
+
+    async def fake_format(_url: str, _token: str) -> Any:
+        return []
+
+    async def fake_opponent(_url: str, _token: str) -> Any:
+        return []
+
+    monkeypatch.setattr(analytics_client, "get_stats_summary", fake_summary)
+    monkeypatch.setattr(analytics_client, "get_stats_by_format", fake_format)
+    monkeypatch.setattr(analytics_client, "get_stats_by_opponent", fake_opponent)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/dashboard")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "No matches yet" in r.text
+    # No breakdown sections
+    assert "By format" not in r.text
+    assert "By opponent" not in r.text
+
+
+@pytest.mark.asyncio
+async def test_dashboard_renders_error_banner_on_analytics_failure(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("simulated outage")
+
+    monkeypatch.setattr(analytics_client, "get_stats_summary", boom)
+    monkeypatch.setattr(analytics_client, "get_stats_by_format", boom)
+    monkeypatch.setattr(analytics_client, "get_stats_by_opponent", boom)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/dashboard")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Stats unavailable" in r.text
+
+
+@pytest.mark.asyncio
+async def test_dashboard_unauth_redirects_to_login(
+    app_client: httpx.AsyncClient,
+) -> None:
+    r = await app_client.get("/dashboard")
+    assert r.status_code == 302
+    assert r.headers["location"].startswith("/login")
+
+
+@pytest.mark.asyncio
+async def test_dashboard_admin_redirects_to_admin_users(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    fake_admin = _deps.BrowserUser(
+        user_id=1,
+        email="admin@local",
+        role="admin",
+        must_change_password=False,
+        scope=None,
+        token="admin-tok",
+    )
+
+    async def dep() -> _deps.BrowserUser:
+        return fake_admin
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/dashboard")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 302
+    assert r.headers["location"] == "/admin/users"

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -2,14 +2,14 @@
 
 The web service calls analytics directly over the backend compose
 network (``http://analytics:8000``) for the admin archetype-catalog
-CRUD pages. Mirrors the structure of :mod:`web_service.auth_client` —
-same exception types so handlers can keep their existing
-AuthForbidden / AuthClientError branches.
+CRUD pages and the user stats dashboard. Mirrors the structure of
+:mod:`web_service.auth_client` — same exception types so handlers can
+keep their existing AuthForbidden / AuthClientError branches.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
@@ -203,3 +203,152 @@ async def admin_delete_archetype(
     raise AnalyticsClientError(
         f"analytics DELETE /archetypes/{{id}} returned {resp.status_code}: {resp.text}"
     )
+
+
+# ---------------------------------------------------------------------------
+# User stats dashboard
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RecentMatchItem:
+    match_id: str
+    played_at: datetime | None
+    opponent: str | None
+    result: str
+    format_: str | None
+    player_wins: int
+    player_losses: int
+
+
+@dataclass
+class StatsSummary:
+    total_matches: int
+    wins: int
+    losses: int
+    draws: int
+    win_rate: float
+    recent_matches: list[RecentMatchItem] = field(default_factory=list)
+
+
+@dataclass
+class FormatStatItem:
+    format_: str
+    matches: int
+    wins: int
+    losses: int
+    draws: int
+    win_rate: float
+
+
+@dataclass
+class OpponentStatItem:
+    opponent: str
+    matches: int
+    wins: int
+    losses: int
+    draws: int
+    win_rate: float
+
+
+def _to_recent(payload: dict[str, Any]) -> RecentMatchItem:
+    return RecentMatchItem(
+        match_id=str(payload.get("match_id", "")),
+        played_at=_parse_dt(payload.get("played_at")),
+        opponent=payload.get("opponent"),
+        result=str(payload.get("result") or ""),
+        format_=payload.get("format"),
+        player_wins=int(payload.get("player_wins") or 0),
+        player_losses=int(payload.get("player_losses") or 0),
+    )
+
+
+def _to_summary(payload: dict[str, Any]) -> StatsSummary:
+    return StatsSummary(
+        total_matches=int(payload.get("total_matches") or 0),
+        wins=int(payload.get("wins") or 0),
+        losses=int(payload.get("losses") or 0),
+        draws=int(payload.get("draws") or 0),
+        win_rate=float(payload.get("win_rate") or 0.0),
+        recent_matches=[_to_recent(m) for m in payload.get("recent_matches", [])],
+    )
+
+
+def _to_format_stat(payload: dict[str, Any]) -> FormatStatItem:
+    return FormatStatItem(
+        format_=str(payload.get("format") or "Unknown"),
+        matches=int(payload.get("matches") or 0),
+        wins=int(payload.get("wins") or 0),
+        losses=int(payload.get("losses") or 0),
+        draws=int(payload.get("draws") or 0),
+        win_rate=float(payload.get("win_rate") or 0.0),
+    )
+
+
+def _to_opponent_stat(payload: dict[str, Any]) -> OpponentStatItem:
+    return OpponentStatItem(
+        opponent=str(payload.get("opponent") or ""),
+        matches=int(payload.get("matches") or 0),
+        wins=int(payload.get("wins") or 0),
+        losses=int(payload.get("losses") or 0),
+        draws=int(payload.get("draws") or 0),
+        win_rate=float(payload.get("win_rate") or 0.0),
+    )
+
+
+async def get_stats_summary(base_url: str, token: str) -> StatsSummary:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/stats/summary",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(f"analytics GET /stats/summary transport error: {exc}") from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /stats/summary returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/summary returned {resp.status_code}: {resp.text}"
+        )
+    return _to_summary(resp.json())
+
+
+async def get_stats_by_format(base_url: str, token: str) -> list[FormatStatItem]:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/stats/by-format",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/by-format transport error: {exc}"
+        ) from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /stats/by-format returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/by-format returned {resp.status_code}: {resp.text}"
+        )
+    return [_to_format_stat(row) for row in resp.json()]
+
+
+async def get_stats_by_opponent(base_url: str, token: str) -> list[OpponentStatItem]:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/stats/by-opponent",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/by-opponent transport error: {exc}"
+        ) from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /stats/by-opponent returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/by-opponent returned {resp.status_code}: {resp.text}"
+        )
+    return [_to_opponent_stat(row) for row in resp.json()]

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -1,0 +1,205 @@
+"""Thin HTTP client over the internal analytics service.
+
+The web service calls analytics directly over the backend compose
+network (``http://analytics:8000``) for the admin archetype-catalog
+CRUD pages. Mirrors the structure of :mod:`web_service.auth_client` —
+same exception types so handlers can keep their existing
+AuthForbidden / AuthClientError branches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+
+@dataclass
+class ArchetypeItem:
+    id: str
+    name: str
+    format: str
+    defining_cards: list[str]
+    sample_decklists: list[Any] | None
+    created_at: datetime | None
+    updated_at: datetime | None
+
+
+class AnalyticsClientError(Exception):
+    """Analytics call failed for transport, 5xx, or unexpected non-2xx."""
+
+
+class AnalyticsForbidden(Exception):
+    """Analytics rejected the request as 401/403."""
+
+
+def _parse_dt(raw: Any) -> datetime | None:
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _to_item(payload: dict[str, Any]) -> ArchetypeItem:
+    return ArchetypeItem(
+        id=str(payload["id"]),
+        name=str(payload["name"]),
+        format=str(payload["format"]),
+        defining_cards=list(payload.get("defining_cards") or []),
+        sample_decklists=payload.get("sample_decklists"),
+        created_at=_parse_dt(payload.get("created_at")),
+        updated_at=_parse_dt(payload.get("updated_at")),
+    )
+
+
+async def admin_list_archetypes(
+    base_url: str,
+    token: str,
+) -> tuple[list[ArchetypeItem], int]:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/archetypes",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(f"analytics GET /archetypes transport error: {exc}") from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /archetypes returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /archetypes returned {resp.status_code}: {resp.text}"
+        )
+    data = resp.json()
+    items = [_to_item(a) for a in data.get("archetypes", [])]
+    return items, int(data.get("total", len(items)))
+
+
+async def admin_get_archetype(
+    base_url: str,
+    token: str,
+    archetype_id: str,
+) -> ArchetypeItem | None:
+    """Fetch a single archetype. Returns None on 404."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/archetypes/{archetype_id}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /archetypes/{{id}} transport error: {exc}"
+        ) from exc
+    if resp.status_code == 404:
+        return None
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /archetypes/{{id}} returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /archetypes/{{id}} returned {resp.status_code}: {resp.text}"
+        )
+    return _to_item(resp.json())
+
+
+async def admin_create_archetype(
+    base_url: str,
+    token: str,
+    *,
+    name: str,
+    format_: str,
+    defining_cards: list[str],
+) -> tuple[ArchetypeItem | None, str | None]:
+    """Create. Returns (item, None) on success; (None, error_code) on 4xx."""
+    body = {
+        "name": name,
+        "format": format_,
+        "defining_cards": defining_cards,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{base_url}/analytics/archetypes",
+                headers={"Authorization": f"Bearer {token}"},
+                json=body,
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(f"analytics POST /archetypes transport error: {exc}") from exc
+    if resp.status_code in (200, 201):
+        return _to_item(resp.json()), None
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics POST /archetypes returned {resp.status_code}")
+    if resp.status_code in (400, 422):
+        return None, "invalid_input"
+    raise AnalyticsClientError(
+        f"analytics POST /archetypes returned {resp.status_code}: {resp.text}"
+    )
+
+
+async def admin_update_archetype(
+    base_url: str,
+    token: str,
+    archetype_id: str,
+    *,
+    name: str,
+    format_: str,
+    defining_cards: list[str],
+) -> tuple[ArchetypeItem | None, str | None]:
+    body = {
+        "name": name,
+        "format": format_,
+        "defining_cards": defining_cards,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.put(
+                f"{base_url}/analytics/archetypes/{archetype_id}",
+                headers={"Authorization": f"Bearer {token}"},
+                json=body,
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics PUT /archetypes/{{id}} transport error: {exc}"
+        ) from exc
+    if resp.status_code == 200:
+        return _to_item(resp.json()), None
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics PUT /archetypes/{{id}} returned {resp.status_code}")
+    if resp.status_code == 404:
+        return None, "archetype_not_found"
+    if resp.status_code in (400, 422):
+        return None, "invalid_input"
+    raise AnalyticsClientError(
+        f"analytics PUT /archetypes/{{id}} returned {resp.status_code}: {resp.text}"
+    )
+
+
+async def admin_delete_archetype(
+    base_url: str,
+    token: str,
+    archetype_id: str,
+) -> tuple[bool, str | None]:
+    """Delete. (True, None) on 204, (False, code) on 404."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.delete(
+                f"{base_url}/analytics/archetypes/{archetype_id}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics DELETE /archetypes/{{id}} transport error: {exc}"
+        ) from exc
+    if resp.status_code == 204:
+        return True, None
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics DELETE /archetypes/{{id}} returned {resp.status_code}")
+    if resp.status_code == 404:
+        return False, "archetype_not_found"
+    raise AnalyticsClientError(
+        f"analytics DELETE /archetypes/{{id}} returned {resp.status_code}: {resp.text}"
+    )

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -186,13 +186,42 @@ async def login_submit(
 async def dashboard(
     request: Request,
     user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
 ) -> Response:
     if user.role == "admin":
         return RedirectResponse(url=_ADMIN_LANDING_PATH, status_code=status.HTTP_302_FOUND)
+
+    stats_summary: Any = None
+    format_stats: list[Any] = []
+    opponent_stats: list[Any] = []
+    stats_error = False
+    try:
+        stats_summary = await analytics_client.get_stats_summary(
+            settings.analytics_service_url, user.token
+        )
+        format_stats = await analytics_client.get_stats_by_format(
+            settings.analytics_service_url, user.token
+        )
+        opponent_stats = await analytics_client.get_stats_by_opponent(
+            settings.analytics_service_url, user.token
+        )
+    except analytics_client.AnalyticsForbidden:
+        # Treat as logged-out: bounce to /login so the user can re-auth.
+        return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics stats call failed; rendering dashboard with error banner")
+        stats_error = True
+
     return templates.TemplateResponse(
         request,
         "dashboard.html",
-        {"user": user},
+        {
+            "user": user,
+            "stats_summary": stats_summary,
+            "format_stats": format_stats,
+            "opponent_stats": opponent_stats,
+            "stats_error": stats_error,
+        },
     )
 
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -20,7 +20,7 @@ from fastapi.templating import Jinja2Templates
 
 from common.logging import configure_logging
 from common.metrics import mount_metrics
-from web_service import auth_client
+from web_service import analytics_client, auth_client
 from web_service.deps import (
     BrowserAuthRedirect,
     BrowserUser,
@@ -1349,6 +1349,310 @@ async def admin_invites_revoke(
         error=message,
         created=None,
         status_code=code,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admin archetype catalog
+# ---------------------------------------------------------------------------
+
+
+def _parse_defining_cards(raw: str) -> list[str]:
+    """Split the textarea body into a clean list of card names.
+
+    The form is one card per line; whitespace-only lines are dropped
+    and each entry is stripped. Order is preserved.
+    """
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+@app.get("/admin/archetypes", response_class=HTMLResponse)
+async def admin_archetypes_list(
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    try:
+        items, total = await analytics_client.admin_list_archetypes(
+            settings.analytics_service_url, user.token
+        )
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.archetypes.list.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics GET /archetypes call failed")
+        return templates.TemplateResponse(
+            request,
+            "admin_archetypes.html",
+            {
+                "user": user,
+                "archetypes": [],
+                "total": 0,
+                "error": "Analytics service unavailable. Please try again.",
+            },
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    return templates.TemplateResponse(
+        request,
+        "admin_archetypes.html",
+        {
+            "user": user,
+            "archetypes": items,
+            "total": total,
+            "error": None,
+        },
+    )
+
+
+@app.get("/admin/archetypes/new", response_class=HTMLResponse)
+async def admin_archetypes_new_form(
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+    return templates.TemplateResponse(
+        request,
+        "admin_archetypes_edit.html",
+        {
+            "user": user,
+            "mode": "create",
+            "archetype_id": None,
+            "name": "",
+            "format": "",
+            "defining_cards_text": "",
+            "error": None,
+        },
+    )
+
+
+@app.post("/admin/archetypes/create")
+async def admin_archetypes_create(
+    request: Request,
+    name: Annotated[str, Form()],
+    format: Annotated[str, Form()],
+    defining_cards: Annotated[str, Form()] = "",
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    submitted_name = name.strip()
+    submitted_format = format.strip()
+    cards = _parse_defining_cards(defining_cards or "")
+
+    def _render_error(message: str, code: int) -> Response:
+        return templates.TemplateResponse(
+            request,
+            "admin_archetypes_edit.html",
+            {
+                "user": user,
+                "mode": "create",
+                "archetype_id": None,
+                "name": submitted_name,
+                "format": submitted_format,
+                "defining_cards_text": (defining_cards or ""),
+                "error": message,
+            },
+            status_code=code,
+        )
+
+    if not submitted_name:
+        return _render_error("Name is required.", status.HTTP_400_BAD_REQUEST)
+    if not submitted_format:
+        return _render_error("Format is required.", status.HTTP_400_BAD_REQUEST)
+
+    try:
+        item, err = await analytics_client.admin_create_archetype(
+            settings.analytics_service_url,
+            user.token,
+            name=submitted_name,
+            format_=submitted_format,
+            defining_cards=cards,
+        )
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.archetypes.create.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics POST /archetypes call failed")
+        return Response(
+            content="Analytics service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if item is None:
+        return _render_error(
+            "Could not create archetype.",
+            status.HTTP_400_BAD_REQUEST if err == "invalid_input" else status.HTTP_400_BAD_REQUEST,
+        )
+    return RedirectResponse(url="/admin/archetypes", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.get("/admin/archetypes/{archetype_id}/edit", response_class=HTMLResponse)
+async def admin_archetypes_edit_form(
+    archetype_id: uuid.UUID,
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    try:
+        item = await analytics_client.admin_get_archetype(
+            settings.analytics_service_url, user.token, str(archetype_id)
+        )
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.archetypes.edit.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics GET /archetypes/{id} call failed")
+        return Response(
+            content="Analytics service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    if item is None:
+        return Response(
+            content="That archetype no longer exists.",
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+    return templates.TemplateResponse(
+        request,
+        "admin_archetypes_edit.html",
+        {
+            "user": user,
+            "mode": "edit",
+            "archetype_id": item.id,
+            "name": item.name,
+            "format": item.format,
+            "defining_cards_text": "\n".join(item.defining_cards),
+            "error": None,
+        },
+    )
+
+
+@app.post("/admin/archetypes/{archetype_id}/edit")
+async def admin_archetypes_edit(
+    archetype_id: uuid.UUID,
+    request: Request,
+    name: Annotated[str, Form()],
+    format: Annotated[str, Form()],
+    defining_cards: Annotated[str, Form()] = "",
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    submitted_name = name.strip()
+    submitted_format = format.strip()
+    cards = _parse_defining_cards(defining_cards or "")
+
+    def _render_error(message: str, code: int) -> Response:
+        return templates.TemplateResponse(
+            request,
+            "admin_archetypes_edit.html",
+            {
+                "user": user,
+                "mode": "edit",
+                "archetype_id": str(archetype_id),
+                "name": submitted_name,
+                "format": submitted_format,
+                "defining_cards_text": (defining_cards or ""),
+                "error": message,
+            },
+            status_code=code,
+        )
+
+    if not submitted_name:
+        return _render_error("Name is required.", status.HTTP_400_BAD_REQUEST)
+    if not submitted_format:
+        return _render_error("Format is required.", status.HTTP_400_BAD_REQUEST)
+
+    try:
+        item, err = await analytics_client.admin_update_archetype(
+            settings.analytics_service_url,
+            user.token,
+            str(archetype_id),
+            name=submitted_name,
+            format_=submitted_format,
+            defining_cards=cards,
+        )
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.archetypes.update.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics PUT /archetypes/{id} call failed")
+        return Response(
+            content="Analytics service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if err == "archetype_not_found":
+        return _render_error("That archetype no longer exists.", status.HTTP_404_NOT_FOUND)
+    if item is None:
+        return _render_error("Could not update archetype.", status.HTTP_400_BAD_REQUEST)
+    return RedirectResponse(url="/admin/archetypes", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post("/admin/archetypes/{archetype_id}/delete")
+async def admin_archetypes_delete(
+    archetype_id: uuid.UUID,
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    try:
+        ok, err = await analytics_client.admin_delete_archetype(
+            settings.analytics_service_url, user.token, str(archetype_id)
+        )
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.archetypes.delete.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics DELETE /archetypes/{id} call failed")
+        return Response(
+            content="Analytics service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if ok:
+        return RedirectResponse(url="/admin/archetypes", status_code=status.HTTP_303_SEE_OTHER)
+
+    if err == "archetype_not_found":
+        try:
+            items, total = await analytics_client.admin_list_archetypes(
+                settings.analytics_service_url, user.token
+            )
+        except (analytics_client.AnalyticsClientError, analytics_client.AnalyticsForbidden):
+            items, total = [], 0
+        return templates.TemplateResponse(
+            request,
+            "admin_archetypes.html",
+            {
+                "user": user,
+                "archetypes": items,
+                "total": total,
+                "error": "That archetype no longer exists.",
+            },
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+    return Response(
+        content="Could not delete archetype.",
+        status_code=status.HTTP_400_BAD_REQUEST,
     )
 
 

--- a/services/web/web_service/settings.py
+++ b/services/web/web_service/settings.py
@@ -19,6 +19,10 @@ class WebSettings(BaseServiceSettings):
     # does not go through the Caddy gateway.
     auth_service_url: str = "http://auth:8000"
 
+    # Internal compose-network URL for the analytics service. Same
+    # backend-only contract as auth_service_url.
+    analytics_service_url: str = "http://analytics:8000"
+
     # Matches auth.access_token_ttl_seconds default. If auth is
     # reconfigured, set DA_SESSION_COOKIE_TTL_SECONDS to match.
     session_cookie_ttl_seconds: int = 900

--- a/services/web/web_service/templates/admin_archetypes.html
+++ b/services/web/web_service/templates/admin_archetypes.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+
+{% block title %}Admin · Archetypes · Deep Analysis{% endblock %}
+
+{% block content %}
+<section class="panel">
+    <h1>Archetypes</h1>
+    <nav class="admin-subnav">
+        <a href="/admin/users">Users</a>
+        <span class="muted"> · </span>
+        <a href="/admin/agents">Agents</a>
+        <span class="muted"> · </span>
+        <a href="/admin/archetypes" aria-current="page"><strong>Archetypes</strong></a>
+        <span class="muted"> · </span>
+        <a href="/admin/invites">Invites</a>
+        <span class="muted"> · </span>
+        <a href="/admin/settings">Settings</a>
+    </nav>
+
+    {% if error %}
+    <div class="alert alert-error" role="alert">{{ error }}</div>
+    {% endif %}
+
+    <p>
+        <a class="btn btn-primary" href="/admin/archetypes/new">New archetype</a>
+    </p>
+
+    {% if not archetypes %}
+        <p>No archetypes defined yet.</p>
+    {% else %}
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Format</th>
+                    <th>Defining cards</th>
+                    <th>Updated</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for a in archetypes %}
+                <tr id="archetype-{{ a.id }}">
+                    <td>{{ a.name }}</td>
+                    <td>{{ a.format }}</td>
+                    <td>{{ a.defining_cards|length }}</td>
+                    <td>{{ a.updated_at.strftime("%Y-%m-%d") if a.updated_at else "—" }}</td>
+                    <td>
+                        <a class="btn" href="/admin/archetypes/{{ a.id }}/edit">Edit</a>
+                        <form method="post"
+                              action="/admin/archetypes/{{ a.id }}/delete"
+                              class="inline-form"
+                              onsubmit="return confirm('Delete archetype {{ a.name }}? Matches tagged with it will be untagged.');">
+                            <button type="submit" class="btn btn-danger">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <p class="muted">
+            {{ total }} archetype{{ "" if total == 1 else "s" }}.
+        </p>
+    {% endif %}
+</section>
+{% endblock %}

--- a/services/web/web_service/templates/admin_archetypes_edit.html
+++ b/services/web/web_service/templates/admin_archetypes_edit.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block title %}Admin · Archetypes ·
+    {% if mode == "create" %}New{% else %}Edit{% endif %} ·
+    Deep Analysis{% endblock %}
+
+{% block content %}
+<section class="panel">
+    <h1>
+        {% if mode == "create" %}New archetype{% else %}Edit archetype{% endif %}
+    </h1>
+    <nav class="admin-subnav">
+        <a href="/admin/users">Users</a>
+        <span class="muted"> · </span>
+        <a href="/admin/agents">Agents</a>
+        <span class="muted"> · </span>
+        <a href="/admin/archetypes" aria-current="page"><strong>Archetypes</strong></a>
+        <span class="muted"> · </span>
+        <a href="/admin/invites">Invites</a>
+        <span class="muted"> · </span>
+        <a href="/admin/settings">Settings</a>
+    </nav>
+
+    {% if error %}
+    <div class="alert alert-error" role="alert">{{ error }}</div>
+    {% endif %}
+
+    <form method="post"
+          action="{% if mode == 'create' %}/admin/archetypes/create{% else %}/admin/archetypes/{{ archetype_id }}/edit{% endif %}">
+        <label class="field">
+            <span>Name</span>
+            <input type="text" name="name" value="{{ name }}" required maxlength="200">
+        </label>
+        <label class="field">
+            <span>Format</span>
+            <input type="text" name="format" value="{{ format }}" required maxlength="64"
+                   placeholder="e.g. Modern, Legacy, Pioneer">
+        </label>
+        <label class="field">
+            <span>Defining cards (one per line)</span>
+            <textarea name="defining_cards" rows="12" cols="60"
+                      placeholder="Lightning Bolt&#10;Goblin Guide&#10;...">{{ defining_cards_text }}</textarea>
+        </label>
+        <p>
+            <button type="submit" class="btn btn-primary">
+                {% if mode == "create" %}Create{% else %}Save changes{% endif %}
+            </button>
+            <a class="btn" href="/admin/archetypes">Cancel</a>
+        </p>
+    </form>
+</section>
+{% endblock %}

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -21,4 +21,139 @@
         {% endif %}
     </ul>
 </section>
+
+{% if stats_error|default(false) or stats_summary is not defined or stats_summary is none %}
+{% if stats_summary is defined %}
+<section class="panel">
+    <div class="alert alert-error" role="alert">
+        Stats unavailable — analytics service could not be reached.
+    </div>
+</section>
+{% endif %}
+{% else %}
+<section class="panel">
+    <h2>Your stats</h2>
+    {% if stats_summary.total_matches == 0 %}
+        <p>No matches yet. Upload a game log to get started.</p>
+    {% else %}
+        <ul class="stats-summary">
+            <li><strong>Total matches:</strong> {{ stats_summary.total_matches }}</li>
+            <li><strong>Record:</strong>
+                {{ stats_summary.wins }}W / {{ stats_summary.losses }}L / {{ stats_summary.draws }}D
+            </li>
+            <li><strong>Win rate:</strong> {{ "%.1f"|format(stats_summary.win_rate) }}%</li>
+        </ul>
+
+        <h3>Recent matches</h3>
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Opponent</th>
+                    <th>Format</th>
+                    <th>Result</th>
+                    <th>Score</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for match in stats_summary.recent_matches %}
+                <tr>
+                    <td>{{ match.played_at.strftime("%Y-%m-%d") if match.played_at else "—" }}</td>
+                    <td>{{ match.opponent or "—" }}</td>
+                    <td>{{ match.format_ or "—" }}</td>
+                    <td>
+                        {% if match.result == "W" %}
+                            <span class="result-badge result-win">W</span>
+                        {% elif match.result == "L" %}
+                            <span class="result-badge result-loss">L</span>
+                        {% elif match.result == "D" %}
+                            <span class="result-badge result-draw">D</span>
+                        {% else %}
+                            —
+                        {% endif %}
+                    </td>
+                    <td>{{ match.player_wins }}-{{ match.player_losses }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+</section>
+
+{% if format_stats|default([]) %}
+<section class="panel">
+    <h2>By format</h2>
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>Format</th>
+                <th>Matches</th>
+                <th>Wins</th>
+                <th>Losses</th>
+                <th>Draws</th>
+                <th>Win rate</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in format_stats %}
+            <tr>
+                <td>{{ row.format_ }}</td>
+                <td>{{ row.matches }}</td>
+                <td>{{ row.wins }}</td>
+                <td>{{ row.losses }}</td>
+                <td>{{ row.draws }}</td>
+                <td>{{ "%.1f"|format(row.win_rate) }}%</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</section>
+{% endif %}
+
+{% if opponent_stats|default([]) %}
+<section class="panel">
+    <h2>By opponent</h2>
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>Opponent</th>
+                <th>Matches</th>
+                <th>Wins</th>
+                <th>Losses</th>
+                <th>Draws</th>
+                <th>Win rate</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in opponent_stats %}
+            <tr>
+                <td>{{ row.opponent }}</td>
+                <td>{{ row.matches }}</td>
+                <td>{{ row.wins }}</td>
+                <td>{{ row.losses }}</td>
+                <td>{{ row.draws }}</td>
+                <td>{{ "%.1f"|format(row.win_rate) }}%</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</section>
+{% endif %}
+{% endif %}
+
+<style>
+.stats-summary { list-style: none; padding: 0; display: flex; gap: 2rem; flex-wrap: wrap; }
+.stats-summary li { padding: 0.5rem 0; }
+.result-badge {
+    display: inline-block;
+    min-width: 1.5rem;
+    padding: 0.1rem 0.4rem;
+    text-align: center;
+    font-weight: bold;
+    border-radius: 3px;
+}
+.result-win { background: #d4edda; color: #155724; }
+.result-loss { background: #f8d7da; color: #721c24; }
+.result-draw { background: #fff3cd; color: #856404; }
+</style>
 {% endblock %}


### PR DESCRIPTION
## Summary

Two features landing together — the archetype catalog (admin reference data) and the user-facing stats dashboard.

### Archetype catalog
- New `analytics.archetypes` table (alembic 004) — name, format, defining_cards JSONB, sample_decklists.
- Cross-schema FK `parser.matches.archetype_id` → `analytics.archetypes.id` with `ON DELETE SET NULL` (alembic 005).
- Analytics service routes: `GET /analytics/archetypes`, `POST /analytics/archetypes` (admin), `GET/PUT/DELETE /analytics/archetypes/{id}` (admin), `POST /analytics/archetypes/classify` (unauthenticated stateless utility for the parser worker).
- Rule-based classifier — overlap fraction of defining cards. Pure function, unit-tested.
- Web admin UI: list / new / edit / delete pages under `/admin/archetypes`.
- Parser worker has a thin client to call classify after persisting a match (best-effort; classify failures never fail the parse).

### User stats dashboard
- Analytics endpoints: `/analytics/stats/summary`, `/by-format`, `/by-opponent`. Cross-schema queries against `parser.matches` + `parser.games`, filtered by JWT-claimed `user_id`. Empty data returned gracefully.
- Match perspective is taken from `match.players[0]` (uploader convention from the parser); W/L/D derived from per-game winners.
- Web `/dashboard` now shows a summary card (total matches, W/L/D record, win rate), recent matches table (last 20), and format / opponent breakdown tables. Empty state and analytics-unavailable error banner both handled in the template.

## Test plan

- [x] `ruff check` and `ruff format --check` clean across `services/analytics services/web`.
- [x] `mypy services/analytics services/web` — clean.
- [x] `pytest services/analytics/tests services/web/tests` — 216 passed (10 classifier + 17 stats + 18 admin archetype routes + 5 dashboard stats + existing 166).
- [ ] Smoke test against a live compose stack: upload a `.dat`, observe match parsed, archetype classified, dashboard renders summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)