### PR TITLE
feat: CI auto-deploy on release tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: deploy
+
+# Triggered when the Release workflow finishes for a tag push. Pulls the
+# 5 service images at the released tag, force-recreates the compose stack
+# on the docker host, runs Alembic migrations, and smoke-checks /healthz
+# on every service.
+#
+# Skips silently when DOCKER_DEPLOY_KEY is not configured (e.g. forks),
+# so the workflow file is safe to ship in the open-source repo.
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+
+concurrency:
+  group: deploy-deep-analysis
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, linux, docker]
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      secrets.DOCKER_DEPLOY_KEY != ''
+    steps:
+      - uses: actions/checkout@v4
+      - name: Write deploy key
+        env:
+          DEPLOY_KEY_CONTENT: ${{ secrets.DOCKER_DEPLOY_KEY }}
+        run: |
+          install -m 0600 /dev/null /tmp/da_deploy_key
+          printf '%s\n' "$DEPLOY_KEY_CONTENT" > /tmp/da_deploy_key
+          chmod 0600 /tmp/da_deploy_key
+      - name: Run deploy
+        env:
+          DOCKER_DEPLOY_KEY: /tmp/da_deploy_key
+          DOCKER_DEPLOY_HOST: ${{ vars.DOCKER_DEPLOY_HOST }}
+          DEPLOY_TAG: ${{ github.event.workflow_run.head_branch }}
+        run: deploy/deploy.sh
+      - name: Clean up deploy key
+        if: always()
+        run: rm -f /tmp/da_deploy_key

--- a/.pka/updates/current.md
+++ b/.pka/updates/current.md
@@ -1,3 +1,9 @@
+## 2026-05-09 21:45 — ci-auto-deploy  [batch]
+
+**Type:** status
+
+Built CI auto-deploy on `feat/ci-auto-deploy` (off main `16bd7c0`). New `.github/workflows/deploy.yml` triggers on `workflow_run` of the Release workflow (`types: [completed]`, no branch filter — Release only fires on `v*.*.*` tags), gates with `github.event.workflow_run.conclusion == 'success' && secrets.DOCKER_DEPLOY_KEY != ''` so the job is skipped silently in forks/repos without the secret, runs on `[self-hosted, linux, docker]`, writes the deploy key to `/tmp/da_deploy_key` mode 0600, runs `deploy/deploy.sh` with `DEPLOY_TAG=${{ github.event.workflow_run.head_branch }}` (head_branch carries the tag name for tag-triggered upstream runs), cleans up the key on `if: always()`. New `deploy/deploy.sh` (executable bit set): SSHes to `$DOCKER_DEPLOY_HOST` with `IdentitiesOnly=yes` + `StrictHostKeyChecking=accept-new`, pulls all 5 service images at `$DEPLOY_TAG`, `docker compose --project-directory /opt/deep-analysis pull && up -d --force-recreate`, runs `alembic upgrade head` via the auth container, then loops `auth ingest parser analytics web` smoke-checking `http://localhost:8000/healthz` inside each container with `curl -sf` (fail-loud on any non-200). YAML and bash both syntax-clean. PR opening + `/self-review` next.
+
 ## 2026-04-26 12:50 — release-v0.4.3  [batch]
 
 **Type:** status

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Deploy the deep-analysis stack to the docker host on a tagged release.
+#
+# Pulls the 5 service images at $DEPLOY_TAG, force-recreates the compose
+# stack at $DEPLOY_PATH on $DEPLOY_HOST, runs Alembic migrations through
+# the auth container, and smoke-checks /healthz on each service.
+#
+# Requires DOCKER_DEPLOY_HOST and DOCKER_DEPLOY_KEY env vars, set by the
+# deploy workflow from repo variables/secrets. DEPLOY_TAG defaults to
+# "latest" but is normally passed the upstream tag (e.g. v0.6.0).
+
+set -euo pipefail
+
+DEPLOY_HOST="${DOCKER_DEPLOY_HOST:?DOCKER_DEPLOY_HOST not set}"
+DEPLOY_KEY="${DOCKER_DEPLOY_KEY:?DOCKER_DEPLOY_KEY not set}"
+DEPLOY_TAG="${DEPLOY_TAG:-latest}"
+DEPLOY_PATH="${DEPLOY_PATH:-/opt/deep-analysis}"
+
+if [[ ! -r "$DEPLOY_KEY" ]]; then
+    echo "deploy key not found or unreadable: $DEPLOY_KEY" >&2
+    echo "set DOCKER_DEPLOY_KEY to the deploy private key path" >&2
+    exit 1
+fi
+
+SSH_OPTS=(-i "$DEPLOY_KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new)
+
+SERVICES=(auth ingest parser analytics web)
+
+echo ">> deploying deep-analysis $DEPLOY_TAG to $DEPLOY_HOST"
+
+echo ">> pulling service images at $DEPLOY_TAG"
+ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
+    "docker pull ghcr.io/sentania-labs/deep-analysis-auth:${DEPLOY_TAG} && \
+     docker pull ghcr.io/sentania-labs/deep-analysis-ingest:${DEPLOY_TAG} && \
+     docker pull ghcr.io/sentania-labs/deep-analysis-parser:${DEPLOY_TAG} && \
+     docker pull ghcr.io/sentania-labs/deep-analysis-analytics:${DEPLOY_TAG} && \
+     docker pull ghcr.io/sentania-labs/deep-analysis-web:${DEPLOY_TAG}"
+
+echo ">> bringing stack up (force-recreate) at $DEPLOY_PATH"
+ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
+    "docker compose --project-directory $DEPLOY_PATH pull && \
+     docker compose --project-directory $DEPLOY_PATH up -d --force-recreate"
+
+echo ">> running alembic migrations via auth container"
+ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
+    "docker compose --project-directory $DEPLOY_PATH exec -T auth alembic upgrade head"
+
+echo ">> smoke-checking /healthz on all services"
+ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
+    "for svc in ${SERVICES[*]}; do \
+        echo \">> smoke check: \$svc\"; \
+        docker compose --project-directory $DEPLOY_PATH exec -T \$svc curl -sf http://localhost:8000/healthz \
+            || { echo \"FAIL: \$svc /healthz\" >&2; exit 1; }; \
+     done"
+
+echo ">> deploy complete — deep-analysis $DEPLOY_TAG"


### PR DESCRIPTION
## Summary

- New `.github/workflows/deploy.yml` triggers on the **Release** workflow's `workflow_run` completion, runs on `[self-hosted, linux, docker]`, and gates with `github.event.workflow_run.conclusion == 'success' && secrets.DOCKER_DEPLOY_KEY != ''` — so the job is **skipped silently** in repos/forks without the deploy secret.
- New executable `deploy/deploy.sh` SSHes to `$DOCKER_DEPLOY_HOST`, pulls all 5 service images at the released tag (`auth`, `ingest`, `parser`, `analytics`, `web`), `docker compose --project-directory /opt/deep-analysis pull && up -d --force-recreate`, runs `alembic upgrade head` via the auth container, then **smoke-checks `/healthz`** on each service inside its container with `curl -sf` (fail-loud on any miss).
- `DEPLOY_TAG` flows from `github.event.workflow_run.head_branch` — for tag-triggered upstream runs this carries the tag name (e.g. `v0.6.0`), so the deploy lines up with the GHCR tag the Release workflow just published.

## Test plan

- [ ] After merge: cut a `vX.Y.Z` tag on `main`, confirm the Release workflow publishes the 5 images, then watch this `deploy` workflow fire on Release completion.
- [ ] Verify the deploy job is **skipped** (not failed) on a Release run when `DOCKER_DEPLOY_KEY` is absent.
- [ ] Verify on a real run: all 5 images pulled at the new tag, `docker compose ps` shows recreated containers, `alembic upgrade head` exits clean, all 5 `/healthz` smoke checks return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)