### PR TITLE
fix: align deploy script with slot model

### DIFF
--- a/.pka/updates/current.md
+++ b/.pka/updates/current.md
@@ -1,3 +1,9 @@
+## 2026-05-09 22:30 — deploy-slot-model-fix  [batch]
+
+**Type:** status
+
+Rewrote `deploy/deploy.sh` on `fix/deploy-slot-model` (off main `79b4efd`) to fit the docker.int slot model per lab-admin response `28f2a67c-5945-4700-af71-bc2262835213`. Slot was provisioned at `/srv/services/deep-analysis-server/` but the prior deploy script used commands the deploy-wrapper allowlist rejects. Five wrapper-allowlist violations fixed: `DEPLOY_PATH` default moved from `/opt/deep-analysis` to `/srv/services/deep-analysis-server`; raw `docker pull` for the 5 service images replaced with a single `docker compose --project-directory $DEPLOY_PATH pull` (compose pulls the tags pinned in compose.yml); `--force-recreate` dropped (plain `up -d` recreates services whose digest changed, which is what we want in CI anyway); `docker compose exec` for Alembic migrations removed entirely with a header comment noting migrations now must be baked into the stack (one-shot `auth-migrate` service or `alembic upgrade head` in the auth entrypoint, gated by env flag) — that wiring is a follow-up; per-service `compose exec curl /healthz` smoke-loop replaced with a single `docker compose ... ps` (matches dashboard slot pattern). Added `scp -O` push of the repo-root `docker-compose.yml` to `$DEPLOY_PATH/docker-compose.yml` before pull/up (mirrors dashboard's `SCRIPT_DIR/../docker-compose.yml` resolution). `DEPLOY_TAG` env var preserved (consumed by compose.yml image tag pins). No fleet-caddy snippet push, no `BRIDGE_API_TOKEN` generation — deep-analysis runs its own gateway+secrets. Bash `-n` syntax-clean; verified no remaining `docker pull` / `--force-recreate` / `compose exec` invocations (only mentions are in the explanatory header comment). PR open + `/self-review` next.
+
 ## 2026-05-09 21:45 — ci-auto-deploy  [batch]
 
 **Type:** status

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,56 +1,64 @@
 #!/usr/bin/env bash
-# Deploy the deep-analysis stack to the docker host on a tagged release.
+# Deploy the deep-analysis stack to the docker.int slot on a tagged release.
 #
-# Pulls the 5 service images at $DEPLOY_TAG, force-recreates the compose
-# stack at $DEPLOY_PATH on $DEPLOY_HOST, runs Alembic migrations through
-# the auth container, and smoke-checks /healthz on each service.
+# Pushes the repo-root docker-compose.yml to the slot dir on $DEPLOY_HOST,
+# pulls the 5 service images at $DEPLOY_TAG via compose, and brings the
+# stack up. Verification is via `compose ps` (matches the dashboard slot
+# pattern). The deploy-wrapper allowlist on docker.int rejects raw
+# `docker pull`, `--force-recreate`, and `compose exec`, so this script
+# uses only allowlisted verbs.
+#
+# Migrations are NOT run from this script. The wrapper does not allow
+# `compose exec`, so Alembic migrations must be baked into the compose
+# stack (one-shot `auth-migrate` service, or `alembic upgrade head` in
+# the auth container's entrypoint gated by an env flag). Until that is
+# wired up, the first deploy after a schema change requires a manual
+# admin step on docker.int.
 #
 # Requires DOCKER_DEPLOY_HOST and DOCKER_DEPLOY_KEY env vars, set by the
 # deploy workflow from repo variables/secrets. DEPLOY_TAG defaults to
-# "latest" but is normally passed the upstream tag (e.g. v0.6.0).
+# "latest" but is normally passed the upstream tag (e.g. v0.6.0); the
+# tag is consumed by docker-compose.yml via image: ${DEPLOY_TAG} pins.
 
 set -euo pipefail
 
 DEPLOY_HOST="${DOCKER_DEPLOY_HOST:?DOCKER_DEPLOY_HOST not set}"
 DEPLOY_KEY="${DOCKER_DEPLOY_KEY:?DOCKER_DEPLOY_KEY not set}"
 DEPLOY_TAG="${DEPLOY_TAG:-latest}"
-DEPLOY_PATH="${DEPLOY_PATH:-/opt/deep-analysis}"
+DEPLOY_PATH="${DEPLOY_PATH:-/srv/services/deep-analysis-server}"
 
 if [[ ! -r "$DEPLOY_KEY" ]]; then
     echo "deploy key not found or unreadable: $DEPLOY_KEY" >&2
-    echo "set DOCKER_DEPLOY_KEY to the deploy private key path" >&2
+    echo "set DOCKER_DEPLOY_KEY to the slot deploy private key path" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/../docker-compose.yml"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    echo "missing compose file: $COMPOSE_FILE" >&2
     exit 1
 fi
 
 SSH_OPTS=(-i "$DEPLOY_KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new)
+SCP_OPTS=(-O "${SSH_OPTS[@]}")
 
-SERVICES=(auth ingest parser analytics web)
+echo ">> deploying deep-analysis $DEPLOY_TAG to $DEPLOY_HOST:$DEPLOY_PATH"
 
-echo ">> deploying deep-analysis $DEPLOY_TAG to $DEPLOY_HOST"
+echo ">> pushing compose file to $DEPLOY_HOST:$DEPLOY_PATH/docker-compose.yml"
+scp "${SCP_OPTS[@]}" "$COMPOSE_FILE" "$DEPLOY_HOST:$DEPLOY_PATH/docker-compose.yml"
 
 echo ">> pulling service images at $DEPLOY_TAG"
 ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
-    "docker pull ghcr.io/sentania-labs/deep-analysis-auth:${DEPLOY_TAG} && \
-     docker pull ghcr.io/sentania-labs/deep-analysis-ingest:${DEPLOY_TAG} && \
-     docker pull ghcr.io/sentania-labs/deep-analysis-parser:${DEPLOY_TAG} && \
-     docker pull ghcr.io/sentania-labs/deep-analysis-analytics:${DEPLOY_TAG} && \
-     docker pull ghcr.io/sentania-labs/deep-analysis-web:${DEPLOY_TAG}"
+    "docker compose --project-directory $DEPLOY_PATH pull"
 
-echo ">> bringing stack up (force-recreate) at $DEPLOY_PATH"
+echo ">> bringing stack up"
 ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
-    "docker compose --project-directory $DEPLOY_PATH pull && \
-     docker compose --project-directory $DEPLOY_PATH up -d --force-recreate"
+    "docker compose --project-directory $DEPLOY_PATH up -d"
 
-echo ">> running alembic migrations via auth container"
+echo ">> verifying stack"
 ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
-    "docker compose --project-directory $DEPLOY_PATH exec -T auth alembic upgrade head"
-
-echo ">> smoke-checking /healthz on all services"
-ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
-    "for svc in ${SERVICES[*]}; do \
-        echo \">> smoke check: \$svc\"; \
-        docker compose --project-directory $DEPLOY_PATH exec -T \$svc curl -sf http://localhost:8000/healthz \
-            || { echo \"FAIL: \$svc /healthz\" >&2; exit 1; }; \
-     done"
+    "docker compose --project-directory $DEPLOY_PATH ps"
 
 echo ">> deploy complete — deep-analysis $DEPLOY_TAG"


### PR DESCRIPTION
## Summary

Rewrites `deploy/deploy.sh` to fit the docker.int slot model. Lab-admin
provisioned the slot at `/srv/services/deep-analysis-server/` but the
prior script used commands the deploy-wrapper allowlist rejects, so CI
deploys would have failed on first run.

References lab-admin response `28f2a67c-5945-4700-af71-bc2262835213`.

## Wrapper-allowlist violations fixed

| Old line | Fix |
|---|---|
| `DEPLOY_PATH=${DEPLOY_PATH:-/opt/deep-analysis}` | Default is now `/srv/services/deep-analysis-server` (the only path the wrapper allows). |
| 5x `docker pull ghcr.io/sentania-labs/deep-analysis-*:${TAG}` | Replaced with one `docker compose --project-directory $DEPLOY_PATH pull` (compose picks up the tag from `docker-compose.yml`). |
| `docker compose ... up -d --force-recreate` | Dropped `--force-recreate`; plain `up -d` recreates services whose digest changed, which is what we want in CI. |
| `docker compose ... exec -T auth alembic upgrade head` | Removed entirely. Header comment documents that migrations now have to be baked into the stack (one-shot `auth-migrate` service, or `alembic upgrade head` in the auth entrypoint gated by env flag) — wiring that is a follow-up, not part of this PR. |
| `docker compose ... exec -T <svc> curl -sf .../healthz` (5x) | Replaced with one `docker compose ... ps` (mirrors the dashboard slot pattern). |

## Other changes

- `scp -O` push of the repo-root `docker-compose.yml` to
  `$DEPLOY_PATH/docker-compose.yml` happens before pull/up, mirroring
  `workspaces/dashboard/deploy/deploy.sh`. Resolved via `$SCRIPT_DIR/..`
  since our compose file lives at the repo root, not in `deploy/`.
- `DEPLOY_TAG` env var preserved — it's still consumed by image tag
  pins in `docker-compose.yml`.
- No fleet-caddy snippet push and no `BRIDGE_API_TOKEN` generation —
  deep-analysis runs its own gateway container and secrets model.

## Follow-ups (not in this PR)

- Bake Alembic migrations into the compose stack (one-shot service or
  entrypoint gated by env flag) so the deploy runs schema upgrades
  again. Tracked in the lab-admin response.
- First deploy still needs seeded `.env` + JWT keypair + Postgres
  password in `/srv/services/deep-analysis-server/`. Manual seed by
  Scott or the CI flow handling it idempotently — out of scope here.

## Test plan

- [x] `bash -n deploy/deploy.sh`
- [x] grep confirms no `docker pull`, `--force-recreate`, or `compose
  exec` in actual commands (only in the explanatory header comment)
- [x] Self-reviewer subagent: APPROVED
- [ ] CI deploy on next tag exercises the new script end-to-end on
  docker.int

🤖 Generated with [Claude Code](https://claude.com/claude-code)