### PR TITLE
feat: run alembic migrations automatically on compose up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
           echo 'GATEWAY_DOMAIN=deepanalysis.local' >> .env
           echo 'DEEP_ANALYSIS_ACME_EMAIL=ci@example.com' >> .env
           echo 'DA_DATABASE_URL=postgresql+asyncpg://da:changeme@postgres:5432/deep_analysis' >> .env
+          # auth-migrate runs inside the compose network, so postgres is
+          # reachable as `postgres`, not `localhost`. Override .env.example's
+          # host-side default.
+          echo 'DATABASE_URL=postgresql+psycopg://da:changeme@postgres:5432/deep_analysis' >> .env
       - name: docker compose up
         run: docker compose -f docker-compose.yml -f ci/docker-compose.ci.yml up -d --build
       - name: Wait for gateway
@@ -255,6 +259,10 @@ jobs:
           echo 'GATEWAY_DOMAIN=deepanalysis.local' >> .env
           echo 'DEEP_ANALYSIS_ACME_EMAIL=ci@example.com' >> .env
           echo 'DA_DATABASE_URL=postgresql+asyncpg://da:changeme@postgres:5432/deep_analysis' >> .env
+          # auth-migrate runs inside the compose network. The job-level
+          # DATABASE_URL above (localhost:5432) is for host-side alembic;
+          # the .env value is what the container reads.
+          echo 'DATABASE_URL=postgresql+psycopg://da:changeme@postgres:5432/deep_analysis' >> .env
           echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" >> .env
           echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}" >> .env
       - name: Generate JWT keypair for CI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,35 @@ services:
       timeout: 5s
       retries: 5
 
+  # One-shot job: applies the auth schema migrations and exits 0. The deploy
+  # wrapper on docker.int rejects `compose exec`, so migrations have to run
+  # as part of `compose up`. The auth service waits for this to complete
+  # successfully (service_completed_successfully) before starting.
+  #
+  # PREREQUISITE: the root alembic head (creates the `auth` schema and the
+  # service roles) must already be applied against this database. There is
+  # no `root-migrate` service yet; that is a follow-up. On a brand-new
+  # database, run `alembic upgrade head` from the repo root once before
+  # `compose up`, or auth-migrate will fail with "schema auth does not exist".
+  #
+  # DATABASE_URL must be a sync psycopg URL (alembic env.py uses the sync
+  # engine), e.g. postgresql+psycopg://USER:PASS@postgres:5432/deep_analysis.
+  # The async asyncpg URL used by the running services (DA_DATABASE_URL) is
+  # not interchangeable here.
+  auth-migrate:
+    build:
+      context: .
+      dockerfile: services/auth/Dockerfile
+    command: ["alembic", "-c", "/app/service/alembic.ini", "upgrade", "head"]
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-}
+    networks:
+      - backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
   gateway:
     image: caddy:2-alpine
     restart: unless-stopped
@@ -93,6 +122,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      auth-migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
       interval: 15s

--- a/services/auth/alembic.ini
+++ b/services/auth/alembic.ini
@@ -1,5 +1,8 @@
 [alembic]
-script_location = services/auth/alembic
+# %(here)s resolves to the directory containing this .ini file. This makes
+# the script path correct whether invoked from the repo root (CI) or from
+# inside the auth image (where alembic.ini lives at /app/service/).
+script_location = %(here)s/alembic
 # Placeholder only — env.py overrides this with DATABASE_URL from the environment.
 sqlalchemy.url = driver://user:pass@host/db
 


### PR DESCRIPTION
## Summary
- Adds `auth-migrate` one-shot service that runs `alembic upgrade head` before auth starts
- Auth service depends on `auth-migrate` completing successfully
- Fixes `alembic.ini` script_location to use `%(here)s` so it resolves correctly from both repo root and inside the container
- No `compose exec` needed — migrations run as part of `compose up -d`

Covers auth-service migrations only. Root schema migrations (001-005) are a first-deploy prerequisite run manually when seeding the slot.

## Test plan
- [ ] `docker compose up -d` runs auth-migrate before auth starts
- [ ] auth-migrate exits 0 on clean DB
- [ ] auth-migrate exits 0 idempotently on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)