### PR TITLE
fix: deploy workflow — make CI auto-deploy actually work

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,15 @@
 name: deploy
 
-# Triggered when the Release workflow finishes for a tag push. Pulls the
-# 5 service images at the released tag, force-recreates the compose stack
-# on the docker host, runs Alembic migrations, and smoke-checks /healthz
-# on every service.
+# Triggered when the Release workflow finishes for a tag push. Rewrites
+# docker-compose.yml's `build:` blocks into `image:` refs at the released
+# tag, scp's it to the edge.int slot dir, then runs `compose pull` and
+# `compose up -d`. Migrations are baked into the stack as one-shot
+# services, so they run as part of the bring-up. Verification is via
+# `compose ps`.
 #
-# Skips silently when DOCKER_DEPLOY_KEY is not configured (e.g. forks),
-# so the workflow file is safe to ship in the open-source repo.
+# If DOCKER_DEPLOY_KEY is unset (e.g. forks), the key-write step produces
+# an empty file and deploy.sh fails fast with a clear error message —
+# acceptable skip behavior for the open-source repo.
 
 on:
   workflow_run:
@@ -23,9 +26,12 @@ permissions:
 jobs:
   deploy:
     runs-on: [self-hosted, linux, docker]
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      secrets.DOCKER_DEPLOY_KEY != ''
+    # Note: do NOT add `secrets.DOCKER_DEPLOY_KEY != ''` here. GitHub does
+    # not evaluate `secrets` in job-level `if:` for `workflow_run` triggers
+    # — the condition silently evaluates to false and the job is skipped
+    # with no log. If the secret is unset (e.g. forks), the key-write step
+    # produces an empty file and deploy.sh fails fast with a clear error.
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
       - name: Write deploy key

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,24 +1,23 @@
 #!/usr/bin/env bash
 # Deploy the deep-analysis stack to the edge.int slot on a tagged release.
 #
-# Pushes the repo-root docker-compose.yml and fleet-caddy snippets to the
-# slot dir on $DEPLOY_HOST, pulls the service images at $DEPLOY_TAG via
-# compose, and brings the stack up. Verification is via `compose ps`.
-# The deploy-wrapper allowlist on edge.int rejects raw `docker pull`,
-# `--force-recreate`, and `compose exec`, so this script uses only
-# allowlisted verbs.
+# The repo-root docker-compose.yml uses `build:` blocks for local dev. The
+# slot host has no source checkout, so we rewrite those blocks into
+# `image: ghcr.io/sentania-labs/deep-analysis-<svc>:<tag>` references and
+# scp the rewritten file. fleet-caddy snippets are scp'd to the per-slot
+# conf.d/ dir; compose pull + up -d brings the stack up. Verification is
+# via `compose ps`. The deploy-wrapper allowlist on edge.int rejects raw
+# `docker pull`, `--force-recreate`, and `compose exec`, so this script
+# uses only allowlisted verbs.
 #
-# Migrations are NOT run from this script. The wrapper does not allow
-# `compose exec`, so Alembic migrations must be baked into the compose
-# stack (one-shot `auth-migrate` service, or `alembic upgrade head` in
-# the auth container's entrypoint gated by an env flag). Until that is
-# wired up, the first deploy after a schema change requires a manual
-# admin step on edge.int.
+# Migrations run as one-shot `root-migrate` and `auth-migrate` services
+# inside the compose stack, ordered via `service_completed_successfully`
+# so they fire on every `compose up -d`.
 #
 # Requires DOCKER_DEPLOY_HOST and DOCKER_DEPLOY_KEY env vars, set by the
-# deploy workflow from repo variables/secrets. DEPLOY_TAG defaults to
-# "latest" but is normally passed the upstream tag (e.g. v0.6.0); the
-# tag is consumed by docker-compose.yml via image: ${DEPLOY_TAG} pins.
+# deploy workflow from repo variables/secrets. DEPLOY_TAG is normally the
+# upstream release tag (e.g. v0.6.0); it is baked into the rewritten
+# compose file's `image:` tags as a literal value.
 
 set -euo pipefail
 
@@ -55,8 +54,51 @@ SCP_OPTS=(-O "${SSH_OPTS[@]}")
 
 echo ">> deploying deep-analysis $DEPLOY_TAG to $DEPLOY_HOST:$DEPLOY_PATH"
 
+echo ">> generating prod compose with image: refs at $DEPLOY_TAG"
+PROD_COMPOSE="$(mktemp -t deep-analysis-compose-prod.XXXXXX.yml)"
+trap 'rm -f "$PROD_COMPOSE"' EXIT
+
+DEPLOY_TAG="$DEPLOY_TAG" python3 - "$COMPOSE_FILE" "$PROD_COMPOSE" <<'PY'
+import os
+import sys
+
+import yaml
+
+src, dst = sys.argv[1], sys.argv[2]
+tag = os.environ["DEPLOY_TAG"]
+
+# Service name → GHCR image (without tag). Services not in this map and
+# without a `build:` key are left untouched (gateway, postgres, redis).
+IMAGES = {
+    "root-migrate": "ghcr.io/sentania-labs/deep-analysis-auth",
+    "auth-migrate": "ghcr.io/sentania-labs/deep-analysis-auth",
+    "auth": "ghcr.io/sentania-labs/deep-analysis-auth",
+    "ingest": "ghcr.io/sentania-labs/deep-analysis-ingest",
+    "parser": "ghcr.io/sentania-labs/deep-analysis-parser",
+    "analytics": "ghcr.io/sentania-labs/deep-analysis-analytics",
+    "web": "ghcr.io/sentania-labs/deep-analysis-web",
+}
+
+with open(src) as f:
+    compose = yaml.safe_load(f)
+
+for name, svc in compose.get("services", {}).items():
+    if "build" in svc:
+        if name not in IMAGES:
+            sys.exit(f"service {name!r} has build: but no image mapping")
+        del svc["build"]
+        svc["image"] = f"{IMAGES[name]}:{tag}"
+
+with open(dst, "w") as f:
+    yaml.safe_dump(compose, f, sort_keys=False)
+PY
+
+echo ">> removing legacy flat fleet-caddy snippet (idempotent)"
+ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
+    "rm -f /srv/fleet-caddy/conf.d/deep-analysis-server.caddy"
+
 echo ">> pushing compose file to $DEPLOY_HOST:$DEPLOY_PATH/docker-compose.yml"
-scp "${SCP_OPTS[@]}" "$COMPOSE_FILE" "$DEPLOY_HOST:$DEPLOY_PATH/docker-compose.yml"
+scp "${SCP_OPTS[@]}" "$PROD_COMPOSE" "$DEPLOY_HOST:$DEPLOY_PATH/docker-compose.yml"
 
 echo ">> pushing fleet-caddy snippets to /srv/fleet-caddy/conf.d/deep-analysis-server/"
 scp "${SCP_OPTS[@]}" "$CADDY_SNIPPET" \


### PR DESCRIPTION
## Summary

- **deploy.yml**: drop `secrets.DOCKER_DEPLOY_KEY != ''` from the job-level `if:`. GitHub does not evaluate `secrets` in job `if:` for `workflow_run` triggers — the condition silently evaluates to false and the job is skipped with no log. This was the root cause of the "0 jobs" symptom on past tag pushes.
- **deploy.sh**: rewrite `docker-compose.yml` on the fly via PyYAML — strip each `build:` block and inject literal `image: ghcr.io/sentania-labs/deep-analysis-<svc>:<DEPLOY_TAG>` refs — and scp the rewritten file to the slot. The slot has no source checkout, so the raw build-style file would fail `compose pull` and try to build on `up -d`. Tempfile is cleaned up via EXIT trap.
- **deploy.sh**: add idempotent `ssh ... rm -f /srv/fleet-caddy/conf.d/deep-analysis-server.caddy` legacy-flat-snippet cleanup, matching the dashboard deploy pattern. Verb is on the lab-admin allowlist.

Service → image mapping: `root-migrate`, `auth-migrate`, `auth` → `deep-analysis-auth`; `ingest`/`parser`/`analytics`/`web` → matching ghcr image. `gateway`, `postgres`, `redis` (no `build:` block) are left untouched.

## Test plan

- [x] `bash -n deploy/deploy.sh` (syntax)
- [x] Smoke-tested the Python rewrite against the repo's `docker-compose.yml` with `DEPLOY_TAG=v0.6.0`; `docker compose -f <generated> config --services` lists all 10 services and image refs land on the expected lines.
- [ ] Cut a tag (e.g. `v0.6.0`) and confirm the Release workflow's completion fires `deploy` (no longer "0 jobs"), the prod compose lands at `/srv/services/deep-analysis-server/docker-compose.yml` on edge.int, `compose pull` resolves all GHCR images, and `compose up -d` brings the stack up cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)