### PR TITLE
fix: admin bootstrap — fire reliably on first deploy

### DIFF
--- a/deploy/seed.sh
+++ b/deploy/seed.sh
@@ -78,6 +78,9 @@ echo ">> seeding deep-analysis-server on $DEPLOY_HOST:$DEPLOY_PATH"
 echo ">> generating Postgres password"
 POSTGRES_PASSWORD="$(openssl rand -hex 32)"
 
+echo ">> generating bootstrap admin password"
+BOOTSTRAP_ADMIN_PASSWORD="$(openssl rand -hex 16)"
+
 echo ">> generating RS256 JWT keypair (RSA-4096) into $TMPDIR"
 openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 \
     -out "$TMPDIR/jwt_private.pem" >/dev/null 2>&1
@@ -102,6 +105,8 @@ DA_REFRESH_TOKEN_TTL_SECONDS=2592000
 GATEWAY_DOMAIN=deepanalysis.sentania.net
 DEEP_ANALYSIS_ACME_EMAIL=ops@sentania.net
 DEPLOY_TAG=latest
+DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=admin@local
+DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=$BOOTSTRAP_ADMIN_PASSWORD
 EOF
 chmod 0600 "$ENV_FILE"
 
@@ -137,6 +142,13 @@ ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
     "docker compose --project-directory $DEPLOY_PATH ps"
 
 echo ">> seed complete — deep-analysis-server"
+echo ""
+echo ">> ADMIN BOOTSTRAP CREDENTIALS (save these now):"
+echo "   email:    admin@local"
+echo "   password: $BOOTSTRAP_ADMIN_PASSWORD"
+echo ""
+echo "   The admin user will be created on first 'compose up -d'."
+echo "   Change the password immediately after first login."
 echo ""
 echo "NOTE: JWT keys were pushed to $DEPLOY_PATH/.secrets/ but will not"
 echo "be picked up until docker-compose.yml's auth_secrets volume is"

--- a/services/auth/auth_service/bootstrap.py
+++ b/services/auth/auth_service/bootstrap.py
@@ -1,6 +1,6 @@
 """First-boot admin bootstrap.
 
-Runs once at auth-service startup. Idempotent: if any enabled admin
+Runs at auth-service startup. Idempotent: if any enabled admin
 already exists, it is a no-op. Otherwise creates an admin account and
 (for the auto-generate path) writes the plaintext password to
 ``/data/secrets/initial_admin.txt`` on the ``auth_secrets`` volume.

--- a/services/auth/tests/test_bootstrap.py
+++ b/services/auth/tests/test_bootstrap.py
@@ -135,3 +135,19 @@ async def test_bootstrap_env_var_path_no_file_written(
     assert admin.must_change_password is False
     assert verify_password("scripted-password-xyz", admin.password_hash)
     assert not settings.initial_admin_secret_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_env_var_path_idempotent_on_restart(
+    db_session: AsyncSession, tmp_path: Path
+) -> None:
+    """Simulate container restart: env vars present, user already exists.
+    Bootstrap must not create a second admin."""
+    settings = _fresh_settings(tmp_path, email="admin@local", pw="strongpassword123x")
+    # First startup: creates the user
+    await bootstrap_admin(db_session, settings)
+    # Second startup (restart): must be a no-op
+    await bootstrap_admin(db_session, settings)
+
+    count = (await db_session.execute(select(func.count()).select_from(User))).scalar_one()
+    assert count == 1


### PR DESCRIPTION
## Summary

Fix the first-deploy 401-forever auth state on edge.int.

`deploy/seed.sh` now generates a bootstrap admin password (`openssl rand -hex 16`) before writing the `.env`, embeds `DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL` / `DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD` into the file, and prints the credentials to stdout after `seed complete` so the operator captures them.

## Failure scenario this closes

1. Operator runs `deploy/seed.sh` against a fresh slot. The previous version wrote a `.env` without the bootstrap env vars.
2. First `compose up -d` starts auth. `bootstrap_admin()` finds no enabled admin, falls into the auto-generate branch (env vars absent), and tries to write the plaintext password to `/data/secrets/initial_admin.txt`.
3. That path is backed by the `auth_secrets` *named* volume. Edge.int's allowlist forbids `compose exec`, `docker cp`, and `docker run`, so the host can't read it.
4. Operator notices the failure and adds the env vars to `.env`. Restart auth — but now an enabled admin already exists, bootstrap returns early as a no-op, and the password set on the first run is unrecoverable. Login is 401 forever.

## Fix

- **`deploy/seed.sh`** — generate `BOOTSTRAP_ADMIN_PASSWORD` up front (hex avoids `+`/`/`/`=` shell-escaping issues), embed both env vars into the `.env` heredoc, and echo the credentials after seed completes.
- **`services/auth/auth_service/bootstrap.py`** — docstring tweak only. The previous wording said "Runs once at auth-service startup" which was misleading; it runs every startup but is gated on the empty-admin check. No logic change.
- **`services/auth/tests/test_bootstrap.py`** — add `test_bootstrap_env_var_path_idempotent_on_restart` covering the exact restart-with-vars scenario the bug exhibited.

## Test plan

- [x] `ruff check` + `ruff format --check` on `services/auth/`
- [x] `pytest services/auth/tests/test_bootstrap.py` — 7/7 pass including new test
- [x] `bash -n deploy/seed.sh`
- [x] `mypy services/auth` — no new errors (3 pre-existing on main, unrelated files)
- [ ] Compose-smoke E2E gate (CI)
- [ ] Re-deploy on edge.int and confirm `seed.sh` prints creds + first `compose up -d` creates the admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)