### PR TITLE
fix: fleet-caddy routing — attach to edge-slots, bypass internal gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ project follows [Semantic Versioning](https://semver.org/) loosely while
 in pre-1.0; expect minor versions to introduce breaking changes until the
 API surface stabilizes.
 
+## v0.7.5 — 2026-05-10
+
+### Fixed
+
+- **fleet-caddy networking: 503 after CI deploy.** Added `edge-slots` as an
+  external network in `docker-compose.yml` and attached `web`, `auth`, `ingest`,
+  and `analytics` services to it. Rewrote the fleet-caddy caddy snippet to route
+  directly to service containers (`deep-analysis-<svc>-1`) instead of through the
+  internal gateway — fleet-caddy handles TLS, so routing two Caddy instances in
+  series was unnecessary. The fix is permanent: `compose up -d` now attaches
+  services to `edge-slots` automatically on every deploy.
+
 ## v0.5.0 — 2026-04-26
 
 ### Added

--- a/deploy/deep-analysis-server.caddy
+++ b/deploy/deep-analysis-server.caddy
@@ -1,4 +1,27 @@
-reverse_proxy deep-analysis-server-gateway:8080 {
-    health_uri /healthz
-    health_interval 30s
+handle /auth/* {
+    reverse_proxy deep-analysis-auth-1:8000 {
+        health_uri /healthz
+        health_interval 30s
+    }
+}
+
+handle /ingest/* {
+    reverse_proxy deep-analysis-ingest-1:8000 {
+        health_uri /healthz
+        health_interval 30s
+    }
+}
+
+handle /analytics/* {
+    reverse_proxy deep-analysis-analytics-1:8000 {
+        health_uri /healthz
+        health_interval 30s
+    }
+}
+
+handle {
+    reverse_proxy deep-analysis-web-1:8000 {
+        health_uri /healthz
+        health_interval 30s
+    }
 }

--- a/deploy/deep-analysis-server.json
+++ b/deploy/deep-analysis-server.json
@@ -3,8 +3,8 @@
   "slot": "deep-analysis-server",
   "mode": "l7-reverse-proxy",
   "sni": "deepanalysis.sentania.net",
-  "upstream_host": "deep-analysis-server-gateway",
-  "upstream_port": 8080,
+  "upstream_host": "deep-analysis-web-1",
+  "upstream_port": 8000,
   "health_uri": "/healthz",
   "auth_required": false,
   "tls_upstream_skip_verify": false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
     restart: unless-stopped
     networks:
       - backend
+      - edge-slots
     environment:
       DA_SERVICE_NAME: auth
       DA_DATABASE_URL: ${DA_DATABASE_URL:-}
@@ -154,6 +155,7 @@ services:
     restart: unless-stopped
     networks:
       - backend
+      - edge-slots
     environment:
       DA_SERVICE_NAME: ingest
       DA_DATABASE_URL: ${DA_DATABASE_URL:-}
@@ -212,6 +214,7 @@ services:
     restart: unless-stopped
     networks:
       - backend
+      - edge-slots
     environment:
       DA_SERVICE_NAME: analytics
       DA_DATABASE_URL: ${DA_DATABASE_URL:-}
@@ -240,6 +243,7 @@ services:
     networks:
       - frontend
       - backend
+      - edge-slots
     environment:
       DA_SERVICE_NAME: web
       DA_DATABASE_URL: ${DA_DATABASE_URL:-}
@@ -263,6 +267,8 @@ services:
 networks:
   frontend:
   backend:
+  edge-slots:
+    external: true
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

- Add `edge-slots` as an external network in `docker-compose.yml` and attach `web`, `auth`, `ingest`, and `analytics` to it so fleet-caddy on docker.int can reach the app containers after every CI deploy.
- Rewrite `deploy/deep-analysis-server.caddy` to route directly to `deep-analysis-<svc>-1:8000` containers instead of the internal compose gateway. fleet-caddy already terminates TLS at the edge — running two Caddy instances in series was unnecessary.
- Update `deploy/deep-analysis-server.json` slot config to point at `deep-analysis-web-1:8000` (used for fallback / health check under l7-reverse-proxy mode).
- Adds `v0.7.5` CHANGELOG entry.

### Why

After a CI deploy, https://deepanalysis.sentania.net was returning 503. Three things compounded:

1. The fleet-caddy snippet routed to `deep-analysis-server-gateway:8080` (the internal Caddy gateway), which is NOT on `edge-slots`.
2. App containers (web, auth, ingest, analytics) were only on `frontend`/`backend` — also not reachable from fleet-caddy.
3. Every CI deploy recreated containers and dropped any manual `docker network connect` fixes.

This change makes the fix permanent: `compose up -d` attaches services to `edge-slots` automatically.

### Untouched

- `gateway`, `parser`, `postgres`, `redis`, and the migrate jobs stay off `edge-slots`. Local `docker compose up` still works because the gateway service is unchanged.

## Test plan

- [ ] Tag v0.7.5 after merge, watch CI auto-deploy
- [ ] Confirm `docker network inspect edge-slots` on docker.int shows web/auth/ingest/analytics attached after deploy
- [ ] `curl -I https://deepanalysis.sentania.net/healthz` returns 200, not 503
- [ ] `/auth/`, `/ingest/`, `/analytics/` paths route to the correct service containers
- [ ] Local `docker compose up` still serves through the internal gateway as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)