### PR TITLE
feat: Scryfall bulk data sync service

### DIFF
--- a/alembic/versions/006_scryfall_cards.py
+++ b/alembic/versions/006_scryfall_cards.py
@@ -1,0 +1,121 @@
+"""catalog.cards — Scryfall bulk-data card mirror.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-05-10
+
+A new ``catalog`` schema for reference data — separate from
+``analytics.*`` because cards are not analytics state, they're a
+periodically-refreshed mirror of Scryfall's oracle bulk data. The
+analytics service owns the table (it's the only service that reads or
+writes it for now), but it lives outside the analytics schema so the
+boundary stays clean if a future service ever consumes it too.
+
+Schema and grants live together in this migration so the catalog
+schema doesn't accumulate drift across multiple files. The analytics
+role gets full privileges — it owns the upsert path; the parser role
+gets SELECT for opportunistic card lookups (e.g., enriching match
+games with card metadata at parse time).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS catalog;")
+
+    op.create_table(
+        "cards",
+        sa.Column(
+            "scryfall_id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("oracle_text", sa.Text(), nullable=True),
+        sa.Column("type_line", sa.Text(), nullable=True),
+        sa.Column("mana_cost", sa.Text(), nullable=True),
+        sa.Column(
+            "colors",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("set_code", sa.Text(), nullable=True),
+        sa.Column("image_uri", sa.Text(), nullable=True),
+        sa.Column("art_crop_uri", sa.Text(), nullable=True),
+        sa.Column(
+            "synced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        schema="catalog",
+    )
+    op.create_index(
+        "cards_name_idx",
+        "cards",
+        ["name"],
+        schema="catalog",
+    )
+
+    # Analytics owns this table — full privileges on the schema and
+    # the cards table. ALTER DEFAULT PRIVILEGES so any future catalog
+    # tables created by the analytics role inherit the grant.
+    op.execute("GRANT USAGE ON SCHEMA catalog TO deep_analysis_analytics;")
+    op.execute(
+        "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA catalog "
+        "TO deep_analysis_analytics;"
+    )
+    op.execute(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA catalog "
+        "GRANT ALL PRIVILEGES ON TABLES TO deep_analysis_analytics;"
+    )
+
+    # Parser reads cards opportunistically for match enrichment.
+    op.execute("GRANT USAGE ON SCHEMA catalog TO deep_analysis_parser;")
+    op.execute(
+        "GRANT SELECT ON ALL TABLES IN SCHEMA catalog "
+        "TO deep_analysis_parser;"
+    )
+    op.execute(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA catalog "
+        "GRANT SELECT ON TABLES TO deep_analysis_parser;"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA catalog "
+        "REVOKE SELECT ON TABLES FROM deep_analysis_parser;"
+    )
+    op.execute(
+        "REVOKE SELECT ON ALL TABLES IN SCHEMA catalog "
+        "FROM deep_analysis_parser;"
+    )
+    op.execute("REVOKE USAGE ON SCHEMA catalog FROM deep_analysis_parser;")
+
+    op.execute(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA catalog "
+        "REVOKE ALL PRIVILEGES ON TABLES FROM deep_analysis_analytics;"
+    )
+    op.execute(
+        "REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA catalog "
+        "FROM deep_analysis_analytics;"
+    )
+    op.execute("REVOKE USAGE ON SCHEMA catalog FROM deep_analysis_analytics;")
+
+    op.drop_index("cards_name_idx", table_name="cards", schema="catalog")
+    op.drop_table("cards", schema="catalog")
+    op.execute("DROP SCHEMA IF EXISTS catalog CASCADE;")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ ignore = []
 "services/web/web_service/deps.py" = ["B008"]
 "services/analytics/analytics_service/archetypes.py" = ["B008"]
 "services/analytics/analytics_service/stats.py" = ["B008"]
+"services/analytics/analytics_service/main.py" = ["B008"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/services/analytics/analytics_service/main.py
+++ b/services/analytics/analytics_service/main.py
@@ -1,16 +1,118 @@
-from fastapi import FastAPI
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI
 
 from analytics_service.archetypes import router as archetypes_router
+from analytics_service.db import get_sessionmaker
+from analytics_service.deps import AuthenticatedUser, require_admin
+from analytics_service.scryfall_sync import run_sync, should_sync
+from analytics_service.settings import get_settings
 from analytics_service.stats import router as stats_router
 from common.logging import configure_logging
 from common.metrics import mount_metrics
 
 SERVICE_NAME = "analytics"
 configure_logging(SERVICE_NAME)
-app = FastAPI(title=f"deep-analysis-{SERVICE_NAME}")
+
+_log = logging.getLogger("analytics.main")
+
+_scheduler_task: asyncio.Task[None] | None = None
+
+
+def reset_scheduler() -> None:
+    """Test hook."""
+    global _scheduler_task
+    _scheduler_task = None
+
+
+async def _scheduler_loop() -> None:
+    """Sleep-and-check loop driving periodic Scryfall syncs.
+
+    Wakes up on the configured interval and asks ``should_sync`` —
+    runs only when the cadence threshold has elapsed, so a manual
+    admin sync resets the clock and we don't double-sync immediately
+    after.
+    """
+    settings = get_settings()
+    interval_seconds = settings.scryfall_sync_interval_days * 24 * 60 * 60
+    sm = get_sessionmaker()
+    while True:
+        try:
+            async with sm() as session:
+                due = await should_sync(session)
+            if due:
+                await run_sync(sm)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — never let scheduler crash kill the service
+            _log.exception("scryfall scheduler iteration failed")
+        await asyncio.sleep(interval_seconds)
+
+
+async def _start_scheduler() -> None:
+    global _scheduler_task
+    if _scheduler_task is not None:
+        return
+    _scheduler_task = asyncio.create_task(_scheduler_loop(), name="scryfall-scheduler")
+    _log.info("scryfall scheduler task started")
+
+
+async def _stop_scheduler() -> None:
+    global _scheduler_task
+    if _scheduler_task is None:
+        return
+    _scheduler_task.cancel()
+    try:
+        await _scheduler_task
+    except asyncio.CancelledError:
+        pass
+    except Exception:  # noqa: BLE001 — surface but don't crash shutdown
+        _log.exception("scryfall scheduler raised on shutdown")
+    _scheduler_task = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    try:
+        await _start_scheduler()
+    except Exception:  # noqa: BLE001 — healthz still serves even if scheduler fails
+        _log.exception("failed to start scryfall scheduler; healthz remains available")
+    try:
+        yield
+    finally:
+        await _stop_scheduler()
+
+
+app = FastAPI(title=f"deep-analysis-{SERVICE_NAME}", lifespan=lifespan)
 mount_metrics(app, SERVICE_NAME)
 app.include_router(archetypes_router)
 app.include_router(stats_router)
+
+
+admin_router = APIRouter(prefix="/analytics/admin", tags=["admin"])
+
+
+@admin_router.post("/sync-cards", status_code=202)
+async def sync_cards(
+    background_tasks: BackgroundTasks,
+    _admin: AuthenticatedUser = Depends(require_admin),
+) -> dict[str, str]:
+    """Trigger a Scryfall card sync.
+
+    Runs in the background — the bulk-data download + parse + upsert
+    takes minutes; tying up an admin request that long is the wrong
+    shape. Returns 202 immediately; progress shows up in service logs.
+    """
+    background_tasks.add_task(run_sync, get_sessionmaker())
+    return {"status": "sync_started"}
+
+
+app.include_router(admin_router)
 
 
 @app.get("/healthz")

--- a/services/analytics/analytics_service/scryfall_sync.py
+++ b/services/analytics/analytics_service/scryfall_sync.py
@@ -1,0 +1,206 @@
+"""Scryfall bulk-data card mirror.
+
+Periodically downloads Scryfall's "oracle-cards" bulk data and upserts
+it into ``catalog.cards``. The mirror is the analytics service's
+local card-metadata source — downstream features (deck displays, art,
+oracle-text search) read from this table rather than hitting Scryfall
+on every request.
+
+Refresh cadence is governed by ``DA_SCRYFALL_SYNC_INTERVAL_DAYS``
+(default 7). The lifespan task in ``main.py`` checks on startup and
+re-checks on a sleep loop; an admin can also trigger a manual sync via
+``POST /analytics/admin/sync-cards``.
+
+Implementation note — JSON streaming
+------------------------------------
+The bulk-data file is ~80MB and is a single top-level JSON array. We
+download it to a NamedTemporaryFile and then stream-parse from disk
+with sync ``ijson.items``. Two reasons over an httpx → ijson async
+pipeline:
+
+1. ``ijson.items_async`` wants an async file-like with an ``async
+   read()`` method; ``httpx.Response.aiter_bytes()`` is an async
+   iterator of chunks. Bridging the two needs a buffering adapter
+   that earns its keep only on a memory-constrained host — and
+   80MB on disk doesn't qualify.
+2. The download phase is network-bound, the parse phase is CPU-bound.
+   Splitting them keeps each phase simple and easy to observe in logs.
+
+Memory stays flat (~80MB on disk, ~constant in process). The sync
+``ijson`` iteration runs on the event loop thread; this is acceptable
+because the sync runs as a background task at a 7-day cadence, not on
+a user-facing request path. If the periodic blocking ever bites,
+wrap ``ijson.items`` in ``asyncio.to_thread`` per batch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import ijson
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from analytics_service.settings import get_settings
+
+_log = logging.getLogger("analytics.scryfall_sync")
+
+_BULK_DATA_URL = "https://api.scryfall.com/bulk-data/oracle-cards"
+_USER_AGENT = "DeepAnalysis/0.7.5 (self-hosted analytics; contact: admin)"
+_BATCH_SIZE = 500
+_HTTP_TIMEOUT = httpx.Timeout(30.0, read=300.0)
+
+
+@dataclass
+class SyncResult:
+    cards_upserted: int
+    synced_at: datetime
+
+
+_UPSERT_SQL = text(
+    """
+    INSERT INTO catalog.cards (
+        scryfall_id, name, oracle_text, type_line, mana_cost,
+        colors, set_code, image_uri, art_crop_uri, synced_at
+    ) VALUES (
+        :scryfall_id, :name, :oracle_text, :type_line, :mana_cost,
+        CAST(:colors AS jsonb), :set_code, :image_uri, :art_crop_uri,
+        :synced_at
+    )
+    ON CONFLICT (scryfall_id) DO UPDATE SET
+        name = EXCLUDED.name,
+        oracle_text = EXCLUDED.oracle_text,
+        type_line = EXCLUDED.type_line,
+        mana_cost = EXCLUDED.mana_cost,
+        colors = EXCLUDED.colors,
+        set_code = EXCLUDED.set_code,
+        image_uri = EXCLUDED.image_uri,
+        art_crop_uri = EXCLUDED.art_crop_uri,
+        synced_at = EXCLUDED.synced_at
+    """
+)
+
+
+def _card_row(card: dict[str, Any], synced_at: datetime) -> dict[str, Any]:
+    """Project a raw Scryfall card object onto the columns we persist.
+
+    Several fields are routinely absent — double-faced cards, for
+    instance, store ``image_uris`` per face rather than at the top
+    level. We persist null in that case rather than synthesizing a
+    face URI; consumers that need face-aware art can do their own
+    Scryfall lookups.
+    """
+    image_uris = card.get("image_uris") or {}
+    colors = card.get("colors")
+    return {
+        "scryfall_id": card["id"],
+        "name": card["name"],
+        "oracle_text": card.get("oracle_text"),
+        "type_line": card.get("type_line"),
+        "mana_cost": card.get("mana_cost"),
+        # asyncpg's JSONB binding wants a JSON string for raw text();
+        # the explicit CAST in the UPSERT SQL handles the cast.
+        "colors": _jsonb_param(colors),
+        "set_code": card.get("set"),
+        "image_uri": image_uris.get("normal"),
+        "art_crop_uri": image_uris.get("art_crop"),
+        "synced_at": synced_at,
+    }
+
+
+def _jsonb_param(value: Any) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(value)
+
+
+async def _upsert_batch(session: AsyncSession, batch: list[dict[str, Any]]) -> None:
+    await session.execute(_UPSERT_SQL, batch)
+
+
+async def fetch_bulk_data_uri(client: httpx.AsyncClient) -> str:
+    """Resolve the current ``oracle-cards`` download URI from Scryfall.
+
+    Scryfall's bulk-data manifest changes the download URI on each
+    refresh, so we look it up fresh every sync rather than caching.
+    """
+    response = await client.get(_BULK_DATA_URL)
+    response.raise_for_status()
+    payload = response.json()
+    download_uri = payload.get("download_uri")
+    if not download_uri:
+        raise RuntimeError("scryfall bulk-data response missing download_uri")
+    return str(download_uri)
+
+
+async def stream_sync_cards(
+    session: AsyncSession,
+    download_uri: str,
+    client: httpx.AsyncClient,
+) -> SyncResult:
+    """Download the bulk-data file and upsert in batches of 500."""
+    synced_at = datetime.now(UTC)
+    cards_upserted = 0
+
+    with tempfile.NamedTemporaryFile(suffix=".json", mode="w+b") as tmp:
+        async with client.stream("GET", download_uri) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_bytes():
+                tmp.write(chunk)
+        tmp.flush()
+        tmp.seek(0)
+
+        batch: list[dict[str, Any]] = []
+        for card in ijson.items(tmp, "item"):
+            batch.append(_card_row(card, synced_at))
+            if len(batch) >= _BATCH_SIZE:
+                await _upsert_batch(session, batch)
+                cards_upserted += len(batch)
+                batch = []
+        if batch:
+            await _upsert_batch(session, batch)
+            cards_upserted += len(batch)
+
+    await session.commit()
+    return SyncResult(cards_upserted=cards_upserted, synced_at=synced_at)
+
+
+async def should_sync(session: AsyncSession) -> bool:
+    """True if ``catalog.cards`` is empty or the last sync is stale."""
+    settings = get_settings()
+    last = (
+        await session.execute(text("SELECT MAX(synced_at) FROM catalog.cards"))
+    ).scalar_one_or_none()
+    if last is None:
+        return True
+    cutoff = datetime.now(UTC) - timedelta(days=settings.scryfall_sync_interval_days)
+    return last < cutoff
+
+
+async def run_sync(sessionmaker: async_sessionmaker[AsyncSession]) -> SyncResult:
+    """Orchestrate a full Scryfall sync.
+
+    Opens its own DB session and HTTP client — designed to be called
+    standalone (admin endpoint) or from the lifespan scheduler.
+    """
+    _log.info("scryfall sync starting")
+    headers = {"User-Agent": _USER_AGENT, "Accept": "application/json"}
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, headers=headers) as client:
+        download_uri = await fetch_bulk_data_uri(client)
+        _log.info("scryfall bulk-data resolved", extra={"download_uri": download_uri})
+        async with sessionmaker() as session:
+            result = await stream_sync_cards(session, download_uri, client)
+    _log.info(
+        "scryfall sync complete",
+        extra={
+            "cards_upserted": result.cards_upserted,
+            "synced_at": result.synced_at.isoformat(),
+        },
+    )
+    return result

--- a/services/analytics/analytics_service/settings.py
+++ b/services/analytics/analytics_service/settings.py
@@ -14,6 +14,8 @@ class AnalyticsSettings(BaseServiceSettings):
         populate_by_name=True,
     )
 
+    scryfall_sync_interval_days: int = 7
+
 
 _settings: AnalyticsSettings | None = None
 

--- a/services/analytics/pyproject.toml
+++ b/services/analytics/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0",
     "asyncpg>=0.29",
     "psycopg[binary]>=3.1",
+    "httpx>=0.27",
+    "ijson>=3.3",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

- New `catalog.cards` table (separate `catalog` schema) holding a periodic mirror of Scryfall's `oracle-cards` bulk data — analytics owns it, parser gets SELECT for opportunistic enrichment.
- `scryfall_sync.py` streams the ~80MB JSON via temp file + `ijson`, upserts in batches of 500 with `ON CONFLICT (scryfall_id) DO UPDATE`. Memory stays flat. The httpx→ijson async pipeline tradeoff is documented in the module docstring.
- Admin can manually trigger via `POST /analytics/admin/sync-cards` (202 + background task). Lifespan scheduler runs `should_sync` on startup and re-checks on `DA_SCRYFALL_SYNC_INTERVAL_DAYS` cadence (default 7).

## Notes for reviewers

- Dependencies added: `httpx`, `ijson`. Both pre-existed at the repo root; analytics now declares them too.
- Migration 006 is the next free slot on `main`. `feat/mtgo-scraper` has a competing local 006 that's not yet merged — whichever lands first wins; the other will need to renumber.
- `openapi/openapi.yaml` does not exist yet — the dispatch listed an OpenAPI update but the file hasn't been drafted (per `openapi/README.md`, "Spec will be drafted during Phase 2"). Skipped intentionally.
- No new tests; the existing analytics suite (17 tests) still passes. The compose-smoke E2E gate exercises the full stack on this PR.

## Test plan
- [x] `ruff check` clean on modified files
- [x] `mypy` clean on `services/analytics/analytics_service/` (no new errors)
- [x] `services/analytics/tests/` 17/17 passing
- [x] `tests/test_route_prefix_convention.py` covers the new `/analytics/admin/sync-cards` endpoint
- [x] Self-review APPROVED
- [ ] CI compose-smoke E2E green