### PR TITLE
fix(auth): add DEEP_ANALYSIS_FORCE_ADMIN_RESET startup reset

### DIFF
--- a/deploy/seed.sh
+++ b/deploy/seed.sh
@@ -107,6 +107,7 @@ DEEP_ANALYSIS_ACME_EMAIL=ops@sentania.net
 DEPLOY_TAG=latest
 DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=admin@local
 DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=$BOOTSTRAP_ADMIN_PASSWORD
+DEEP_ANALYSIS_FORCE_ADMIN_RESET=true
 EOF
 chmod 0600 "$ENV_FILE"
 
@@ -147,8 +148,10 @@ echo ">> ADMIN BOOTSTRAP CREDENTIALS (save these now):"
 echo "   email:    admin@local"
 echo "   password: $BOOTSTRAP_ADMIN_PASSWORD"
 echo ""
-echo "   The admin user will be created on first 'compose up -d'."
-echo "   Change the password immediately after first login."
+echo "   DEEP_ANALYSIS_FORCE_ADMIN_RESET=true is set in .env."
+echo "   On first 'compose up -d', the auth service will delete any"
+echo "   existing admin@local user and recreate it with the password above."
+echo "   Remove DEEP_ANALYSIS_FORCE_ADMIN_RESET from .env after verifying login."
 echo ""
 echo "NOTE: JWT keys were pushed to $DEPLOY_PATH/.secrets/ but will not"
 echo "be picked up until docker-compose.yml's auth_secrets volume is"

--- a/services/auth/auth_service/bootstrap.py
+++ b/services/auth/auth_service/bootstrap.py
@@ -39,7 +39,51 @@ def _write_initial_password(path: Path, password: str) -> None:
     os.chmod(path, 0o600)
 
 
+async def force_reset_admin(db: AsyncSession, settings: AuthSettings) -> bool:
+    """Delete and recreate the admin user when DEEP_ANALYSIS_FORCE_ADMIN_RESET is set.
+
+    Returns True if a reset was performed, False otherwise.
+    """
+    if not settings.force_admin_reset:
+        return False
+
+    env_email = settings.bootstrap_admin_email
+    env_password = settings.bootstrap_admin_password
+    if not env_email or not env_password:
+        logger.error(
+            "DEEP_ANALYSIS_FORCE_ADMIN_RESET is set but "
+            "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL or "
+            "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD is missing — skipping reset"
+        )
+        return False
+
+    existing = (await db.execute(select(User).where(User.email == env_email))).scalar_one_or_none()
+    if existing is not None:
+        await db.delete(existing)
+        await db.commit()
+
+    user = User(
+        email=env_email,
+        password_hash=hash_password(env_password),
+        role="admin",
+        must_change_password=False,
+        disabled=False,
+    )
+    db.add(user)
+    await db.commit()
+
+    logger.warning(
+        "Admin user reset: %s (DEEP_ANALYSIS_FORCE_ADMIN_RESET was set — "
+        "remove this env var after verifying login)",
+        env_email,
+    )
+    return True
+
+
 async def bootstrap_admin(db: AsyncSession, settings: AuthSettings) -> None:
+    if await force_reset_admin(db, settings):
+        return
+
     existing = (
         await db.execute(
             select(User.id).where(User.role == "admin", User.disabled.is_(False)).limit(1)

--- a/services/auth/auth_service/settings.py
+++ b/services/auth/auth_service/settings.py
@@ -39,6 +39,14 @@ class AuthSettings(BaseServiceSettings):
             "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD",
         ),
     )
+    force_admin_reset: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            "force_admin_reset",
+            "DA_FORCE_ADMIN_RESET",
+            "DEEP_ANALYSIS_FORCE_ADMIN_RESET",
+        ),
+    )
     initial_admin_secret_path: Path = Path("/data/secrets/initial_admin.txt")
 
 


### PR DESCRIPTION
## Summary
- Adds `force_admin_reset` AuthSettings flag (DA_FORCE_ADMIN_RESET / DEEP_ANALYSIS_FORCE_ADMIN_RESET).
- New `force_reset_admin` runs before normal `bootstrap_admin`: when set, deletes any user with the bootstrap email and recreates from env. Logs a warning instructing operators to remove the flag after verifying login.
- `deploy/seed.sh` now writes `DEEP_ANALYSIS_FORCE_ADMIN_RESET=true` into the generated `.env` and prints clearer guidance about the self-heal path.

## Why
The bootstrap admin on edge.int has a corrupted password hash from shell-escaping when seed.sh wrote `.env`. Login fails. The existing bootstrap is a no-op when an admin already exists, so a restart can't fix it. This flag forces a one-shot delete+recreate at auth startup so a fresh deploy self-heals.

## Test plan
- [x] ruff check passes on auth service
- [x] ruff format passes on auth service
- [x] mypy: no new errors (pre-existing errors in admin.py unchanged)
- [ ] On edge.int next deploy: confirm admin login works with seeded password, then remove `DEEP_ANALYSIS_FORCE_ADMIN_RESET` from `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)