### PR TITLE
feat: agent registration UX — registration-code UI + credentials endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ project follows [Semantic Versioning](https://semver.org/) loosely while
 in pre-1.0; expect minor versions to introduce breaking changes until the
 API surface stabilizes.
 
+## v0.7.12 — 2026-05-10
+
+### Added
+
+- **Agent registration code UI.** Profile agents page (`/profile/agents`) now
+  has a "Register New Agent" section with a "Generate Registration Code" button.
+  On click, the code is displayed prominently with its 10-minute expiry and
+  copy instructions.
+
+- **`POST /auth/agent/register-with-credentials`.** One-step agent registration
+  endpoint: accepts `{email, password, agent_name, client_version}`, authenticates
+  the user, and returns `{agent_id, api_token, user_id}` — same response as the
+  code-based flow. Allows agents to offer username/password registration without
+  a separate UI step. Rejects admin users (same guard as existing register endpoint).
+
 ## v0.7.5 — 2026-05-10
 
 ### Fixed

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -44,6 +44,7 @@ from auth_service.schemas import (
     AgentListView,
     AgentRegisterRequest,
     AgentRegisterResponse,
+    AgentRegisterWithCredentialsRequest,
     AgentRegistrationCodeResponse,
     AgentView,
     LoginRequest,
@@ -529,6 +530,83 @@ async def register_agent(
     await db.commit()
     await db.refresh(agent)
 
+    return AgentRegisterResponse(
+        agent_id=agent.id,
+        api_token=api_token,
+        user_id=user_id,
+    )
+
+
+@app.post(
+    "/auth/agent/register-with-credentials",
+    response_model=AgentRegisterResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def register_agent_with_credentials(
+    body: AgentRegisterWithCredentialsRequest,
+    redis: Redis = Depends(get_redis),
+    db: AsyncSession = Depends(get_session),
+) -> AgentRegisterResponse:
+    """One-step agent registration: authenticate + register in a single call.
+
+    Accepts {email, password, agent_name, client_version}. Authenticates the
+    user with the same logic as /auth/login, auto-mints a registration code,
+    immediately consumes it, and returns {agent_id, api_token, user_id} —
+    the same payload as the code-based flow.
+
+    Rejects admin users (matches the role split that /auth/agent/register
+    enforces at consume time). Does not create a browser session, so no
+    refresh token is issued.
+    """
+    user = (
+        await db.execute(select(User).where(func.lower(User.email) == body.email.lower()))
+    ).scalar_one_or_none()
+    if user is None or user.disabled:
+        raise _INVALID_CREDENTIALS
+    if not verify_password(body.password, user.password_hash):
+        raise _INVALID_CREDENTIALS
+
+    if user.role != "user":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "admin_cannot_register_agent"},
+        )
+
+    # Mint + consume immediately. Going through the existing helpers
+    # keeps this flow symmetric with the code-based one — same Redis
+    # primitive, same atomic GETDEL — so a future change to either
+    # flow lands in one place. The 30s TTL is paranoia padding; in
+    # practice the consume happens microseconds after the store.
+    code = generate_registration_code()
+    await store_registration_code(redis, code, user.id, ttl_seconds=30)
+    user_id = await consume_registration_code(redis, code)
+    if user_id is None:
+        # Implies a Redis flush or eviction within microseconds of our
+        # own store — operationally exceptional, but worth surfacing
+        # rather than papering over with a silent retry.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "registration_code_race"},
+        )
+
+    api_token = generate_api_token()
+    now = datetime.now(UTC)
+    agent = AgentRegistration(
+        user_id=user_id,
+        machine_name=body.agent_name,
+        api_token_hash=hash_api_token(api_token),
+        created_at=now,
+        last_seen_at=now,
+        client_version=body.client_version,
+    )
+    db.add(agent)
+    await db.commit()
+    await db.refresh(agent)
+
+    _log.info(
+        "auth.agent.register_with_credentials.success",
+        extra={"agent_id": str(agent.id), "user_id": user_id},
+    )
     return AgentRegisterResponse(
         agent_id=agent.id,
         api_token=api_token,

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -206,3 +206,10 @@ class RegisterRequest(BaseModel):
 class RegisterResponse(BaseModel):
     user_id: int
     email: str
+
+
+class AgentRegisterWithCredentialsRequest(BaseModel):
+    email: str = Field(min_length=1, max_length=320)
+    password: str = Field(min_length=1)
+    agent_name: str = Field(min_length=1, max_length=255)
+    client_version: str = Field(min_length=1, max_length=64)

--- a/services/auth/tests/test_agent_register_with_credentials.py
+++ b/services/auth/tests/test_agent_register_with_credentials.py
@@ -1,0 +1,119 @@
+"""POST /auth/agent/register-with-credentials tests.
+
+One-step agent registration: authenticate via email+password and
+return {agent_id, api_token, user_id} in a single call. Lets agents
+ship a username/password registration UX without a separate code
+copy-paste step.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from auth_service.models import User
+from auth_service.passwords import hash_password
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_register_with_credentials_success(client: Any, seed_user: dict[str, Any]) -> None:
+    r = await client.post(
+        "/auth/agent/register-with-credentials",
+        json={
+            "email": seed_user["email"],
+            "password": seed_user["password"],
+            "agent_name": "laptop-1",
+            "client_version": "0.7.12",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["agent_id"]
+    assert body["api_token"]
+    assert body["user_id"] == seed_user["id"]
+
+
+@pytest.mark.asyncio
+async def test_register_with_credentials_wrong_password(
+    client: Any, seed_user: dict[str, Any]
+) -> None:
+    r = await client.post(
+        "/auth/agent/register-with-credentials",
+        json={
+            "email": seed_user["email"],
+            "password": "definitely-not-the-password",
+            "agent_name": "laptop-1",
+            "client_version": "0.7.12",
+        },
+    )
+    assert r.status_code == 401
+    assert r.json() == {"detail": {"error": "invalid_credentials"}}
+
+
+@pytest.mark.asyncio
+async def test_register_with_credentials_unknown_email(client: Any) -> None:
+    r = await client.post(
+        "/auth/agent/register-with-credentials",
+        json={
+            "email": "nobody@example.com",
+            "password": "anything",
+            "agent_name": "laptop-1",
+            "client_version": "0.7.12",
+        },
+    )
+    assert r.status_code == 401
+    assert r.json() == {"detail": {"error": "invalid_credentials"}}
+
+
+@pytest.mark.asyncio
+async def test_register_with_credentials_rejects_admin(
+    client: Any, db_session: AsyncSession
+) -> None:
+    """Mirrors the role guard on POST /auth/agent/register: admins
+    can't own agents under the W3.6.1 hard role split."""
+    admin = User(
+        email="admin-cred-reg@example.com",
+        password_hash=hash_password("AdminPw2026!"),
+        role="admin",
+    )
+    db_session.add(admin)
+    await db_session.commit()
+
+    r = await client.post(
+        "/auth/agent/register-with-credentials",
+        json={
+            "email": "admin-cred-reg@example.com",
+            "password": "AdminPw2026!",
+            "agent_name": "laptop-1",
+            "client_version": "0.7.12",
+        },
+    )
+    assert r.status_code == 403
+    assert r.json() == {"detail": {"error": "admin_cannot_register_agent"}}
+
+
+@pytest.mark.asyncio
+async def test_register_with_credentials_disabled_user(
+    client: Any, db_session: AsyncSession
+) -> None:
+    user = User(
+        email="disabled-cred-reg@example.com",
+        password_hash=hash_password("DisabledPw2026!"),
+        role="user",
+        disabled=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    r = await client.post(
+        "/auth/agent/register-with-credentials",
+        json={
+            "email": "disabled-cred-reg@example.com",
+            "password": "DisabledPw2026!",
+            "agent_name": "laptop-1",
+            "client_version": "0.7.12",
+        },
+    )
+    assert r.status_code == 401
+    assert r.json() == {"detail": {"error": "invalid_credentials"}}

--- a/services/web/tests/test_profile_agents_reg_code_route.py
+++ b/services/web/tests/test_profile_agents_reg_code_route.py
@@ -1,0 +1,222 @@
+"""POST /profile/agents/registration-code route tests.
+
+Covers the W3.5-B+ agent registration UX: clicking "Generate
+Registration Code" on /profile/agents posts here, the handler asks
+auth to mint a code, then re-renders the agents page with the code
+displayed for the user to enter into their agent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(token: str = "fake-tok") -> Any:
+    from web_service import deps as _deps
+
+    fake_user = _deps.BrowserUser(
+        user_id=42,
+        email="u@example.com",
+        role="user",
+        must_change_password=False,
+        scope=None,
+        token=token,
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_user
+
+    return _dep, fake_user
+
+
+@pytest.mark.asyncio
+async def test_post_registration_code_renders_code(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import auth_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    expires = datetime.now(UTC) + timedelta(minutes=10)
+
+    async def fake_mint(_url: str, _token: str) -> auth_client.RegistrationCodeResult:
+        return auth_client.RegistrationCodeResult(code="ABCD-EFGH", expires_at=expires)
+
+    async def fake_list(
+        _url: str, _token: str, limit: int = 50, offset: int = 0
+    ) -> tuple[list[auth_client.AgentItem], int]:
+        return [], 0
+
+    monkeypatch.setattr(auth_client, "mint_registration_code", fake_mint)
+    monkeypatch.setattr(auth_client, "list_my_agents", fake_list)
+    dep, _ = _override_user()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post("/profile/agents/registration-code")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "ABCD-EFGH" in r.text
+    assert "Register New Agent" in r.text
+
+
+@pytest.mark.asyncio
+async def test_post_registration_code_tolerates_list_outage(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The list refetch is best-effort. If it fails, the code still
+    renders so the user can complete the registration."""
+    from web_service import auth_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    expires = datetime.now(UTC) + timedelta(minutes=10)
+
+    async def fake_mint(_url: str, _token: str) -> auth_client.RegistrationCodeResult:
+        return auth_client.RegistrationCodeResult(code="WXYZ-1234", expires_at=expires)
+
+    async def boom_list(*_a: Any, **_kw: Any) -> Any:
+        raise auth_client.AuthClientError("list failed")
+
+    monkeypatch.setattr(auth_client, "mint_registration_code", fake_mint)
+    monkeypatch.setattr(auth_client, "list_my_agents", boom_list)
+    dep, _ = _override_user()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post("/profile/agents/registration-code")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "WXYZ-1234" in r.text
+
+
+@pytest.mark.asyncio
+async def test_post_registration_code_redirects_to_login_on_auth_forbidden(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import auth_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise auth_client.AuthForbidden("simulated session revocation")
+
+    monkeypatch.setattr(auth_client, "mint_registration_code", boom)
+    dep, _ = _override_user()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post("/profile/agents/registration-code")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 302
+    assert r.headers["location"] == "/login"
+
+
+@pytest.mark.asyncio
+async def test_post_registration_code_503_when_auth_unreachable(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import auth_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise auth_client.AuthClientError("simulated outage")
+
+    monkeypatch.setattr(auth_client, "mint_registration_code", boom)
+    dep, _ = _override_user()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post("/profile/agents/registration-code")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 503
+    assert "unavailable" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_post_registration_code_admin_bounces_to_panel(
+    app_client: httpx.AsyncClient,
+) -> None:
+    """Admins have no self-service surface; should redirect to /admin/users."""
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    admin_user = _deps.BrowserUser(
+        user_id=1,
+        email="admin@local",
+        role="admin",
+        must_change_password=False,
+        scope=None,
+        token="admin-tok",
+    )
+
+    async def dep() -> _deps.BrowserUser:
+        return admin_user
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post("/profile/agents/registration-code")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 302
+    assert r.headers["location"] == "/admin/users"
+
+
+@pytest.mark.asyncio
+async def test_get_profile_agents_shows_register_section(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Register New Agent section renders even when no code has
+    been minted yet — the form is the entry point for minting."""
+    from web_service import auth_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_list(
+        _url: str, _token: str, limit: int = 50, offset: int = 0
+    ) -> tuple[list[auth_client.AgentItem], int]:
+        return [], 0
+
+    monkeypatch.setattr(auth_client, "list_my_agents", fake_list)
+    dep, _ = _override_user()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/profile/agents")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Register New Agent" in r.text
+    assert "/profile/agents/registration-code" in r.text
+    assert "Generate Registration Code" in r.text

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -475,6 +475,39 @@ async def admin_revoke_agent(
 
 
 @dataclass
+class RegistrationCodeResult:
+    code: str
+    expires_at: datetime
+
+
+async def mint_registration_code(base_url: str, token: str) -> RegistrationCodeResult:
+    """POST /auth/agent/registration-code. Returns code + expires_at.
+
+    401/403 raise :class:`AuthForbidden`; transport / 5xx / other
+    non-2xx raise :class:`AuthClientError`.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{base_url}/auth/agent/registration-code",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AuthClientError(f"auth /agent/registration-code transport error: {exc}") from exc
+    if resp.status_code in (401, 403):
+        raise AuthForbidden(f"auth /agent/registration-code returned {resp.status_code}")
+    if resp.status_code != 201:
+        raise AuthClientError(
+            f"auth /agent/registration-code returned {resp.status_code}: {resp.text}"
+        )
+    data = resp.json()
+    expires_at = _parse_dt(data.get("expires_at"))
+    if expires_at is None:
+        raise AuthClientError("auth /agent/registration-code response missing parseable expires_at")
+    return RegistrationCodeResult(code=str(data["code"]), expires_at=expires_at)
+
+
+@dataclass
 class RegistrationMode:
     mode: str  # "open" | "invite_only"
     updated_at: datetime | None

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -473,6 +473,51 @@ async def profile_agents(
     )
 
 
+@app.post("/profile/agents/registration-code")
+async def profile_agents_generate_code(
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    bounce = _bounce_admin_to_panel(user)
+    if bounce is not None:
+        return bounce
+    try:
+        result = await auth_client.mint_registration_code(settings.auth_service_url, user.token)
+    except auth_client.AuthForbidden:
+        _log.info("profile.agents.registration_code.forbidden", extra={"user_id": user.user_id})
+        return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
+    except auth_client.AuthClientError:
+        _log.exception("auth /agent/registration-code call failed")
+        return _service_unavailable(request, user)
+
+    # Re-render the agents page with the freshly minted code. List
+    # fetch is best-effort — surfacing the code matters more than the
+    # list, so we tolerate an empty list if auth is mid-glitch.
+    offset = 0
+    per_page = _PROFILE_AGENTS_DEFAULT_PER_PAGE
+    try:
+        agents, total = await auth_client.list_my_agents(
+            settings.auth_service_url, user.token, limit=per_page, offset=offset
+        )
+    except (auth_client.AuthForbidden, auth_client.AuthClientError):
+        agents, total = [], 0
+
+    return templates.TemplateResponse(
+        request,
+        "profile_agents.html",
+        {
+            "user": user,
+            "agents": agents,
+            "total": total,
+            "page": 1,
+            "per_page": per_page,
+            "registration_code": result.code,
+            "registration_code_expires_at": result.expires_at,
+        },
+    )
+
+
 @app.post("/profile/agents/{agent_id}/revoke")
 async def profile_agents_revoke(
     # Typed UUID rejects malformed IDs at the route boundary with 422,

--- a/services/web/web_service/templates/profile_agents.html
+++ b/services/web/web_service/templates/profile_agents.html
@@ -6,6 +6,59 @@
 <section class="panel">
     <h1>My agents</h1>
     <p><a href="/profile">&larr; Back to profile</a></p>
+
+    <section class="register-agent">
+        <h2>Register New Agent</h2>
+        <p class="muted">
+            Generate a one-time code, then enter it in your Deep Analysis
+            agent to link it to your account.
+        </p>
+        <form method="post" action="/profile/agents/registration-code">
+            <button type="submit" class="btn btn-primary">Generate Registration Code</button>
+        </form>
+        {% if registration_code %}
+        <div class="registration-code-card" role="status">
+            <p class="muted">Your registration code:</p>
+            <pre id="registration-code-block"><code>{{ registration_code }}</code></pre>
+            <p>
+                <button type="button"
+                        class="btn"
+                        onclick="copyRegistrationCode()"
+                        id="copy-registration-code-btn">Copy</button>
+            </p>
+            <p class="muted">
+                Expires {{ registration_code_expires_at.strftime("%H:%M UTC") }}.
+                Enter this code in your Deep Analysis agent to register it.
+                The code expires in 10 minutes.
+            </p>
+        </div>
+        <script>
+        function copyRegistrationCode() {
+            var code = {{ registration_code | tojson }};
+            var btn = document.getElementById("copy-registration-code-btn");
+            var done = function () {
+                if (btn) {
+                    var original = btn.textContent;
+                    btn.textContent = "Copied";
+                    setTimeout(function () { btn.textContent = original; }, 1500);
+                }
+            };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(code).then(done, done);
+                return;
+            }
+            var ta = document.createElement("textarea");
+            ta.value = code;
+            document.body.appendChild(ta);
+            ta.select();
+            try { document.execCommand("copy"); } catch (e) { /* ignore */ }
+            document.body.removeChild(ta);
+            done();
+        }
+        </script>
+        {% endif %}
+    </section>
+
     {% if not agents %}
         <p>No agents registered yet.</p>
     {% else %}

--- a/tests/test_route_prefix_convention.py
+++ b/tests/test_route_prefix_convention.py
@@ -58,6 +58,7 @@ _WEB_BROWSER_PATHS = frozenset(
         "/profile",
         "/profile/edit",
         "/profile/agents",
+        "/profile/agents/registration-code",
         "/profile/agents/{agent_id}/revoke",
         "/admin/users",
         "/admin/users/{user_id}/delete",


### PR DESCRIPTION
## Summary

Two pieces of agent-registration UX, both shipping as v0.7.12.

- **Web UI: registration-code generator on `/profile/agents`.** Adds a "Register New Agent" section with a "Generate Registration Code" button. Clicking it calls the auth service via the web service's `auth_client.mint_registration_code()`, then displays the one-time code and its 10-minute expiry. Lets users mint codes from the dashboard instead of via CLI.
- **Auth: one-step `POST /auth/agent/register-with-credentials`.** New endpoint accepts `{email, password, agent_name, client_version}`, authenticates the user, and returns `{agent_id, api_token, user_id}` — the same shape as the existing code-based register endpoint. Carries the same admin-rejection guard. Allows the agent client to register against username/password without a separate code-mint step.

## Test plan

- [x] Ruff check + format clean
- [x] Mypy: no new errors vs main (12 pre-existing import-stub errors unchanged)
- [x] Auth tests: happy path, bad creds, admin rejection (`services/auth/tests/test_agent_register_with_credentials.py`)
- [x] Web tests: route, auth-client call, template rendering (`services/web/tests/test_profile_agents_reg_code_route.py`)
- [x] Self-review APPROVED
- [ ] Post-merge: tag v0.7.12 triggers release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)