### PR TITLE
fix(auth): enforce UID 1 = admin@local invariant

### DIFF
--- a/services/auth/alembic/versions/005_users_id_on_update_cascade.py
+++ b/services/auth/alembic/versions/005_users_id_on_update_cascade.py
@@ -1,0 +1,97 @@
+"""Add ON UPDATE CASCADE to all FKs referencing auth.users.id.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-05-10
+
+Background
+----------
+The UID 1 = admin@local invariant requires reclaim_uid1 to move
+admin@local back to id=1 when it has drifted. The raw UPDATE
+``auth.users SET id = 1`` fails at end-of-statement under the
+default ON UPDATE NO ACTION semantics whenever child tables
+(``sessions``, ``agent_registrations``, ``server_settings``,
+``invite_tokens``) still reference the old id. Switching the five
+inbound FKs to ON UPDATE CASCADE lets PostgreSQL propagate the new
+parent id to children automatically, preserving sessions, agent
+registrations, audit pointers, and invite history through the
+reclaim.
+
+ON DELETE behavior is unchanged: CASCADE for sessions and
+agent_registrations, SET NULL for server_settings audit pointer and
+the two invite_tokens audit pointers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# (table, column, fk_name, ondelete) — fk_name follows PostgreSQL's
+# default <table>_<column>_fkey since none of the prior migrations
+# named these constraints.
+_FKS = [
+    ("sessions", "user_id", "sessions_user_id_fkey", "CASCADE"),
+    (
+        "agent_registrations",
+        "user_id",
+        "agent_registrations_user_id_fkey",
+        "CASCADE",
+    ),
+    (
+        "server_settings",
+        "updated_by_user_id",
+        "server_settings_updated_by_user_id_fkey",
+        "SET NULL",
+    ),
+    (
+        "invite_tokens",
+        "created_by_user_id",
+        "invite_tokens_created_by_user_id_fkey",
+        "SET NULL",
+    ),
+    (
+        "invite_tokens",
+        "used_by_user_id",
+        "invite_tokens_used_by_user_id_fkey",
+        "SET NULL",
+    ),
+]
+
+
+def upgrade() -> None:
+    for table, column, fk_name, ondelete in _FKS:
+        op.drop_constraint(fk_name, table, type_="foreignkey", schema="auth")
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "users",
+            [column],
+            ["id"],
+            source_schema="auth",
+            referent_schema="auth",
+            ondelete=ondelete,
+            onupdate="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    for table, column, fk_name, ondelete in _FKS:
+        op.drop_constraint(fk_name, table, type_="foreignkey", schema="auth")
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "users",
+            [column],
+            ["id"],
+            source_schema="auth",
+            referent_schema="auth",
+            ondelete=ondelete,
+        )

--- a/services/auth/auth_service/bootstrap.py
+++ b/services/auth/auth_service/bootstrap.py
@@ -12,9 +12,10 @@ import contextlib
 import logging
 import os
 import secrets
+from datetime import UTC, datetime
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth_service.models import User
@@ -24,6 +25,53 @@ from auth_service.settings import AuthSettings
 logger = logging.getLogger("auth.bootstrap")
 
 _DEFAULT_ADMIN_EMAIL = "admin@local"
+
+
+async def _resync_users_id_sequence(db: AsyncSession) -> None:
+    """Resync auth.users id sequence to MAX(id) after an explicit-id insert.
+
+    PostgreSQL serial sequences are not advanced by inserts with explicit
+    values; without this, the next sequence-driven insert collides.
+    """
+    await db.execute(
+        text(
+            "SELECT setval(pg_get_serial_sequence('auth.users', 'id'), "
+            "GREATEST(1, (SELECT COALESCE(MAX(id), 1) FROM auth.users)), true)"
+        )
+    )
+    await db.commit()
+
+
+async def reclaim_uid1(db: AsyncSession) -> None:
+    """Reclaim UID 1 for admin@local if it has drifted to another id.
+
+    Runs on every startup before any other admin bootstrap step. No-op
+    unless admin@local exists at id != 1 AND UID 1 is currently free.
+    If UID 1 is held by a different account, logs an error and leaves
+    state untouched — manual intervention required.
+    """
+    admin = (
+        await db.execute(select(User).where(User.email == _DEFAULT_ADMIN_EMAIL))
+    ).scalar_one_or_none()
+    if admin is None or admin.id == 1:
+        return
+
+    uid1_holder = (await db.execute(select(User).where(User.id == 1))).scalar_one_or_none()
+    if uid1_holder is None:
+        old_id = admin.id
+        await db.execute(
+            text("UPDATE auth.users SET id = 1 WHERE email = :email"),
+            {"email": _DEFAULT_ADMIN_EMAIL},
+        )
+        await db.commit()
+        await _resync_users_id_sequence(db)
+        logger.warning("admin@local was at id=%s; reclaimed id=1", old_id)
+        return
+
+    logger.error(
+        "admin@local has id=%s but id=1 is taken — manual intervention required",
+        admin.id,
+    )
 
 
 def _write_initial_password(path: Path, password: str) -> None:
@@ -40,7 +88,14 @@ def _write_initial_password(path: Path, password: str) -> None:
 
 
 async def force_reset_admin(db: AsyncSession, settings: AuthSettings) -> bool:
-    """Delete and recreate the admin user when DEEP_ANALYSIS_FORCE_ADMIN_RESET is set.
+    """Reset the admin password when DEEP_ANALYSIS_FORCE_ADMIN_RESET is set.
+
+    Behavior depends on current state:
+    - If a user with ``env_email`` already exists, update their
+      ``password_hash`` in place. Their id is preserved.
+    - Else if UID 1 is held by a different account, log an error and
+      return False — refuse to clobber UID 1.
+    - Else insert a fresh admin with explicit ``id=1``.
 
     Returns True if a reset was performed, False otherwise.
     """
@@ -59,10 +114,31 @@ async def force_reset_admin(db: AsyncSession, settings: AuthSettings) -> bool:
 
     existing = (await db.execute(select(User).where(User.email == env_email))).scalar_one_or_none()
     if existing is not None:
-        await db.delete(existing)
+        existing.password_hash = hash_password(env_password)
+        existing.must_change_password = False
+        existing.disabled = False
+        existing.role = "admin"
+        existing.updated_at = datetime.now(UTC)
         await db.commit()
+        logger.warning(
+            "Admin password reset in place for %s (DEEP_ANALYSIS_FORCE_ADMIN_RESET was set — "
+            "remove this env var after verifying login)",
+            env_email,
+        )
+        return True
+
+    uid1_holder = (await db.execute(select(User).where(User.id == 1))).scalar_one_or_none()
+    if uid1_holder is not None:
+        logger.error(
+            "DEEP_ANALYSIS_FORCE_ADMIN_RESET: no user with email=%s but id=1 is "
+            "held by %s — refusing to clobber UID 1",
+            env_email,
+            uid1_holder.email,
+        )
+        return False
 
     user = User(
+        id=1,
         email=env_email,
         password_hash=hash_password(env_password),
         role="admin",
@@ -71,9 +147,10 @@ async def force_reset_admin(db: AsyncSession, settings: AuthSettings) -> bool:
     )
     db.add(user)
     await db.commit()
+    await _resync_users_id_sequence(db)
 
     logger.warning(
-        "Admin user reset: %s (DEEP_ANALYSIS_FORCE_ADMIN_RESET was set — "
+        "Admin user created at id=1: %s (DEEP_ANALYSIS_FORCE_ADMIN_RESET was set — "
         "remove this env var after verifying login)",
         env_email,
     )
@@ -81,6 +158,8 @@ async def force_reset_admin(db: AsyncSession, settings: AuthSettings) -> bool:
 
 
 async def bootstrap_admin(db: AsyncSession, settings: AuthSettings) -> None:
+    await reclaim_uid1(db)
+
     if await force_reset_admin(db, settings):
         return
 
@@ -108,6 +187,7 @@ async def bootstrap_admin(db: AsyncSession, settings: AuthSettings) -> None:
         must_change = True
 
     user = User(
+        id=1,
         email=email,
         password_hash=hash_password(password),
         role="admin",
@@ -116,6 +196,7 @@ async def bootstrap_admin(db: AsyncSession, settings: AuthSettings) -> None:
     )
     db.add(user)
     await db.commit()
+    await _resync_users_id_sequence(db)
 
     if scripted:
         logger.warning(

--- a/services/auth/tests/test_bootstrap.py
+++ b/services/auth/tests/test_bootstrap.py
@@ -97,7 +97,10 @@ async def test_bootstrap_noop_when_admin_exists(db_session: AsyncSession, tmp_pa
 async def test_bootstrap_noop_when_disabled_admin_has_other_active(
     db_session: AsyncSession, tmp_path: Path
 ) -> None:
+    # Pin the disabled admin to id=2 so UID 1 stays free for the
+    # admin@local bootstrap insert (which pins to id=1).
     disabled_admin = User(
+        id=2,
         email="old-admin@example.com",
         password_hash=hash_password("pw"),
         role="admin",
@@ -397,6 +400,11 @@ async def test_reclaim_uid1_cascades_to_sessions_and_agents(
     await db_session.commit()
 
     await reclaim_uid1(db_session)
+
+    # CASCADE happens in the database; clear the ORM identity map so the
+    # next selects re-read user_id from the DB rather than returning the
+    # cached pre-update objects.
+    db_session.expire_all()
 
     reclaimed = (
         await db_session.execute(select(User).where(User.email == "admin@local"))

--- a/services/auth/tests/test_bootstrap.py
+++ b/services/auth/tests/test_bootstrap.py
@@ -6,11 +6,11 @@ import os
 from pathlib import Path
 
 import pytest
-from auth_service.bootstrap import bootstrap_admin, force_reset_admin
+from auth_service.bootstrap import bootstrap_admin, force_reset_admin, reclaim_uid1
 from auth_service.models import User
 from auth_service.passwords import hash_password, verify_password
 from auth_service.settings import AuthSettings
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -156,11 +156,11 @@ async def test_bootstrap_env_var_path_idempotent_on_restart(
 
 
 @pytest.mark.asyncio
-async def test_force_reset_replaces_existing_admin(
+async def test_force_reset_updates_password_in_place(
     db_session: AsyncSession, tmp_path: Path
 ) -> None:
-    """force_admin_reset=True with valid env credentials deletes the existing
-    user with that email and recreates from env."""
+    """force_admin_reset=True with valid env credentials updates the
+    existing user's password hash in place — preserving their id."""
     existing = User(
         email="admin@local",
         password_hash=hash_password("garbled-old-hash"),
@@ -185,7 +185,7 @@ async def test_force_reset_replaces_existing_admin(
     )
     assert len(admins) == 1
     admin = admins[0]
-    assert admin.id != old_id
+    assert admin.id == old_id
     assert admin.role == "admin"
     assert admin.disabled is False
     assert admin.must_change_password is False
@@ -260,8 +260,8 @@ async def test_force_reset_disabled_by_default(db_session: AsyncSession, tmp_pat
 async def test_bootstrap_admin_invokes_force_reset_first(
     db_session: AsyncSession, tmp_path: Path
 ) -> None:
-    """When force_admin_reset is set, bootstrap_admin replaces the existing
-    admin instead of treating it as already-bootstrapped."""
+    """When force_admin_reset is set, bootstrap_admin updates the existing
+    admin's password instead of treating it as already-bootstrapped."""
     existing = User(
         email="admin@local",
         password_hash=hash_password("garbled"),
@@ -281,6 +281,267 @@ async def test_bootstrap_admin_invokes_force_reset_first(
     await bootstrap_admin(db_session, settings)
 
     admin = (await db_session.execute(select(User).where(User.email == "admin@local"))).scalar_one()
-    assert admin.id != old_id
+    assert admin.id == old_id
     assert verify_password("resetviabootstrap", admin.password_hash)
     assert not settings.initial_admin_secret_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_creates_admin_at_id_1(db_session: AsyncSession, tmp_path: Path) -> None:
+    """Empty-table bootstrap pins the admin to UID 1, not the next
+    sequence value."""
+    settings = _fresh_settings(tmp_path)
+    await bootstrap_admin(db_session, settings)
+
+    admin = (await db_session.execute(select(User).where(User.email == "admin@local"))).scalar_one()
+    assert admin.id == 1
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_id_1_pin_does_not_break_next_insert(
+    db_session: AsyncSession, tmp_path: Path
+) -> None:
+    """After explicit-id=1 insert, the users sequence is resynced so the
+    next user-driven insert does not collide on id=1."""
+    settings = _fresh_settings(tmp_path)
+    await bootstrap_admin(db_session, settings)
+
+    other = User(
+        email="someone-else@example.com",
+        password_hash=hash_password("pw"),
+        role="user",
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+    assert other.id > 1
+
+
+@pytest.mark.asyncio
+async def test_reclaim_uid1_moves_admin_when_id_1_is_free(
+    db_session: AsyncSession,
+) -> None:
+    """admin@local sitting at id != 1 with UID 1 free is reclaimed to id=1."""
+    placeholder = User(
+        email="placeholder@example.com",
+        password_hash=hash_password("pw"),
+        role="user",
+    )
+    db_session.add(placeholder)
+    await db_session.commit()
+
+    admin = User(
+        email="admin@local",
+        password_hash=hash_password("pw"),
+        role="admin",
+    )
+    db_session.add(admin)
+    await db_session.commit()
+    assert admin.id != 1
+
+    await db_session.execute(text("DELETE FROM auth.users WHERE email = 'placeholder@example.com'"))
+    await db_session.commit()
+
+    await reclaim_uid1(db_session)
+
+    reclaimed = (
+        await db_session.execute(select(User).where(User.email == "admin@local"))
+    ).scalar_one()
+    assert reclaimed.id == 1
+
+
+@pytest.mark.asyncio
+async def test_reclaim_uid1_cascades_to_sessions_and_agents(
+    db_session: AsyncSession,
+) -> None:
+    """When admin@local has child rows pointing at the old id, the
+    ON UPDATE CASCADE FK propagates the new id=1 to sessions and
+    agent_registrations. No FK violation, no data loss."""
+    from datetime import UTC, datetime, timedelta
+
+    from auth_service.models import AgentRegistration, Session
+
+    placeholder = User(
+        email="placeholder@example.com",
+        password_hash=hash_password("pw"),
+        role="user",
+    )
+    db_session.add(placeholder)
+    await db_session.commit()
+
+    admin = User(
+        email="admin@local",
+        password_hash=hash_password("pw"),
+        role="admin",
+    )
+    db_session.add(admin)
+    await db_session.commit()
+    old_admin_id = admin.id
+    assert old_admin_id != 1
+
+    session = Session(
+        user_id=old_admin_id,
+        refresh_token_hash="hash-for-reclaim-test",
+        expires_at=datetime.now(UTC) + timedelta(days=1),
+    )
+    agent = AgentRegistration(
+        user_id=old_admin_id,
+        machine_name="reclaim-test-host",
+        api_token_hash="agent-hash-for-reclaim-test",
+    )
+    db_session.add(session)
+    db_session.add(agent)
+    await db_session.commit()
+
+    await db_session.execute(text("DELETE FROM auth.users WHERE email = 'placeholder@example.com'"))
+    await db_session.commit()
+
+    await reclaim_uid1(db_session)
+
+    reclaimed = (
+        await db_session.execute(select(User).where(User.email == "admin@local"))
+    ).scalar_one()
+    assert reclaimed.id == 1
+
+    refreshed_session = (
+        await db_session.execute(
+            select(Session).where(Session.refresh_token_hash == "hash-for-reclaim-test")
+        )
+    ).scalar_one()
+    refreshed_agent = (
+        await db_session.execute(
+            select(AgentRegistration).where(
+                AgentRegistration.api_token_hash == "agent-hash-for-reclaim-test"
+            )
+        )
+    ).scalar_one()
+    assert refreshed_session.user_id == 1
+    assert refreshed_agent.user_id == 1
+
+
+@pytest.mark.asyncio
+async def test_reclaim_uid1_noop_when_admin_already_at_id_1(
+    db_session: AsyncSession,
+) -> None:
+    """admin@local already at id=1 — reclaim is a no-op."""
+    admin = User(
+        id=1,
+        email="admin@local",
+        password_hash=hash_password("pw"),
+        role="admin",
+    )
+    db_session.add(admin)
+    await db_session.commit()
+
+    await reclaim_uid1(db_session)
+
+    fetched = (
+        await db_session.execute(select(User).where(User.email == "admin@local"))
+    ).scalar_one()
+    assert fetched.id == 1
+
+
+@pytest.mark.asyncio
+async def test_reclaim_uid1_noop_when_admin_missing(db_session: AsyncSession) -> None:
+    """No admin@local user — reclaim is a no-op (no rows touched)."""
+    other = User(
+        email="someone@example.com",
+        password_hash=hash_password("pw"),
+        role="user",
+    )
+    db_session.add(other)
+    await db_session.commit()
+    other_id = other.id
+
+    await reclaim_uid1(db_session)
+
+    fetched = (
+        await db_session.execute(select(User).where(User.email == "someone@example.com"))
+    ).scalar_one()
+    assert fetched.id == other_id
+
+
+@pytest.mark.asyncio
+async def test_reclaim_uid1_refuses_when_id_1_taken(db_session: AsyncSession) -> None:
+    """admin@local at id != 1 with UID 1 held by another account — refuse
+    to clobber. Both rows remain at their original ids."""
+    squatter = User(
+        id=1,
+        email="squatter@example.com",
+        password_hash=hash_password("pw"),
+        role="user",
+    )
+    db_session.add(squatter)
+    await db_session.commit()
+
+    admin = User(
+        id=42,
+        email="admin@local",
+        password_hash=hash_password("pw"),
+        role="admin",
+    )
+    db_session.add(admin)
+    await db_session.commit()
+
+    await reclaim_uid1(db_session)
+
+    fetched_admin = (
+        await db_session.execute(select(User).where(User.email == "admin@local"))
+    ).scalar_one()
+    fetched_squatter = (
+        await db_session.execute(select(User).where(User.email == "squatter@example.com"))
+    ).scalar_one()
+    assert fetched_admin.id == 42
+    assert fetched_squatter.id == 1
+
+
+@pytest.mark.asyncio
+async def test_force_reset_refuses_when_id_1_held_by_other(
+    db_session: AsyncSession, tmp_path: Path
+) -> None:
+    """force_admin_reset with no env_email user and UID 1 held by someone
+    else: return False, no modifications."""
+    squatter = User(
+        id=1,
+        email="squatter@example.com",
+        password_hash=hash_password("untouched"),
+        role="user",
+    )
+    db_session.add(squatter)
+    await db_session.commit()
+
+    settings = _fresh_settings(
+        tmp_path,
+        email="admin@local",
+        pw="ignored",
+        force_admin_reset=True,
+    )
+    result = await force_reset_admin(db_session, settings)
+    assert result is False
+
+    fetched = (
+        await db_session.execute(select(User).where(User.email == "squatter@example.com"))
+    ).scalar_one()
+    assert verify_password("untouched", fetched.password_hash)
+    assert fetched.id == 1
+    count = (await db_session.execute(select(func.count()).select_from(User))).scalar_one()
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_force_reset_inserts_at_id_1_when_free(
+    db_session: AsyncSession, tmp_path: Path
+) -> None:
+    """force_admin_reset with no env_email user and UID 1 free: insert
+    with explicit id=1."""
+    settings = _fresh_settings(
+        tmp_path,
+        email="admin@local",
+        pw="freshpw1234567",
+        force_admin_reset=True,
+    )
+    result = await force_reset_admin(db_session, settings)
+    assert result is True
+
+    admin = (await db_session.execute(select(User).where(User.email == "admin@local"))).scalar_one()
+    assert admin.id == 1


### PR DESCRIPTION
## Summary

Pin `admin@local` to UID 1 across every auth-bootstrap path so the
UID=1 gate that protects admin-only routes (`/settings` etc.) stops
breaking after force-resets, reseeds, or schema reflows.

- `bootstrap_admin` empty-table path: insert with explicit `id=1` instead of relying on the sequence.
- `force_reset_admin`: update the existing `env_email` user in place (preserves the id, refreshes `updated_at`); refuse to clobber UID 1 if it's held by a different account; only insert at `id=1` when the row is truly absent and the slot is free.
- New `reclaim_uid1()` runs on every startup ahead of force-reset and the idempotent check — if `admin@local` has drifted to `id != 1` and UID 1 is free, promote it back via a raw UPDATE. If UID 1 is held by someone else, log and leave state alone.
- `_resync_users_id_sequence`: advance the SERIAL sequence after any explicit-id insert so the next user-driven insert doesn't collide on `id=1`.
- Migration `005` adds `ON UPDATE CASCADE` to all five FKs that reference `auth.users.id` (sessions, agent_registrations, server_settings, invite_tokens × 2). Without this, the reclaim UPDATE fails the FK check whenever the drifted admin has live sessions or agent registrations.

## Test plan

- [x] New tests added in `services/auth/tests/test_bootstrap.py`:
  - `test_bootstrap_creates_admin_at_id_1`
  - `test_bootstrap_id_1_pin_does_not_break_next_insert` (sequence resync verified)
  - `test_reclaim_uid1_moves_admin_when_id_1_is_free`
  - `test_reclaim_uid1_cascades_to_sessions_and_agents` (FK CASCADE exercised end-to-end)
  - `test_reclaim_uid1_noop_when_admin_already_at_id_1`
  - `test_reclaim_uid1_noop_when_admin_missing`
  - `test_reclaim_uid1_refuses_when_id_1_taken`
  - `test_force_reset_refuses_when_id_1_held_by_other`
  - `test_force_reset_inserts_at_id_1_when_free`
- [x] Existing `test_force_reset_replaces_existing_admin` (now `test_force_reset_updates_password_in_place`) flipped to assert `id == old_id` instead of `id != old_id`, matching the new in-place behavior.
- [ ] Test suite NOT run locally (no Postgres/Redis available in this environment) — relying on CI smoke gate.
- [ ] Post-deploy verification on `edge.int`: confirm `SELECT id, email, role FROM auth.users` shows `(1, 'admin@local', 'admin')`, and `/settings` returns 200 to the admin.

Self-review passed; marker at HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)