### PR TITLE
fix(auth): move admin@local to uid=1, prevent future drift

### DIFF
--- a/services/auth/alembic/versions/005_user_fk_on_update_cascade.py
+++ b/services/auth/alembic/versions/005_user_fk_on_update_cascade.py
@@ -1,0 +1,94 @@
+"""Add ON UPDATE CASCADE to FK constraints referencing auth.users.id.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-05-10
+
+Background
+----------
+The drift-correction helper in ``auth_service.bootstrap`` issues
+``UPDATE auth.users SET id = 1 WHERE id = <old_id>`` to move
+``admin@local`` back to UID=1 when it landed at a different id (the
+web settings page is gated on UID=1 via ``require_root_admin``). The
+original FK constraints were declared with ``ON DELETE CASCADE`` (or
+``ON DELETE SET NULL``) but no ``ON UPDATE`` clause — PostgreSQL
+defaults the latter to ``NO ACTION``, so the parent UPDATE is rejected
+whenever referencing rows exist (sessions, agent_registrations,
+invite_tokens, server_settings).
+
+This migration drops and re-adds the five FK constraints in the auth
+schema with the same ``ON DELETE`` behavior plus ``ON UPDATE CASCADE``
+so child rows follow the admin to its new id without manual cleanup.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_FK_CHANGES = [
+    # (table, constraint_name, column, on_delete)
+    ("sessions", "sessions_user_id_fkey", "user_id", "CASCADE"),
+    (
+        "agent_registrations",
+        "agent_registrations_user_id_fkey",
+        "user_id",
+        "CASCADE",
+    ),
+    (
+        "server_settings",
+        "server_settings_updated_by_user_id_fkey",
+        "updated_by_user_id",
+        "SET NULL",
+    ),
+    (
+        "invite_tokens",
+        "invite_tokens_created_by_user_id_fkey",
+        "created_by_user_id",
+        "SET NULL",
+    ),
+    (
+        "invite_tokens",
+        "invite_tokens_used_by_user_id_fkey",
+        "used_by_user_id",
+        "SET NULL",
+    ),
+]
+
+
+def upgrade() -> None:
+    for table, name, column, on_delete in _FK_CHANGES:
+        op.drop_constraint(name, table, schema="auth", type_="foreignkey")
+        op.create_foreign_key(
+            name,
+            source_table=table,
+            referent_table="users",
+            local_cols=[column],
+            remote_cols=["id"],
+            source_schema="auth",
+            referent_schema="auth",
+            ondelete=on_delete,
+            onupdate="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    for table, name, column, on_delete in _FK_CHANGES:
+        op.drop_constraint(name, table, schema="auth", type_="foreignkey")
+        op.create_foreign_key(
+            name,
+            source_table=table,
+            referent_table="users",
+            local_cols=[column],
+            remote_cols=["id"],
+            source_schema="auth",
+            referent_schema="auth",
+            ondelete=on_delete,
+        )

--- a/services/auth/auth_service/bootstrap.py
+++ b/services/auth/auth_service/bootstrap.py
@@ -15,6 +15,7 @@ import secrets
 from pathlib import Path
 
 from sqlalchemy import select
+from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth_service.models import User
@@ -39,8 +40,54 @@ def _write_initial_password(path: Path, password: str) -> None:
     os.chmod(path, 0o600)
 
 
+async def _ensure_admin_is_uid1(db: AsyncSession) -> None:
+    """If admin@local exists at id != 1 and id=1 is free, move it to id=1."""
+    result = await db.execute(
+        sa_text("SELECT id FROM auth.users WHERE email = :email"),
+        {"email": _DEFAULT_ADMIN_EMAIL},
+    )
+    row = result.fetchone()
+    if row is None or row[0] == 1:
+        return  # already correct or doesn't exist
+
+    current_id = row[0]
+
+    # Check if id=1 is free
+    conflict = await db.execute(
+        sa_text("SELECT id FROM auth.users WHERE id = 1"),
+    )
+    if conflict.fetchone() is not None:
+        logger.warning(
+            "Cannot move admin@local from id=%s to id=1: id=1 is occupied by another user",
+            current_id,
+        )
+        return
+
+    # Move the admin user to id=1
+    await db.execute(
+        sa_text("UPDATE auth.users SET id = 1 WHERE id = :old_id"),
+        {"old_id": current_id},
+    )
+    # Reset the sequence so future INSERTs don't collide
+    await db.execute(
+        sa_text(
+            "SELECT setval(pg_get_serial_sequence('auth.users', 'id'),"
+            " (SELECT COALESCE(MAX(id), 0) FROM auth.users), true)"
+        )
+    )
+    await db.commit()
+    logger.warning(
+        "Moved admin@local from id=%s to id=1 and reset sequence",
+        current_id,
+    )
+
+
 async def force_reset_admin(db: AsyncSession, settings: AuthSettings) -> bool:
-    """Delete and recreate the admin user when DEEP_ANALYSIS_FORCE_ADMIN_RESET is set.
+    """Reset the admin user's credentials when DEEP_ANALYSIS_FORCE_ADMIN_RESET is set.
+
+    UPDATEs in place when the user exists (preserving id); otherwise INSERTs
+    via the ORM. After the operation, ``_ensure_admin_is_uid1`` moves the row
+    to id=1 if id=1 is free.
 
     Returns True if a reset was performed, False otherwise.
     """
@@ -57,20 +104,28 @@ async def force_reset_admin(db: AsyncSession, settings: AuthSettings) -> bool:
         )
         return False
 
+    pw_hash = hash_password(env_password)
+
     existing = (await db.execute(select(User).where(User.email == env_email))).scalar_one_or_none()
     if existing is not None:
-        await db.delete(existing)
+        # UPDATE in place via ORM so the user's id is preserved.
+        existing.password_hash = pw_hash
+        existing.role = "admin"
+        existing.must_change_password = False
+        existing.disabled = False
+        await db.commit()
+    else:
+        user = User(
+            email=env_email,
+            password_hash=pw_hash,
+            role="admin",
+            must_change_password=False,
+            disabled=False,
+        )
+        db.add(user)
         await db.commit()
 
-    user = User(
-        email=env_email,
-        password_hash=hash_password(env_password),
-        role="admin",
-        must_change_password=False,
-        disabled=False,
-    )
-    db.add(user)
-    await db.commit()
+    await _ensure_admin_is_uid1(db)
 
     logger.warning(
         "Admin user reset: %s (DEEP_ANALYSIS_FORCE_ADMIN_RESET was set — "
@@ -90,6 +145,9 @@ async def bootstrap_admin(db: AsyncSession, settings: AuthSettings) -> None:
         )
     ).scalar_one_or_none()
     if existing is not None:
+        # Admin already present; still run the drift correction in case
+        # admin@local landed at id != 1 in a prior boot.
+        await _ensure_admin_is_uid1(db)
         return
 
     env_email = settings.bootstrap_admin_email
@@ -116,6 +174,8 @@ async def bootstrap_admin(db: AsyncSession, settings: AuthSettings) -> None:
     )
     db.add(user)
     await db.commit()
+
+    await _ensure_admin_is_uid1(db)
 
     if scripted:
         logger.warning(

--- a/services/auth/tests/test_bootstrap.py
+++ b/services/auth/tests/test_bootstrap.py
@@ -6,11 +6,16 @@ import os
 from pathlib import Path
 
 import pytest
-from auth_service.bootstrap import bootstrap_admin, force_reset_admin
+from auth_service.bootstrap import (
+    _ensure_admin_is_uid1,
+    bootstrap_admin,
+    force_reset_admin,
+)
 from auth_service.models import User
 from auth_service.passwords import hash_password, verify_password
 from auth_service.settings import AuthSettings
 from sqlalchemy import func, select
+from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -159,8 +164,8 @@ async def test_bootstrap_env_var_path_idempotent_on_restart(
 async def test_force_reset_replaces_existing_admin(
     db_session: AsyncSession, tmp_path: Path
 ) -> None:
-    """force_admin_reset=True with valid env credentials deletes the existing
-    user with that email and recreates from env."""
+    """force_admin_reset=True with valid env credentials updates the existing
+    user's credentials in place, preserving the id."""
     existing = User(
         email="admin@local",
         password_hash=hash_password("garbled-old-hash"),
@@ -185,7 +190,7 @@ async def test_force_reset_replaces_existing_admin(
     )
     assert len(admins) == 1
     admin = admins[0]
-    assert admin.id != old_id
+    assert admin.id == old_id
     assert admin.role == "admin"
     assert admin.disabled is False
     assert admin.must_change_password is False
@@ -281,6 +286,188 @@ async def test_bootstrap_admin_invokes_force_reset_first(
     await bootstrap_admin(db_session, settings)
 
     admin = (await db_session.execute(select(User).where(User.email == "admin@local"))).scalar_one()
-    assert admin.id != old_id
+    assert admin.id == old_id
     assert verify_password("resetviabootstrap", admin.password_hash)
     assert not settings.initial_admin_secret_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_ensure_admin_is_uid1_moves_drifted_admin(db_session: AsyncSession) -> None:
+    """When admin@local is at id != 1 and id=1 is free, the helper moves it
+    to id=1 and resets the sequence so future INSERTs don't collide."""
+    # Force a non-1 id by burning id=1 with a placeholder then deleting it,
+    # leaving the sequence past 1 and id=1 free.
+    placeholder = User(
+        email="placeholder@example.com",
+        password_hash=hash_password("pw"),
+        role="user",
+    )
+    db_session.add(placeholder)
+    await db_session.commit()
+    placeholder_id = placeholder.id
+
+    admin = User(
+        email="admin@local",
+        password_hash=hash_password("pw"),
+        role="admin",
+    )
+    db_session.add(admin)
+    await db_session.commit()
+    drifted_id = admin.id
+    assert drifted_id != 1
+
+    await db_session.execute(
+        sa_text("DELETE FROM auth.users WHERE id = :id"), {"id": placeholder_id}
+    )
+    await db_session.commit()
+
+    await _ensure_admin_is_uid1(db_session)
+
+    moved = (await db_session.execute(select(User).where(User.email == "admin@local"))).scalar_one()
+    assert moved.id == 1
+
+    # Sequence should now be aligned with MAX(id) so a fresh INSERT doesn't collide.
+    new_user = User(email="newcomer@example.com", password_hash=hash_password("pw"), role="user")
+    db_session.add(new_user)
+    await db_session.commit()
+    assert new_user.id > 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_admin_is_uid1_noop_when_admin_missing(db_session: AsyncSession) -> None:
+    """If admin@local doesn't exist, the helper is a no-op."""
+    other = User(email="other@example.com", password_hash=hash_password("pw"), role="user")
+    db_session.add(other)
+    await db_session.commit()
+    before = other.id
+
+    await _ensure_admin_is_uid1(db_session)
+
+    still_there = (
+        await db_session.execute(select(User).where(User.email == "other@example.com"))
+    ).scalar_one()
+    assert still_there.id == before
+
+
+@pytest.mark.asyncio
+async def test_ensure_admin_is_uid1_skips_when_id1_occupied(db_session: AsyncSession) -> None:
+    """If id=1 is occupied by a different user, the helper warns and skips."""
+    other = User(email="squatter@example.com", password_hash=hash_password("pw"), role="user")
+    db_session.add(other)
+    await db_session.commit()
+    squatter_id = other.id
+
+    admin = User(email="admin@local", password_hash=hash_password("pw"), role="admin")
+    db_session.add(admin)
+    await db_session.commit()
+    admin_id_before = admin.id
+
+    await _ensure_admin_is_uid1(db_session)
+
+    admin_after = (
+        await db_session.execute(select(User).where(User.email == "admin@local"))
+    ).scalar_one()
+    squatter_after = (
+        await db_session.execute(select(User).where(User.email == "squatter@example.com"))
+    ).scalar_one()
+    # Both rows unchanged
+    assert admin_after.id == admin_id_before
+    assert squatter_after.id == squatter_id
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_admin_places_new_admin_at_uid1(
+    db_session: AsyncSession, tmp_path: Path
+) -> None:
+    """First-boot bootstrap creates the admin at id=1 (the auto-generate path)."""
+    settings = _fresh_settings(tmp_path)
+    await bootstrap_admin(db_session, settings)
+
+    admin = (await db_session.execute(select(User).where(User.email == "admin@local"))).scalar_one()
+    assert admin.id == 1
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_admin_corrects_drift_on_existing_admin(
+    db_session: AsyncSession, tmp_path: Path
+) -> None:
+    """If admin@local is already present but drifted off id=1, bootstrap_admin
+    runs the drift correction even though it would otherwise short-circuit on
+    the "admin exists" check."""
+    placeholder = User(
+        email="placeholder@example.com",
+        password_hash=hash_password("pw"),
+        role="user",
+    )
+    db_session.add(placeholder)
+    await db_session.commit()
+    placeholder_id = placeholder.id
+
+    admin = User(email="admin@local", password_hash=hash_password("pw"), role="admin")
+    db_session.add(admin)
+    await db_session.commit()
+    assert admin.id != 1
+
+    await db_session.execute(
+        sa_text("DELETE FROM auth.users WHERE id = :id"), {"id": placeholder_id}
+    )
+    await db_session.commit()
+
+    settings = _fresh_settings(tmp_path)
+    await bootstrap_admin(db_session, settings)
+
+    moved = (await db_session.execute(select(User).where(User.email == "admin@local"))).scalar_one()
+    assert moved.id == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_admin_is_uid1_cascades_sessions(db_session: AsyncSession) -> None:
+    """The drift correction must work even when admin@local has existing
+    sessions referencing the old id — ON UPDATE CASCADE on the FK moves the
+    session along with the user."""
+    placeholder = User(
+        email="placeholder@example.com",
+        password_hash=hash_password("pw"),
+        role="user",
+    )
+    db_session.add(placeholder)
+    await db_session.commit()
+    placeholder_id = placeholder.id
+
+    admin = User(email="admin@local", password_hash=hash_password("pw"), role="admin")
+    db_session.add(admin)
+    await db_session.commit()
+    drifted_id = admin.id
+    assert drifted_id != 1
+
+    # Simulate a prior admin login: insert a session row referencing the
+    # drifted admin id.
+    await db_session.execute(
+        sa_text(
+            "INSERT INTO auth.sessions (user_id, refresh_token_hash, issued_at,"
+            " expires_at)"
+            " VALUES (:uid, :h, now(), now() + interval '7 days')"
+        ),
+        {"uid": drifted_id, "h": "x" * 64},
+    )
+    await db_session.commit()
+
+    # Free up id=1
+    await db_session.execute(
+        sa_text("DELETE FROM auth.users WHERE id = :id"), {"id": placeholder_id}
+    )
+    await db_session.commit()
+
+    await _ensure_admin_is_uid1(db_session)
+
+    moved = (await db_session.execute(select(User).where(User.email == "admin@local"))).scalar_one()
+    assert moved.id == 1
+
+    # Session row's user_id should have followed the parent UPDATE.
+    session_owner = (
+        await db_session.execute(
+            sa_text("SELECT user_id FROM auth.sessions WHERE refresh_token_hash = :h"),
+            {"h": "x" * 64},
+        )
+    ).scalar_one()
+    assert session_owner == 1

--- a/services/ingest/alembic/versions/002_user_uploads_fk_on_update_cascade.py
+++ b/services/ingest/alembic/versions/002_user_uploads_fk_on_update_cascade.py
@@ -1,0 +1,60 @@
+"""Add ON UPDATE CASCADE to ingest.user_uploads.user_id FK.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-05-10
+
+Background
+----------
+Mirror of auth-schema migration 005: the drift-correction helper in
+``auth_service.bootstrap`` can re-issue ``admin@local``'s id when it
+lands at the wrong UID. ``ingest.user_uploads.user_id`` references
+``auth.users.id`` with ``ON DELETE CASCADE`` but no ``ON UPDATE``
+clause, so the parent UPDATE would be rejected when admin@local has
+prior uploads. Add ``ON UPDATE CASCADE`` so the FK follows the move.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_FK_NAME = "fk_user_uploads_user_id"
+_TABLE = "user_uploads"
+_COLUMN = "user_id"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_FK_NAME, _TABLE, schema="ingest", type_="foreignkey")
+    op.create_foreign_key(
+        _FK_NAME,
+        source_table=_TABLE,
+        referent_table="users",
+        local_cols=[_COLUMN],
+        remote_cols=["id"],
+        source_schema="ingest",
+        referent_schema="auth",
+        ondelete="CASCADE",
+        onupdate="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_FK_NAME, _TABLE, schema="ingest", type_="foreignkey")
+    op.create_foreign_key(
+        _FK_NAME,
+        source_table=_TABLE,
+        referent_table="users",
+        local_cols=[_COLUMN],
+        remote_cols=["id"],
+        source_schema="ingest",
+        referent_schema="auth",
+        ondelete="CASCADE",
+    )


### PR DESCRIPTION
## Problem

admin@local was created at UID 2 instead of UID 1. The web settings
page gates admin access on `user.id == 1` (the "root admin"
concept in `require_root_admin`), so admin could not reach
settings.

## Fix

Four files:

- `services/auth/auth_service/bootstrap.py`
  - New helper `_ensure_admin_is_uid1()`: if admin@local exists at
    `id != 1` and id=1 is free, UPDATEs to id=1 and resets the
    sequence. No-op when admin missing or id=1 occupied (logs a
    warning in the latter case).
  - `force_reset_admin()`: UPDATEs in place via ORM (preserves the
    user's id) instead of DELETE + INSERT. Falls back to ORM INSERT
    when no admin exists. Calls `_ensure_admin_is_uid1` at the end.
  - `bootstrap_admin()`: ALSO calls `_ensure_admin_is_uid1` on the
    early-return "admin already exists" path, so drift gets corrected
    on every startup (not only when `DEEP_ANALYSIS_FORCE_ADMIN_RESET`
    is set).

- `services/auth/alembic/versions/005_user_fk_on_update_cascade.py`:
  new migration adds `ON UPDATE CASCADE` to the 5 FKs in `auth.*`
  that reference `auth.users.id` (sessions, agent_registrations,
  server_settings, invite_tokens.created_by, invite_tokens.used_by).
  Without this the parent UPDATE would be rejected for FK violation
  whenever admin@local has any child rows (sessions etc.).

- `services/ingest/alembic/versions/002_user_uploads_fk_on_update_cascade.py`:
  mirror of 005 for the cross-schema `ingest.user_uploads.user_id`
  FK.

- `services/auth/tests/test_bootstrap.py`: updates two stale
  assertions (`admin.id != old_id` → `admin.id == old_id`) and adds 6
  new tests: drift correction, no-op when admin missing, skip when
  id=1 occupied, fresh-bootstrap at id=1, drift correction on the
  existing-admin path, and FK cascade for sessions.

## Test plan

- [x] All 18 bootstrap tests pass; 155 auth tests pass overall
- [x] 19 ingest tests pass with the new migration applied
- [x] Both new Alembic migrations upgrade + downgrade cleanly
- [x] FK constraint metadata verified via `pg_constraint` — all 6
      FKs show `confupdtype = 'c'` after upgrade
- [ ] After deploy on edge.int, verify admin@local lives at id=1 and
      the settings page loads