### PR TITLE
fix(auth,ingest): scrub password from error logs; add ingest-migrate

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -73,6 +73,7 @@ IMAGES = {
     "root-migrate": "ghcr.io/sentania-labs/deep-analysis-auth",
     "auth-migrate": "ghcr.io/sentania-labs/deep-analysis-auth",
     "auth": "ghcr.io/sentania-labs/deep-analysis-auth",
+    "ingest-migrate": "ghcr.io/sentania-labs/deep-analysis-ingest",
     "ingest": "ghcr.io/sentania-labs/deep-analysis-ingest",
     "parser": "ghcr.io/sentania-labs/deep-analysis-parser",
     "analytics": "ghcr.io/sentania-labs/deep-analysis-analytics",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,11 +48,10 @@ services:
   #
   # `root-migrate` runs the root alembic head, which creates the four
   # logical schemas (auth/ingest/parser/analytics) and the unprivileged
-  # service roles. `auth-migrate` then applies the auth.* tables.
-  #
-  # Both reuse the auth image, which bakes in both alembic trees. The
-  # ingest/parser schemas still need their own migrate services — that is
-  # a follow-up; today only the auth service writes its head from compose.
+  # service roles. `auth-migrate` and `ingest-migrate` then apply each
+  # service's own tables; both reuse their service's image, which bakes
+  # in the alembic tree at /app/service/alembic. parser still has no
+  # migrate service of its own — that lands when parser grows tables.
   #
   # DATABASE_URL must be a sync psycopg URL (alembic env.py uses the sync
   # engine), e.g. postgresql+psycopg://USER:PASS@postgres:5432/deep_analysis.
@@ -76,6 +75,22 @@ services:
     build:
       context: .
       dockerfile: services/auth/Dockerfile
+    command: ["alembic", "-c", "/app/service/alembic.ini", "upgrade", "head"]
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-}
+    networks:
+      - backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+      root-migrate:
+        condition: service_completed_successfully
+    restart: "no"
+
+  ingest-migrate:
+    build:
+      context: .
+      dockerfile: services/ingest/Dockerfile
     command: ["alembic", "-c", "/app/service/alembic.ini", "upgrade", "head"]
     environment:
       DATABASE_URL: ${DATABASE_URL:-}
@@ -172,6 +187,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      ingest-migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
       interval: 15s

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -145,49 +145,64 @@ async def login(
     db: AsyncSession = Depends(get_session),
 ) -> TokenResponse:
     # Rate limiting deferred to W7 gateway.
-    settings = get_settings()
-    user = (
-        await db.execute(select(User).where(func.lower(User.email) == body.email.lower()))
-    ).scalar_one_or_none()
-    if user is None or user.disabled:
-        raise _INVALID_CREDENTIALS
-    if not verify_password(body.password, user.password_hash):
-        raise _INVALID_CREDENTIALS
+    # Body carries a plaintext password — any unhandled exception escaping
+    # this handler could be logged with the request body by FastAPI/uvicorn,
+    # leaking the password. Catch broadly and re-raise a sanitized 500.
+    try:
+        settings = get_settings()
+        user = (
+            await db.execute(select(User).where(func.lower(User.email) == body.email.lower()))
+        ).scalar_one_or_none()
+        if user is None or user.disabled:
+            raise _INVALID_CREDENTIALS
+        if not verify_password(body.password, user.password_hash):
+            raise _INVALID_CREDENTIALS
 
-    refresh_token = issue_refresh_token()
-    now = datetime.now(UTC)
-    session_row = SessionRow(
-        user_id=user.id,
-        refresh_token_hash=hash_refresh_token(refresh_token),
-        issued_at=now,
-        expires_at=now + timedelta(seconds=settings.refresh_token_ttl_seconds),
-        user_agent=(request.headers.get("user-agent") or None),
-        ip=_client_ip(request),
-    )
-    db.add(session_row)
-    await db.commit()
-    await db.refresh(session_row)
-
-    if user.must_change_password:
-        access = issue_access_token(
-            user.id,
-            user.role,
-            session_row.id,
-            scope=PASSWORD_CHANGE_SCOPE,
-            override_ttl_seconds=settings.password_change_token_ttl_seconds,
-            email=user.email,
+        refresh_token = issue_refresh_token()
+        now = datetime.now(UTC)
+        session_row = SessionRow(
+            user_id=user.id,
+            refresh_token_hash=hash_refresh_token(refresh_token),
+            issued_at=now,
+            expires_at=now + timedelta(seconds=settings.refresh_token_ttl_seconds),
+            user_agent=(request.headers.get("user-agent") or None),
+            ip=_client_ip(request),
         )
-        expires_in = settings.password_change_token_ttl_seconds
-    else:
-        access = issue_access_token(user.id, user.role, session_row.id, email=user.email)
-        expires_in = settings.access_token_ttl_seconds
+        db.add(session_row)
+        await db.commit()
+        await db.refresh(session_row)
 
-    return TokenResponse(
-        access_token=access,
-        refresh_token=refresh_token,
-        expires_in=expires_in,
-        must_change_password=user.must_change_password,
-    )
+        if user.must_change_password:
+            access = issue_access_token(
+                user.id,
+                user.role,
+                session_row.id,
+                scope=PASSWORD_CHANGE_SCOPE,
+                override_ttl_seconds=settings.password_change_token_ttl_seconds,
+                email=user.email,
+            )
+            expires_in = settings.password_change_token_ttl_seconds
+        else:
+            access = issue_access_token(user.id, user.role, session_row.id, email=user.email)
+            expires_in = settings.access_token_ttl_seconds
+
+        return TokenResponse(
+            access_token=access,
+            refresh_token=refresh_token,
+            expires_in=expires_in,
+            must_change_password=user.must_change_password,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001 — sanitize before re-raising
+        _log.error(
+            "auth.login.error",
+            extra={"email": body.email, "exc_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "internal_error"},
+        ) from None
 
 
 @app.post("/auth/refresh", response_model=TokenResponse)
@@ -558,60 +573,75 @@ async def register_agent_with_credentials(
     enforces at consume time). Does not create a browser session, so no
     refresh token is issued.
     """
-    user = (
-        await db.execute(select(User).where(func.lower(User.email) == body.email.lower()))
-    ).scalar_one_or_none()
-    if user is None or user.disabled:
-        raise _INVALID_CREDENTIALS
-    if not verify_password(body.password, user.password_hash):
-        raise _INVALID_CREDENTIALS
+    # Body carries a plaintext password — any unhandled exception escaping
+    # this handler could be logged with the request body by FastAPI/uvicorn,
+    # leaking the password. Catch broadly and re-raise a sanitized 500.
+    try:
+        user = (
+            await db.execute(select(User).where(func.lower(User.email) == body.email.lower()))
+        ).scalar_one_or_none()
+        if user is None or user.disabled:
+            raise _INVALID_CREDENTIALS
+        if not verify_password(body.password, user.password_hash):
+            raise _INVALID_CREDENTIALS
 
-    if user.role != "user":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"error": "admin_cannot_register_agent"},
+        if user.role != "user":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": "admin_cannot_register_agent"},
+            )
+
+        # Mint + consume immediately. Going through the existing helpers
+        # keeps this flow symmetric with the code-based one — same Redis
+        # primitive, same atomic GETDEL — so a future change to either
+        # flow lands in one place. The 30s TTL is paranoia padding; in
+        # practice the consume happens microseconds after the store.
+        code = generate_registration_code()
+        await store_registration_code(redis, code, user.id, ttl_seconds=30)
+        user_id = await consume_registration_code(redis, code)
+        if user_id is None:
+            # Implies a Redis flush or eviction within microseconds of our
+            # own store — operationally exceptional, but worth surfacing
+            # rather than papering over with a silent retry.
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={"error": "registration_code_race"},
+            )
+
+        api_token = generate_api_token()
+        now = datetime.now(UTC)
+        agent = AgentRegistration(
+            user_id=user_id,
+            machine_name=body.agent_name,
+            api_token_hash=hash_api_token(api_token),
+            created_at=now,
+            last_seen_at=now,
+            client_version=body.client_version,
         )
+        db.add(agent)
+        await db.commit()
+        await db.refresh(agent)
 
-    # Mint + consume immediately. Going through the existing helpers
-    # keeps this flow symmetric with the code-based one — same Redis
-    # primitive, same atomic GETDEL — so a future change to either
-    # flow lands in one place. The 30s TTL is paranoia padding; in
-    # practice the consume happens microseconds after the store.
-    code = generate_registration_code()
-    await store_registration_code(redis, code, user.id, ttl_seconds=30)
-    user_id = await consume_registration_code(redis, code)
-    if user_id is None:
-        # Implies a Redis flush or eviction within microseconds of our
-        # own store — operationally exceptional, but worth surfacing
-        # rather than papering over with a silent retry.
+        _log.info(
+            "auth.agent.register_with_credentials.success",
+            extra={"agent_id": str(agent.id), "user_id": user_id},
+        )
+        return AgentRegisterResponse(
+            agent_id=agent.id,
+            api_token=api_token,
+            user_id=user_id,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001 — sanitize before re-raising
+        _log.error(
+            "auth.agent.register_with_credentials.error",
+            extra={"email": body.email, "exc_type": type(exc).__name__},
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": "registration_code_race"},
-        )
-
-    api_token = generate_api_token()
-    now = datetime.now(UTC)
-    agent = AgentRegistration(
-        user_id=user_id,
-        machine_name=body.agent_name,
-        api_token_hash=hash_api_token(api_token),
-        created_at=now,
-        last_seen_at=now,
-        client_version=body.client_version,
-    )
-    db.add(agent)
-    await db.commit()
-    await db.refresh(agent)
-
-    _log.info(
-        "auth.agent.register_with_credentials.success",
-        extra={"agent_id": str(agent.id), "user_id": user_id},
-    )
-    return AgentRegisterResponse(
-        agent_id=agent.id,
-        api_token=api_token,
-        user_id=user_id,
-    )
+            detail={"error": "internal_error"},
+        ) from None
 
 
 # ---------------------------------------------------------------------------

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -210,6 +210,6 @@ class RegisterResponse(BaseModel):
 
 class AgentRegisterWithCredentialsRequest(BaseModel):
     email: str = Field(min_length=1, max_length=320)
-    password: str = Field(min_length=1)
+    password: str = Field(min_length=1, json_schema_extra={"writeOnly": True})
     agent_name: str = Field(min_length=1, max_length=255)
     client_version: str = Field(min_length=1, max_length=64)

--- a/services/auth/tests/test_credential_scrub.py
+++ b/services/auth/tests/test_credential_scrub.py
@@ -1,0 +1,112 @@
+"""Regression tests for password scrubbing on unhandled errors.
+
+If a DB error escapes /auth/login or /auth/agent/register-with-credentials,
+FastAPI/uvicorn's default unhandled-exception logging may dump the request
+body — which contains a plaintext password. Both handlers wrap their body
+in a try/except that catches non-HTTPException errors and re-raises a
+sanitized 500 with `from None` so no chained exception (carrying the
+request body in its frame locals) escapes.
+
+These tests pin that contract: on a forced DB error, the response is 500,
+the body does NOT echo "password", and no log line carries the plaintext
+password value.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from auth_service import db as _db
+from auth_service import main as _main
+
+
+class _ExplodingSession:
+    """Drop-in for AsyncSession that raises on the first ORM call.
+
+    Matches enough of the AsyncSession surface that the dependency
+    override resolves without TypeErrors — we don't expect any call to
+    succeed.
+    """
+
+    async def execute(self, *_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("simulated DB failure")
+
+    def add(self, *_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("simulated DB failure")
+
+    async def commit(self) -> None:
+        raise RuntimeError("simulated DB failure")
+
+    async def refresh(self, *_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("simulated DB failure")
+
+    async def rollback(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+async def _exploding_get_session() -> Any:
+    yield _ExplodingSession()
+
+
+_LEAKY_PASSWORD = "leaky-plaintext-password-xyz-2026"
+
+
+@pytest.fixture
+def _override_db() -> Any:
+    _main.app.dependency_overrides[_db.get_session] = _exploding_get_session
+    try:
+        yield
+    finally:
+        _main.app.dependency_overrides.pop(_db.get_session, None)
+
+
+@pytest.mark.asyncio
+async def test_register_with_credentials_db_error_scrubs_password(
+    client: Any,
+    _override_db: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG)
+    r = await client.post(
+        "/auth/agent/register-with-credentials",
+        json={
+            "email": "scrub-test@example.com",
+            "password": _LEAKY_PASSWORD,
+            "agent_name": "laptop-1",
+            "client_version": "0.7.14",
+        },
+    )
+    assert r.status_code == 500, r.text
+    assert _LEAKY_PASSWORD not in r.text
+    assert "password" not in r.json()["detail"]
+    for record in caplog.records:
+        # Both the formatted message and the raw extra dict could carry
+        # a leak; check the rendered line which covers both surfaces.
+        assert _LEAKY_PASSWORD not in record.getMessage()
+        for value in record.__dict__.values():
+            assert _LEAKY_PASSWORD not in repr(value)
+
+
+@pytest.mark.asyncio
+async def test_login_db_error_scrubs_password(
+    client: Any,
+    _override_db: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG)
+    r = await client.post(
+        "/auth/login",
+        json={"email": "scrub-test@example.com", "password": _LEAKY_PASSWORD},
+    )
+    assert r.status_code == 500, r.text
+    assert _LEAKY_PASSWORD not in r.text
+    assert "password" not in r.json()["detail"]
+    for record in caplog.records:
+        assert _LEAKY_PASSWORD not in record.getMessage()
+        for value in record.__dict__.values():
+            assert _LEAKY_PASSWORD not in repr(value)

--- a/services/ingest/alembic.ini
+++ b/services/ingest/alembic.ini
@@ -1,5 +1,5 @@
 [alembic]
-script_location = services/ingest/alembic
+script_location = %(here)s/alembic
 # Placeholder only — env.py overrides this with DATABASE_URL from the environment.
 sqlalchemy.url = driver://user:pass@host/db
 


### PR DESCRIPTION
## Summary

- **Security (auth):** Wrap `/auth/login` and `/auth/agent/register-with-credentials` bodies in a sanitizing try/except so non-HTTPException errors re-raise as a clean 500 with `from None`. The original exception (carrying the request body's frame locals) never reaches FastAPI's default logger. Log only email + exc_type. Marks the password field writeOnly in OpenAPI for hygiene.
- **Ingest migrations:** Add the missing `ingest-migrate` one-shot compose service so `ingest.*` tables get created on every `compose up`. Fixes `UndefinedTableError: relation "ingest.game_log_files" does not exist` on upload. Switches `services/ingest/alembic.ini` to `%(here)s/alembic` so the path resolves both from the repo root and inside the Docker image. Maps the new compose service to the existing ingest GHCR image in `deploy/deploy.sh`.

## Test plan

- [x] `ruff check` + `ruff format --check services/auth services/ingest` — clean
- [x] `mypy services/auth/auth_service services/ingest/ingest_service` — clean (21 files)
- [x] `pytest services/auth/tests/` — 162 passed (incl. 2 new scrub tests)
- [x] Smoke-test `alembic -c services/ingest/alembic.ini current` from a foreign CWD — `%(here)s` resolves correctly
- [x] Self-review approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)