### PR TITLE
feat: user-facing features v0.8.0 (card search, match detail, admin cards, dashboard links)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ ignore = []
 "services/analytics/analytics_service/archetypes.py" = ["B008"]
 "services/analytics/analytics_service/stats.py" = ["B008"]
 "services/analytics/analytics_service/main.py" = ["B008"]
+"services/analytics/analytics_service/cards.py" = ["B008"]
+"services/analytics/analytics_service/matches.py" = ["B008"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/services/analytics/analytics_service/cards.py
+++ b/services/analytics/analytics_service/cards.py
@@ -1,0 +1,70 @@
+"""Card search router.
+
+Reads ``catalog.cards`` (the Scryfall bulk-data mirror) for card-name
+lookups. The mirror is refreshed by the background sync; this router
+is the read side that surfaces the data to logged-in users.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from analytics_service.db import get_session
+from analytics_service.deps import AuthenticatedUser, require_user
+
+router = APIRouter(prefix="/analytics/cards", tags=["cards"])
+
+_RESULT_LIMIT = 20
+
+
+class CardResult(BaseModel):
+    name: str
+    mana_cost: str | None = None
+    type_line: str | None = None
+    oracle_text: str | None = None
+    image_uri: str | None = None
+    set_code: str | None = None
+
+
+@router.get("", response_model=list[CardResult])
+async def search_cards(
+    q: str = "",
+    _user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> list[CardResult]:
+    """Case-insensitive substring search on card name.
+
+    Blank queries return an empty list — there is no value in dumping
+    the first 20 cards by storage order.
+    """
+    needle = q.strip()
+    if not needle:
+        return []
+    rows = (
+        await db.execute(
+            text(
+                """
+                SELECT name, mana_cost, type_line, oracle_text, image_uri, set_code
+                FROM catalog.cards
+                WHERE name ILIKE :pattern
+                ORDER BY name
+                LIMIT :limit
+                """
+            ),
+            {"pattern": f"%{needle}%", "limit": _RESULT_LIMIT},
+        )
+    ).all()
+    return [
+        CardResult(
+            name=str(name),
+            mana_cost=mana_cost,
+            type_line=type_line,
+            oracle_text=oracle_text,
+            image_uri=image_uri,
+            set_code=set_code,
+        )
+        for (name, mana_cost, type_line, oracle_text, image_uri, set_code) in rows
+    ]

--- a/services/analytics/analytics_service/main.py
+++ b/services/analytics/analytics_service/main.py
@@ -8,10 +8,13 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI
+from sqlalchemy import text
 
 from analytics_service.archetypes import router as archetypes_router
+from analytics_service.cards import router as cards_router
 from analytics_service.db import get_sessionmaker
 from analytics_service.deps import AuthenticatedUser, require_admin
+from analytics_service.matches import router as matches_router
 from analytics_service.mtgo_scraper import SCRAPER_NAME as MTGO_SCRAPER_NAME
 from analytics_service.mtgo_scraper import get_health as get_mtgo_health
 from analytics_service.mtgo_scraper import run_scrape as run_mtgo_scrape
@@ -161,6 +164,8 @@ app = FastAPI(title=f"deep-analysis-{SERVICE_NAME}", lifespan=lifespan)
 mount_metrics(app, SERVICE_NAME)
 app.include_router(archetypes_router)
 app.include_router(stats_router)
+app.include_router(cards_router)
+app.include_router(matches_router)
 
 
 admin_router = APIRouter(prefix="/analytics/admin", tags=["admin"])
@@ -199,6 +204,28 @@ async def scraper_health(
     sm = get_sessionmaker()
     async with sm() as session:
         return await get_mtgo_health(session, MTGO_SCRAPER_NAME)
+
+
+@admin_router.get("/cards-status")
+async def cards_status(
+    _admin: AuthenticatedUser = Depends(require_admin),
+) -> dict[str, Any]:
+    """Card-mirror summary for the admin dashboard.
+
+    ``last_sync_at`` is ``MAX(synced_at)`` over the table rather than a
+    dedicated bookkeeping row — the upsert path stamps every row on
+    each refresh, so the column already tracks the freshest sync.
+    """
+    sm = get_sessionmaker()
+    async with sm() as session:
+        count_row = await session.execute(text("SELECT COUNT(*) FROM catalog.cards"))
+        last_row = await session.execute(text("SELECT MAX(synced_at) FROM catalog.cards"))
+        card_count = int(count_row.scalar_one())
+        last_sync_at: datetime | None = last_row.scalar_one_or_none()
+    return {
+        "card_count": card_count,
+        "last_sync_at": last_sync_at.isoformat() if last_sync_at is not None else None,
+    }
 
 
 app.include_router(admin_router)

--- a/services/analytics/analytics_service/matches.py
+++ b/services/analytics/analytics_service/matches.py
@@ -1,0 +1,96 @@
+"""Match detail router.
+
+Single-match read endpoint scoped to the calling user. The ownership
+check is enforced in the WHERE clause — a user can only fetch matches
+they uploaded.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from analytics_service.db import get_session
+from analytics_service.deps import AuthenticatedUser, require_user
+
+router = APIRouter(prefix="/analytics/matches", tags=["matches"])
+
+
+class GameDetail(BaseModel):
+    game_number: int
+    winner: str | None = None
+    turns: int | None = None
+
+
+class MatchDetail(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    match_id: str
+    format_: str | None = Field(default=None, alias="format")
+    players: list[str] = Field(default_factory=list)
+    played_at: datetime | None = None
+    games: list[GameDetail] = Field(default_factory=list)
+
+
+@router.get("/{match_id}", response_model=MatchDetail)
+async def get_match(
+    match_id: uuid.UUID,
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchDetail:
+    match_row = (
+        await db.execute(
+            text(
+                """
+                SELECT id, format, players, parsed_at
+                FROM parser.matches
+                WHERE id = :match_id AND user_id = :user_id
+                """
+            ),
+            {"match_id": match_id, "user_id": user.user_id},
+        )
+    ).one_or_none()
+    if match_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "match_not_found"},
+        )
+    row_id, fmt, players, parsed_at = match_row
+    game_rows = (
+        await db.execute(
+            text(
+                """
+                SELECT g.id, g.game_number, g.winner,
+                       (SELECT MAX(s.turn_number)
+                          FROM parser.game_states s
+                         WHERE s.game_id = g.id) AS turns
+                FROM parser.games g
+                WHERE g.match_id = :match_id
+                ORDER BY g.game_number
+                """
+            ),
+            {"match_id": row_id},
+        )
+    ).all()
+    games = [
+        GameDetail(
+            game_number=int(game_number),
+            winner=winner,
+            turns=int(turns) if turns is not None else None,
+        )
+        for (_game_id, game_number, winner, turns) in game_rows
+    ]
+    raw_players: list[Any] = list(players or [])
+    return MatchDetail(
+        match_id=str(row_id),
+        format=fmt,
+        players=[str(p) for p in raw_players],
+        played_at=parsed_at,
+        games=games,
+    )

--- a/services/analytics/tests/test_cards.py
+++ b/services/analytics/tests/test_cards.py
@@ -1,0 +1,174 @@
+"""Card search endpoint tests.
+
+The handler does direct SQL via ``db.execute(text(...))`` — we override
+the ``get_session`` dep with a fake session that records the query and
+returns prefab rows so we can exercise the blank-query fast path, a
+matching search, and an empty-result search without a live Postgres.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _analytics_test_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    out = tmp_path_factory.mktemp("analytics-jwt-keys-cards")
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pub_path = out / "jwt_public.pem"
+    pub_path.write_bytes(pub_pem)
+    os.environ["DA_JWT_PUBLIC_KEY_PATH"] = str(pub_path)
+    os.environ.setdefault("DA_DATABASE_URL", "postgresql+asyncpg://x:x@localhost:5432/x")
+    os.environ.setdefault("DA_REDIS_URL", "redis://localhost:6379/0")
+    yield pub_path
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from analytics_service import main as _main
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 7) -> Any:
+    from analytics_service import deps as _deps
+
+    fake = _deps.AuthenticatedUser(user_id=user_id, role="user")
+
+    async def _dep() -> _deps.AuthenticatedUser:
+        return fake
+
+    return _dep
+
+
+class _FakeResult:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[tuple[Any, ...]]:
+        return list(self._rows)
+
+
+class _FakeSession:
+    """Captures execute calls; returns canned row sets in order."""
+
+    def __init__(self, *, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(self, _stmt: Any, params: dict[str, Any] | None = None) -> _FakeResult:
+        self.calls.append(dict(params or {}))
+        return _FakeResult(self._rows)
+
+
+def _override_session(session: _FakeSession) -> Any:
+    async def _dep() -> AsyncIterator[Any]:
+        yield session
+
+    return _dep
+
+
+@pytest.mark.asyncio
+async def test_cards_blank_query_returns_empty_list_without_hitting_db(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    session = _FakeSession(rows=[("should-not-appear", None, None, None, None, None)])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/cards", params={"q": "   "})
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert r.json() == []
+    # Blank query short-circuits without an execute() call.
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_cards_returns_matches(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    session = _FakeSession(
+        rows=[
+            (
+                "Lightning Bolt",
+                "{R}",
+                "Instant",
+                "Lightning Bolt deals 3 damage to any target.",
+                "https://example/lb.jpg",
+                "lea",
+            ),
+            (
+                "Lightning Strike",
+                "{1}{R}",
+                "Instant",
+                "Lightning Strike deals 3 damage to any target.",
+                None,
+                "thb",
+            ),
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/cards", params={"q": "Lightning"})
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 2
+    assert body[0]["name"] == "Lightning Bolt"
+    assert body[0]["mana_cost"] == "{R}"
+    assert body[0]["image_uri"] == "https://example/lb.jpg"
+    assert body[1]["image_uri"] is None
+    # Confirm the ILIKE pattern was assembled with wildcards.
+    assert session.calls[0]["pattern"] == "%Lightning%"
+    assert session.calls[0]["limit"] == 20
+
+
+@pytest.mark.asyncio
+async def test_cards_no_matches_returns_empty_list(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    session = _FakeSession(rows=[])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/cards", params={"q": "zzznosuchcard"})
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+@pytest.mark.asyncio
+async def test_cards_unauth_returns_401(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get("/analytics/cards", params={"q": "Bolt"})
+    assert r.status_code == 401

--- a/services/analytics/tests/test_matches.py
+++ b/services/analytics/tests/test_matches.py
@@ -1,0 +1,230 @@
+"""Match detail endpoint tests.
+
+The handler does two direct SQL queries: the match lookup (with the
+``WHERE user_id = :user_id`` ownership filter) and the games-with-turns
+join. We override ``get_session`` with a fake session that returns
+canned row sets in order, so we can verify the ownership filter,
+404 paths, and games aggregation without a live Postgres.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _analytics_test_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    out = tmp_path_factory.mktemp("analytics-jwt-keys-matches")
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pub_path = out / "jwt_public.pem"
+    pub_path.write_bytes(pub_pem)
+    os.environ["DA_JWT_PUBLIC_KEY_PATH"] = str(pub_path)
+    os.environ.setdefault("DA_DATABASE_URL", "postgresql+asyncpg://x:x@localhost:5432/x")
+    os.environ.setdefault("DA_REDIS_URL", "redis://localhost:6379/0")
+    yield pub_path
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from analytics_service import main as _main
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 7) -> Any:
+    from analytics_service import deps as _deps
+
+    fake = _deps.AuthenticatedUser(user_id=user_id, role="user")
+
+    async def _dep() -> _deps.AuthenticatedUser:
+        return fake
+
+    return _dep
+
+
+class _RowProxy:
+    """Mimics SQLAlchemy Row: supports tuple-unpacking AND .one_or_none()."""
+
+    def __init__(self, row: tuple[Any, ...]) -> None:
+        self._row = row
+
+    def __iter__(self) -> Any:
+        return iter(self._row)
+
+    def __len__(self) -> int:
+        return len(self._row)
+
+    def __getitem__(self, idx: int) -> Any:
+        return self._row[idx]
+
+
+class _FakeResult:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[_RowProxy]:
+        return [_RowProxy(r) for r in self._rows]
+
+    def one_or_none(self) -> _RowProxy | None:
+        if not self._rows:
+            return None
+        return _RowProxy(self._rows[0])
+
+
+class _FakeSession:
+    """Records execute() calls and pops results from a queue."""
+
+    def __init__(self, *, queue: list[list[tuple[Any, ...]]]) -> None:
+        self._queue = queue
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(self, _stmt: Any, params: dict[str, Any] | None = None) -> _FakeResult:
+        self.calls.append(dict(params or {}))
+        rows = self._queue.pop(0) if self._queue else []
+        return _FakeResult(rows)
+
+
+def _override_session(session: _FakeSession) -> Any:
+    async def _dep() -> AsyncIterator[Any]:
+        yield session
+
+    return _dep
+
+
+@pytest.mark.asyncio
+async def test_match_detail_returns_match_with_games(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    match_id = uuid.uuid4()
+    game_1_id = uuid.uuid4()
+    game_2_id = uuid.uuid4()
+    played_at = datetime(2026, 5, 9, 12, 30, tzinfo=UTC)
+    session = _FakeSession(
+        queue=[
+            # match row
+            [(match_id, "Modern", ["alice", "bob"], played_at)],
+            # games rows: (game_id, game_number, winner, turns)
+            [
+                (game_1_id, 1, "alice", 8),
+                (game_2_id, 2, "bob", 11),
+            ],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user(user_id=7)
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get(f"/analytics/matches/{match_id}")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["match_id"] == str(match_id)
+    assert body["format"] == "Modern"
+    assert body["players"] == ["alice", "bob"]
+    assert len(body["games"]) == 2
+    assert body["games"][0]["game_number"] == 1
+    assert body["games"][0]["winner"] == "alice"
+    assert body["games"][0]["turns"] == 8
+    assert body["games"][1]["turns"] == 11
+    # Ownership filter is applied: the match query received both
+    # match_id and user_id parameters.
+    first_call = session.calls[0]
+    assert first_call["match_id"] == match_id
+    assert first_call["user_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_match_detail_404_when_not_found_or_not_owned(
+    app_client: httpx.AsyncClient,
+) -> None:
+    """Empty match-row result yields a 404.
+
+    The handler's WHERE clause filters by both ``id`` and ``user_id``,
+    so a not-owned match returns zero rows — same shape as not-found.
+    Testing the empty-rows path covers both cases.
+    """
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    match_id = uuid.uuid4()
+    session = _FakeSession(queue=[[]])  # no match row
+    _main.app.dependency_overrides[_deps.require_user] = _override_user(user_id=999)
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get(f"/analytics/matches/{match_id}")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 404
+    assert r.json()["detail"]["error"] == "match_not_found"
+
+
+@pytest.mark.asyncio
+async def test_match_detail_handles_missing_turns_gracefully(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    match_id = uuid.uuid4()
+    game_id = uuid.uuid4()
+    session = _FakeSession(
+        queue=[
+            [(match_id, None, ["alice", "bob"], None)],
+            # turns column is NULL when the parser didn't store game states
+            [(game_id, 1, "alice", None)],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user(user_id=7)
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get(f"/analytics/matches/{match_id}")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["games"][0]["turns"] is None
+    assert body["format"] is None
+
+
+@pytest.mark.asyncio
+async def test_match_detail_unauth_returns_401(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get(f"/analytics/matches/{uuid.uuid4()}")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_match_detail_malformed_id_returns_422(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get("/analytics/matches/not-a-uuid")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 422

--- a/services/web/tests/test_admin_cards_route.py
+++ b/services/web/tests/test_admin_cards_route.py
@@ -1,0 +1,238 @@
+"""Tests for the /admin/cards admin route.
+
+Bypasses browser auth via FastAPI dependency overrides and patches the
+analytics client. Covers admin gating, the happy path (status + scraper
+health render), the sync trigger redirect, and the analytics-outage
+banner.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_admin(user_id: int = 1, token: str = "admin-tok") -> Any:
+    from web_service import deps as _deps
+
+    fake_admin = _deps.BrowserUser(
+        user_id=user_id,
+        email="admin@local",
+        role="admin",
+        must_change_password=False,
+        scope=None,
+        token=token,
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_admin
+
+    return _dep
+
+
+def _override_user(user_id: int = 42, token: str = "user-tok") -> Any:
+    from web_service import deps as _deps
+
+    fake_user = _deps.BrowserUser(
+        user_id=user_id,
+        email="alice@example.com",
+        role="user",
+        must_change_password=False,
+        scope=None,
+        token=token,
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_user
+
+    return _dep
+
+
+def _sample_status() -> dict[str, Any]:
+    return {
+        "card_count": 31337,
+        "last_sync_at": datetime(2026, 5, 9, 1, 0, tzinfo=UTC),
+    }
+
+
+def _sample_health(broken: bool = False) -> dict[str, Any]:
+    return {
+        "scraper_name": "mtgo",
+        "last_run_at": datetime(2026, 5, 10, 6, 0, tzinfo=UTC),
+        "last_success_at": datetime(2026, 5, 10, 6, 0, tzinfo=UTC),
+        "consecutive_failures": 3 if broken else 0,
+        "is_broken": broken,
+        "last_error": "boom" if broken else None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_admin_cards_renders(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_status(_url: str, _token: str) -> Any:
+        return _sample_status()
+
+    async def fake_health(_url: str, _token: str) -> Any:
+        return _sample_health()
+
+    monkeypatch.setattr(analytics_client, "admin_get_cards_status", fake_status)
+    monkeypatch.setattr(analytics_client, "admin_get_scraper_health", fake_health)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        r = await app_client.get("/admin/cards")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    text = r.text
+    assert "31337" in text
+    assert "MTGO scraper health" in text
+    # Sync button + form present
+    assert 'action="/admin/cards/sync"' in text
+    assert "OK" in text  # not broken
+    assert "Sync started" not in text  # not via ?synced=1
+
+
+@pytest.mark.asyncio
+async def test_admin_cards_shows_synced_banner(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_status(*_a: Any, **_kw: Any) -> Any:
+        return _sample_status()
+
+    async def fake_health(*_a: Any, **_kw: Any) -> Any:
+        return _sample_health()
+
+    monkeypatch.setattr(analytics_client, "admin_get_cards_status", fake_status)
+    monkeypatch.setattr(analytics_client, "admin_get_scraper_health", fake_health)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        r = await app_client.get("/admin/cards", params={"synced": 1})
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Sync started" in r.text
+
+
+@pytest.mark.asyncio
+async def test_admin_cards_outage_banner_when_status_unavailable(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom_status(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("simulated outage")
+
+    async def boom_health(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("simulated outage")
+
+    monkeypatch.setattr(analytics_client, "admin_get_cards_status", boom_status)
+    monkeypatch.setattr(analytics_client, "admin_get_scraper_health", boom_health)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        r = await app_client.get("/admin/cards")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    # Both panels failed → 503.
+    assert r.status_code == 503
+    assert "Analytics service unavailable" in r.text
+
+
+@pytest.mark.asyncio
+async def test_admin_cards_non_admin_403(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/admin/cards")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_cards_sync_redirects_to_synced_marker(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    triggered: dict[str, bool] = {}
+
+    async def fake_trigger(_url: str, _token: str) -> bool:
+        triggered["called"] = True
+        return True
+
+    monkeypatch.setattr(analytics_client, "admin_trigger_sync", fake_trigger)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        # follow_redirects defaults to False on AsyncClient — we want
+        # to assert the redirect target itself.
+        r = await app_client.post("/admin/cards/sync")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/admin/cards?synced=1"
+    assert triggered.get("called") is True
+
+
+@pytest.mark.asyncio
+async def test_admin_cards_sync_non_admin_403(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.post("/admin/cards/sync")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 403

--- a/services/web/tests/test_cards_route.py
+++ b/services/web/tests/test_cards_route.py
@@ -1,0 +1,174 @@
+"""Tests for the user-facing /cards search route.
+
+Bypasses browser auth via FastAPI dependency overrides and patches the
+analytics client so we can exercise template rendering, the empty
+search form, the empty-results path, and the error-banner branch
+without a live analytics service.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 42, token: str = "user-tok") -> Any:
+    from web_service import deps as _deps
+
+    fake_user = _deps.BrowserUser(
+        user_id=user_id,
+        email="alice@example.com",
+        role="user",
+        must_change_password=False,
+        scope=None,
+        token=token,
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_user
+
+    return _dep
+
+
+def _sample_card(name: str = "Lightning Bolt", with_image: bool = True) -> Any:
+    from web_service import analytics_client
+
+    return analytics_client.CardItem(
+        name=name,
+        mana_cost="{R}",
+        type_line="Instant",
+        oracle_text="Lightning Bolt deals 3 damage to any target.",
+        image_uri="https://example/lb.jpg" if with_image else None,
+        set_code="lea",
+    )
+
+
+@pytest.mark.asyncio
+async def test_cards_blank_query_renders_form_only(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:  # would-be analytics call
+        raise AssertionError("search_cards should not be called for blank query")
+
+    monkeypatch.setattr(analytics_client, "search_cards", boom)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/cards")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Card Search" in r.text
+    assert "Search card name" in r.text
+    assert "No cards found" not in r.text
+
+
+@pytest.mark.asyncio
+async def test_cards_search_renders_results(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    seen: dict[str, Any] = {}
+
+    async def fake_search(_url: str, _token: str, q: str) -> Any:
+        seen["q"] = q
+        return [_sample_card(), _sample_card(name="Lightning Strike", with_image=False)]
+
+    monkeypatch.setattr(analytics_client, "search_cards", fake_search)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/cards", params={"q": "Lightning"})
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert seen["q"] == "Lightning"
+    text = r.text
+    assert "Lightning Bolt" in text
+    assert "Lightning Strike" in text
+    assert "https://example/lb.jpg" in text
+    assert "Search unavailable" not in text
+
+
+@pytest.mark.asyncio
+async def test_cards_search_no_results_message(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_search(_url: str, _token: str, _q: str) -> Any:
+        return []
+
+    monkeypatch.setattr(analytics_client, "search_cards", fake_search)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/cards", params={"q": "zzznosuch"})
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "No cards found" in r.text
+
+
+@pytest.mark.asyncio
+async def test_cards_search_error_banner_on_analytics_failure(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("simulated outage")
+
+    monkeypatch.setattr(analytics_client, "search_cards", boom)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/cards", params={"q": "Bolt"})
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Search unavailable" in r.text
+
+
+@pytest.mark.asyncio
+async def test_cards_unauth_redirects_to_login(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get("/cards")
+    assert r.status_code == 302
+    assert r.headers["location"].startswith("/login")

--- a/services/web/tests/test_match_detail_route.py
+++ b/services/web/tests/test_match_detail_route.py
@@ -1,0 +1,207 @@
+"""Tests for the /matches/{match_id} detail route.
+
+Bypasses browser auth via FastAPI dependency overrides and patches the
+analytics client. Covers the happy path (renders metadata + games),
+the 404 path (analytics returned None), the analytics-outage 503, and
+the overall W/L/D computation from the games list.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 42, token: str = "user-tok") -> Any:
+    from web_service import deps as _deps
+
+    fake_user = _deps.BrowserUser(
+        user_id=user_id,
+        email="alice@example.com",
+        role="user",
+        must_change_password=False,
+        scope=None,
+        token=token,
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_user
+
+    return _dep
+
+
+def _sample_match(
+    *,
+    match_id: str,
+    games_won_by_uploader: int = 2,
+    games_won_by_opponent: int = 1,
+) -> Any:
+    from web_service import analytics_client
+
+    games: list[Any] = []
+    n = 0
+    for _ in range(games_won_by_uploader):
+        n += 1
+        games.append(analytics_client.GameItem(game_number=n, winner="alice", turns=7))
+    for _ in range(games_won_by_opponent):
+        n += 1
+        games.append(analytics_client.GameItem(game_number=n, winner="bob", turns=10))
+    return analytics_client.MatchDetail(
+        match_id=match_id,
+        format_="Modern",
+        players=["alice", "bob"],
+        played_at=datetime(2026, 5, 9, 12, 0, tzinfo=UTC),
+        games=games,
+    )
+
+
+@pytest.mark.asyncio
+async def test_match_detail_renders(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    match_id = str(uuid.uuid4())
+
+    async def fake_detail(_url: str, _token: str, mid: str) -> Any:
+        assert mid == match_id
+        return _sample_match(match_id=match_id)
+
+    monkeypatch.setattr(analytics_client, "get_match_detail", fake_detail)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(f"/matches/{match_id}")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    text = r.text
+    # Title uses first 8 chars of the match id.
+    assert match_id[:8] in text
+    assert "Modern" in text
+    assert "alice" in text
+    assert "bob" in text
+    # Three games rendered (2W, 1L) → overall W.
+    assert "result-win" in text
+
+
+@pytest.mark.asyncio
+async def test_match_detail_overall_loss(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    match_id = str(uuid.uuid4())
+
+    async def fake_detail(_url: str, _token: str, _mid: str) -> Any:
+        return _sample_match(
+            match_id=match_id,
+            games_won_by_uploader=0,
+            games_won_by_opponent=2,
+        )
+
+    monkeypatch.setattr(analytics_client, "get_match_detail", fake_detail)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(f"/matches/{match_id}")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "result-loss" in r.text
+
+
+@pytest.mark.asyncio
+async def test_match_detail_404_when_analytics_returns_none(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_detail(*_a: Any, **_kw: Any) -> Any:
+        return None
+
+    monkeypatch.setattr(analytics_client, "get_match_detail", fake_detail)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(f"/matches/{uuid.uuid4()}")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 404
+    assert "Match not found" in r.text
+
+
+@pytest.mark.asyncio
+async def test_match_detail_503_when_analytics_unavailable(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("simulated outage")
+
+    monkeypatch.setattr(analytics_client, "get_match_detail", boom)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(f"/matches/{uuid.uuid4()}")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_match_detail_malformed_id_returns_422(app_client: httpx.AsyncClient) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/matches/not-a-uuid")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_match_detail_unauth_redirects_to_login(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get(f"/matches/{uuid.uuid4()}")
+    assert r.status_code == 302
+    assert r.headers["location"].startswith("/login")

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -334,6 +334,190 @@ async def get_stats_by_format(base_url: str, token: str) -> list[FormatStatItem]
     return [_to_format_stat(row) for row in resp.json()]
 
 
+# ---------------------------------------------------------------------------
+# Card search
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CardItem:
+    name: str
+    mana_cost: str | None
+    type_line: str | None
+    oracle_text: str | None
+    image_uri: str | None
+    set_code: str | None
+
+
+def _to_card(payload: dict[str, Any]) -> CardItem:
+    return CardItem(
+        name=str(payload.get("name") or ""),
+        mana_cost=payload.get("mana_cost"),
+        type_line=payload.get("type_line"),
+        oracle_text=payload.get("oracle_text"),
+        image_uri=payload.get("image_uri"),
+        set_code=payload.get("set_code"),
+    )
+
+
+async def search_cards(base_url: str, token: str, q: str) -> list[CardItem]:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/cards",
+                params={"q": q},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(f"analytics GET /cards transport error: {exc}") from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /cards returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(f"analytics GET /cards returned {resp.status_code}: {resp.text}")
+    return [_to_card(row) for row in resp.json()]
+
+
+# ---------------------------------------------------------------------------
+# Admin cards
+# ---------------------------------------------------------------------------
+
+
+async def admin_get_cards_status(base_url: str, token: str) -> dict[str, Any]:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/admin/cards-status",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /admin/cards-status transport error: {exc}"
+        ) from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /admin/cards-status returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /admin/cards-status returned {resp.status_code}: {resp.text}"
+        )
+    payload = resp.json()
+    return {
+        "card_count": int(payload.get("card_count") or 0),
+        "last_sync_at": _parse_dt(payload.get("last_sync_at")),
+    }
+
+
+async def admin_get_scraper_health(base_url: str, token: str) -> dict[str, Any]:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/admin/scraper-health",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /admin/scraper-health transport error: {exc}"
+        ) from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /admin/scraper-health returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /admin/scraper-health returned {resp.status_code}: {resp.text}"
+        )
+    payload = resp.json()
+    last_run = _parse_dt(payload.get("last_run_at"))
+    last_success = _parse_dt(payload.get("last_success_at"))
+    return {
+        "scraper_name": payload.get("scraper_name"),
+        "last_run_at": last_run,
+        "last_success_at": last_success,
+        "consecutive_failures": int(payload.get("consecutive_failures") or 0),
+        "is_broken": bool(payload.get("is_broken")),
+        "last_error": payload.get("last_error"),
+    }
+
+
+async def admin_trigger_sync(base_url: str, token: str) -> bool:
+    """Kick off a card sync. Returns True on 202 (sync scheduled)."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{base_url}/analytics/admin/sync-cards",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics POST /admin/sync-cards transport error: {exc}"
+        ) from exc
+    if resp.status_code == 202:
+        return True
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics POST /admin/sync-cards returned {resp.status_code}")
+    raise AnalyticsClientError(
+        f"analytics POST /admin/sync-cards returned {resp.status_code}: {resp.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Match detail
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GameItem:
+    game_number: int
+    winner: str | None
+    turns: int | None
+
+
+@dataclass
+class MatchDetail:
+    match_id: str
+    format_: str | None
+    players: list[str]
+    played_at: datetime | None
+    games: list[GameItem] = field(default_factory=list)
+
+
+def _to_game(payload: dict[str, Any]) -> GameItem:
+    raw_turns = payload.get("turns")
+    return GameItem(
+        game_number=int(payload.get("game_number") or 0),
+        winner=payload.get("winner"),
+        turns=int(raw_turns) if raw_turns is not None else None,
+    )
+
+
+def _to_match_detail(payload: dict[str, Any]) -> MatchDetail:
+    return MatchDetail(
+        match_id=str(payload.get("match_id") or ""),
+        format_=payload.get("format"),
+        players=[str(p) for p in (payload.get("players") or [])],
+        played_at=_parse_dt(payload.get("played_at")),
+        games=[_to_game(g) for g in (payload.get("games") or [])],
+    )
+
+
+async def get_match_detail(base_url: str, token: str, match_id: str) -> MatchDetail | None:
+    """Fetch a single match. Returns None on 404."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/matches/{match_id}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(f"analytics GET /matches/{{id}} transport error: {exc}") from exc
+    if resp.status_code == 404:
+        return None
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /matches/{{id}} returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /matches/{{id}} returned {resp.status_code}: {resp.text}"
+        )
+    return _to_match_detail(resp.json())
+
+
 async def get_stats_by_opponent(base_url: str, token: str) -> list[OpponentStatItem]:
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -550,6 +550,86 @@ async def profile_agents_revoke(
     return RedirectResponse(url="/profile/agents", status_code=status.HTTP_303_SEE_OTHER)
 
 
+@app.get("/cards", response_class=HTMLResponse)
+async def cards_search_page(
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+    q: Annotated[str, Query()] = "",
+) -> Response:
+    """Card search page — ILIKE against the Scryfall mirror."""
+    needle = q.strip()
+    results: list[Any] = []
+    search_error = False
+    if needle:
+        try:
+            results = await analytics_client.search_cards(
+                settings.analytics_service_url, user.token, needle
+            )
+        except analytics_client.AnalyticsForbidden:
+            return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
+        except analytics_client.AnalyticsClientError:
+            _log.exception("analytics GET /cards call failed")
+            search_error = True
+    return templates.TemplateResponse(
+        request,
+        "cards.html",
+        {
+            "user": user,
+            "q": needle,
+            "submitted": bool(needle),
+            "results": results,
+            "search_error": search_error,
+        },
+    )
+
+
+@app.get("/matches/{match_id}", response_class=HTMLResponse)
+async def match_detail_page(
+    match_id: uuid.UUID,
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    try:
+        match = await analytics_client.get_match_detail(
+            settings.analytics_service_url, user.token, str(match_id)
+        )
+    except analytics_client.AnalyticsForbidden:
+        return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics GET /matches/{id} call failed")
+        return Response(
+            content="Analytics service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    if match is None:
+        return Response(content="Match not found.", status_code=status.HTTP_404_NOT_FOUND)
+
+    # Compute overall W/L/D from the games list using the same
+    # "uploader is players[0]" convention the dashboard uses.
+    overall_result = ""
+    if match.players and match.games:
+        uploader = match.players[0]
+        user_wins = sum(1 for g in match.games if g.winner == uploader)
+        opp_wins = sum(1 for g in match.games if g.winner is not None and g.winner != uploader)
+        if user_wins > opp_wins:
+            overall_result = "W"
+        elif user_wins < opp_wins:
+            overall_result = "L"
+        elif user_wins or opp_wins:
+            overall_result = "D"
+    return templates.TemplateResponse(
+        request,
+        "match_detail.html",
+        {
+            "user": user,
+            "match": match,
+            "overall_result": overall_result,
+        },
+    )
+
+
 def _service_unavailable(request: Request, user: BrowserUser) -> Response:
     return templates.TemplateResponse(
         request,
@@ -1728,6 +1808,115 @@ async def admin_archetypes_delete(
         content="Could not delete archetype.",
         status_code=status.HTTP_400_BAD_REQUEST,
     )
+
+
+# ---------------------------------------------------------------------------
+# Admin cards — Scryfall mirror status + manual sync
+# ---------------------------------------------------------------------------
+
+
+def _render_admin_cards(
+    request: Request,
+    user: BrowserUser,
+    *,
+    cards_status_view: dict[str, Any] | None,
+    scraper_health: dict[str, Any] | None,
+    error: str | None,
+    synced: bool,
+    status_code: int,
+) -> Response:
+    return templates.TemplateResponse(
+        request,
+        "admin_cards.html",
+        {
+            "user": user,
+            "cards_status": cards_status_view,
+            "scraper_health": scraper_health,
+            "error": error,
+            "synced": synced,
+        },
+        status_code=status_code,
+    )
+
+
+@app.get("/admin/cards", response_class=HTMLResponse)
+async def admin_cards_page(
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+    synced: Annotated[int, Query(ge=0, le=1)] = 0,
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    cards_status_view: dict[str, Any] | None = None
+    scraper_health: dict[str, Any] | None = None
+    error: str | None = None
+    try:
+        cards_status_view = await analytics_client.admin_get_cards_status(
+            settings.analytics_service_url, user.token
+        )
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.cards.status.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics GET /admin/cards-status call failed")
+        error = "Analytics service unavailable. Please try again."
+
+    try:
+        scraper_health = await analytics_client.admin_get_scraper_health(
+            settings.analytics_service_url, user.token
+        )
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.cards.health.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics GET /admin/scraper-health call failed")
+        # Surface partial data — the status panel is independent of the
+        # scraper-health panel. Avoid overwriting an earlier error.
+        if error is None:
+            error = "Scraper health unavailable. Please try again."
+
+    code = (
+        status.HTTP_503_SERVICE_UNAVAILABLE
+        if error and cards_status_view is None and scraper_health is None
+        else 200
+    )
+    return _render_admin_cards(
+        request,
+        user,
+        cards_status_view=cards_status_view,
+        scraper_health=scraper_health,
+        error=error,
+        synced=synced == 1,
+        status_code=code,
+    )
+
+
+@app.post("/admin/cards/sync")
+async def admin_cards_sync(
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    try:
+        await analytics_client.admin_trigger_sync(settings.analytics_service_url, user.token)
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.cards.sync.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics POST /admin/sync-cards call failed")
+        return Response(
+            content="Analytics service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    return RedirectResponse(url="/admin/cards?synced=1", status_code=status.HTTP_303_SEE_OTHER)
 
 
 # ---------------------------------------------------------------------------

--- a/services/web/web_service/templates/admin_agents.html
+++ b/services/web/web_service/templates/admin_agents.html
@@ -10,6 +10,8 @@
         <span class="muted"> · </span>
         <a href="/admin/agents" aria-current="page"><strong>Agents</strong></a>
         <span class="muted"> · </span>
+        <a href="/admin/cards">Cards</a>
+        <span class="muted"> · </span>
         <a href="/admin/invites">Invites</a>
         <span class="muted"> · </span>
         <a href="/admin/settings">Settings</a>

--- a/services/web/web_service/templates/admin_archetypes.html
+++ b/services/web/web_service/templates/admin_archetypes.html
@@ -12,6 +12,8 @@
         <span class="muted"> · </span>
         <a href="/admin/archetypes" aria-current="page"><strong>Archetypes</strong></a>
         <span class="muted"> · </span>
+        <a href="/admin/cards">Cards</a>
+        <span class="muted"> · </span>
         <a href="/admin/invites">Invites</a>
         <span class="muted"> · </span>
         <a href="/admin/settings">Settings</a>

--- a/services/web/web_service/templates/admin_archetypes_edit.html
+++ b/services/web/web_service/templates/admin_archetypes_edit.html
@@ -16,6 +16,8 @@
         <span class="muted"> · </span>
         <a href="/admin/archetypes" aria-current="page"><strong>Archetypes</strong></a>
         <span class="muted"> · </span>
+        <a href="/admin/cards">Cards</a>
+        <span class="muted"> · </span>
         <a href="/admin/invites">Invites</a>
         <span class="muted"> · </span>
         <a href="/admin/settings">Settings</a>

--- a/services/web/web_service/templates/admin_cards.html
+++ b/services/web/web_service/templates/admin_cards.html
@@ -1,0 +1,99 @@
+{% extends "base.html" %}
+
+{% block title %}Admin · Cards · Deep Analysis{% endblock %}
+
+{% block content %}
+<section class="panel">
+    <h1>Cards</h1>
+    <nav class="admin-subnav">
+        <a href="/admin/users">Users</a>
+        <span class="muted"> · </span>
+        <a href="/admin/agents">Agents</a>
+        <span class="muted"> · </span>
+        <a href="/admin/archetypes">Archetypes</a>
+        <span class="muted"> · </span>
+        <a href="/admin/cards" aria-current="page"><strong>Cards</strong></a>
+        <span class="muted"> · </span>
+        <a href="/admin/invites">Invites</a>
+        <span class="muted"> · </span>
+        <a href="/admin/settings">Settings</a>
+    </nav>
+
+    {% if error %}
+    <div class="alert alert-error" role="alert">{{ error }}</div>
+    {% endif %}
+
+    {% if synced %}
+    <div class="alert alert-info" role="status">
+        Sync started. Card mirror refresh runs in the background; reload in a few minutes to see updated totals.
+    </div>
+    {% endif %}
+
+    <h2>Card mirror</h2>
+    {% if cards_status %}
+    <ul class="stats-summary">
+        <li><strong>Cards in database:</strong> {{ cards_status.card_count }}</li>
+        <li><strong>Last sync:</strong>
+            {% if cards_status.last_sync_at %}
+                {{ cards_status.last_sync_at.strftime("%Y-%m-%d %H:%M UTC") }}
+            {% else %}
+                Never
+            {% endif %}
+        </li>
+    </ul>
+    {% else %}
+        <p class="muted">Card mirror status unavailable.</p>
+    {% endif %}
+
+    <form method="post" action="/admin/cards/sync" class="inline-form">
+        <button type="submit" class="btn btn-primary">Sync Now</button>
+    </form>
+
+    <h2>MTGO scraper health</h2>
+    {% if scraper_health %}
+    <ul class="stats-summary">
+        <li><strong>Last run:</strong>
+            {% if scraper_health.last_run_at %}
+                {{ scraper_health.last_run_at.strftime("%Y-%m-%d %H:%M UTC") }}
+            {% else %}
+                Never
+            {% endif %}
+        </li>
+        <li><strong>Last success:</strong>
+            {% if scraper_health.last_success_at %}
+                {{ scraper_health.last_success_at.strftime("%Y-%m-%d %H:%M UTC") }}
+            {% else %}
+                Never
+            {% endif %}
+        </li>
+        <li><strong>Status:</strong>
+            {% if scraper_health.is_broken %}
+                <span class="result-badge result-loss">Broken</span>
+            {% else %}
+                <span class="result-badge result-win">OK</span>
+            {% endif %}
+        </li>
+        <li><strong>Consecutive failures:</strong> {{ scraper_health.consecutive_failures }}</li>
+    </ul>
+    {% if scraper_health.last_error %}
+    <p class="muted">Last error: {{ scraper_health.last_error }}</p>
+    {% endif %}
+    {% else %}
+        <p class="muted">Scraper health unavailable.</p>
+    {% endif %}
+</section>
+
+<style>
+.stats-summary { list-style: none; padding: 0; display: flex; gap: 2rem; flex-wrap: wrap; }
+.stats-summary li { padding: 0.5rem 0; }
+.result-badge {
+    display: inline-block;
+    padding: 0.1rem 0.4rem;
+    text-align: center;
+    font-weight: bold;
+    border-radius: 3px;
+}
+.result-win { background: #d4edda; color: #155724; }
+.result-loss { background: #f8d7da; color: #721c24; }
+</style>
+{% endblock %}

--- a/services/web/web_service/templates/admin_invites.html
+++ b/services/web/web_service/templates/admin_invites.html
@@ -10,6 +10,8 @@
         <span class="muted"> · </span>
         <a href="/admin/agents">Agents</a>
         <span class="muted"> · </span>
+        <a href="/admin/cards">Cards</a>
+        <span class="muted"> · </span>
         <a href="/admin/invites" aria-current="page"><strong>Invites</strong></a>
         <span class="muted"> · </span>
         <a href="/admin/settings">Settings</a>

--- a/services/web/web_service/templates/admin_settings.html
+++ b/services/web/web_service/templates/admin_settings.html
@@ -10,6 +10,8 @@
         <span class="muted"> · </span>
         <a href="/admin/agents">Agents</a>
         <span class="muted"> · </span>
+        <a href="/admin/cards">Cards</a>
+        <span class="muted"> · </span>
         <a href="/admin/invites">Invites</a>
         <span class="muted"> · </span>
         <a href="/admin/settings" aria-current="page"><strong>Settings</strong></a>

--- a/services/web/web_service/templates/admin_users.html
+++ b/services/web/web_service/templates/admin_users.html
@@ -10,6 +10,8 @@
         <span class="muted"> · </span>
         <a href="/admin/agents">Agents</a>
         <span class="muted"> · </span>
+        <a href="/admin/cards">Cards</a>
+        <span class="muted"> · </span>
         <a href="/admin/invites">Invites</a>
         <span class="muted"> · </span>
         <a href="/admin/settings">Settings</a>

--- a/services/web/web_service/templates/base.html
+++ b/services/web/web_service/templates/base.html
@@ -12,6 +12,7 @@
             <a class="site-logo" href="/dashboard">Deep Analysis</a>
             <nav class="site-nav">
                 {% if user %}
+                    <a class="nav-link" href="/cards">Cards</a>
                     {% if user.email %}
                         <span class="nav-user">{{ user.email }}</span>
                     {% else %}

--- a/services/web/web_service/templates/cards.html
+++ b/services/web/web_service/templates/cards.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% block title %}Card Search &middot; Deep Analysis{% endblock %}
+
+{% block content %}
+<section class="panel">
+    <h1>Card Search</h1>
+
+    {% if search_error %}
+    <div class="alert alert-error" role="alert">
+        Search unavailable — analytics service could not be reached.
+    </div>
+    {% endif %}
+
+    <form method="get" action="/cards" class="card-search-form">
+        <input
+            type="text"
+            name="q"
+            value="{{ q }}"
+            placeholder="Search card name..."
+            autocomplete="off"
+        >
+        <button type="submit" class="btn btn-primary">Search</button>
+    </form>
+
+    {% if submitted and not search_error %}
+        {% if not results %}
+            <p>No cards found for &ldquo;{{ q }}&rdquo;.</p>
+        {% else %}
+            <table class="data-table card-results">
+                <thead>
+                    <tr>
+                        <th>Image</th>
+                        <th>Name</th>
+                        <th>Mana cost</th>
+                        <th>Type</th>
+                        <th>Oracle text</th>
+                        <th>Set</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for card in results %}
+                    <tr>
+                        <td>
+                            {% if card.image_uri %}
+                                <img src="{{ card.image_uri }}" alt="{{ card.name }}" width="200">
+                            {% else %}
+                                &mdash;
+                            {% endif %}
+                        </td>
+                        <td><strong>{{ card.name }}</strong></td>
+                        <td>{{ card.mana_cost or "—" }}</td>
+                        <td>{{ card.type_line or "—" }}</td>
+                        <td class="card-oracle">{{ card.oracle_text or "—" }}</td>
+                        <td>{{ card.set_code or "—" }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    {% endif %}
+</section>
+
+<style>
+.card-search-form { margin-bottom: 1rem; display: flex; gap: 0.5rem; }
+.card-search-form input[type="text"] { flex: 1; max-width: 400px; padding: 0.5rem; }
+.card-results td { vertical-align: top; }
+.card-oracle { white-space: pre-line; max-width: 30rem; }
+</style>
+{% endblock %}

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -58,7 +58,11 @@
             <tbody>
                 {% for match in stats_summary.recent_matches %}
                 <tr>
-                    <td>{{ match.played_at.strftime("%Y-%m-%d") if match.played_at else "—" }}</td>
+                    <td>
+                        <a href="/matches/{{ match.match_id }}">
+                            {{ match.played_at.strftime("%Y-%m-%d") if match.played_at else match.match_id[:8] }}
+                        </a>
+                    </td>
                     <td>{{ match.opponent or "—" }}</td>
                     <td>{{ match.format_ or "—" }}</td>
                     <td>
@@ -111,6 +115,30 @@
 {% endif %}
 
 {% if opponent_stats|default([]) %}
+<section class="panel">
+    <h2>Top opponents</h2>
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>Opponent</th>
+                <th>Matches</th>
+                <th>Record</th>
+                <th>Win rate</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in opponent_stats[:5] %}
+            <tr>
+                <td>{{ row.opponent }}</td>
+                <td>{{ row.matches }}</td>
+                <td>{{ row.wins }}W / {{ row.losses }}L / {{ row.draws }}D</td>
+                <td>{{ "%.1f"|format(row.win_rate) }}%</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</section>
+
 <section class="panel">
     <h2>By opponent</h2>
     <table class="data-table">

--- a/services/web/web_service/templates/match_detail.html
+++ b/services/web/web_service/templates/match_detail.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block title %}Match {{ match.match_id[:8] }} &middot; Deep Analysis{% endblock %}
+
+{% block content %}
+<section class="panel">
+    <h1>Match {{ match.match_id[:8] }}</h1>
+
+    <ul class="match-meta">
+        <li><strong>Date:</strong>
+            {{ match.played_at.strftime("%Y-%m-%d %H:%M") if match.played_at else "—" }}
+        </li>
+        <li><strong>Format:</strong> {{ match.format_ or "—" }}</li>
+        <li><strong>Players:</strong>
+            {% if match.players %}
+                {{ match.players|join(", ") }}
+            {% else %}
+                —
+            {% endif %}
+        </li>
+        <li><strong>Result:</strong>
+            {% if overall_result == "W" %}
+                <span class="result-badge result-win">W</span>
+            {% elif overall_result == "L" %}
+                <span class="result-badge result-loss">L</span>
+            {% elif overall_result == "D" %}
+                <span class="result-badge result-draw">D</span>
+            {% else %}
+                —
+            {% endif %}
+        </li>
+    </ul>
+
+    <h2>Games</h2>
+    {% if not match.games %}
+        <p>Game data unavailable.</p>
+    {% else %}
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Game #</th>
+                    <th>Winner</th>
+                    <th>Turns</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for game in match.games %}
+                <tr>
+                    <td>{{ game.game_number }}</td>
+                    <td>{{ game.winner or "—" }}</td>
+                    <td>{{ game.turns if game.turns is not none else "—" }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+
+    <p><a href="/dashboard">&larr; Back to dashboard</a></p>
+</section>
+
+<style>
+.match-meta { list-style: none; padding: 0; display: flex; gap: 2rem; flex-wrap: wrap; }
+.match-meta li { padding: 0.25rem 0; }
+.result-badge {
+    display: inline-block;
+    min-width: 1.5rem;
+    padding: 0.1rem 0.4rem;
+    text-align: center;
+    font-weight: bold;
+    border-radius: 3px;
+}
+.result-win { background: #d4edda; color: #155724; }
+.result-loss { background: #f8d7da; color: #721c24; }
+.result-draw { background: #fff3cd; color: #856404; }
+</style>
+{% endblock %}

--- a/tests/test_route_prefix_convention.py
+++ b/tests/test_route_prefix_convention.py
@@ -70,6 +70,8 @@ _WEB_BROWSER_PATHS = frozenset(
         "/admin/settings",
         "/admin/settings/registration-mode",
         "/register",
+        "/cards",
+        "/matches/{match_id}",
     }
 )
 


### PR DESCRIPTION
## Summary

Four user-facing features for the v0.8.0 release:

- **Dashboard match links + Top opponents.** Recent-match rows now link to a per-match detail page; new "Top opponents" panel surfaces the 5 most-played opponents above the existing By opponent table.
- **Card search.** `GET /cards` runs an ILIKE substring search against the Scryfall `catalog.cards` mirror (top 20 by name) and renders results with art crops. Backed by new `GET /analytics/cards?q=…`.
- **Admin cards page.** `GET /admin/cards` shows mirror size + last sync timestamp and the MTGO scraper health row; `POST /admin/cards/sync` triggers a Scryfall refresh and redirects with a success banner. Backed by new `GET /analytics/admin/cards-status`.
- **Match detail view.** `GET /matches/{match_id}` shows match metadata + per-game outcomes with turn counts (when available). Ownership is enforced server-side — `GET /analytics/matches/{match_id}` requires `user_id` to match the JWT subject; non-owners and not-found both return 404.

Cards nav link added to `base.html` for logged-in users; admin subnav extended with Cards across all admin templates.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on all services and tests
- [x] `mypy services/web/web_service services/analytics/analytics_service` clean (one pre-existing settings.py warning unrelated)
- [x] `pytest services/analytics/tests services/web/tests` — 261 passing (26 new tests added across 5 files)
- [x] Self-review (`/self-review`) approved on `eb79019`
- [ ] CI compose-smoke E2E green on PR
- [ ] After merge: tag `v0.8.0` and verify release workflow publishes the 5 service images to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)