### PR TITLE
feat(parser): backfill scanner for ingested-but-not-parsed files

### DIFF
--- a/services/parser/parser_service/backfill.py
+++ b/services/parser/parser_service/backfill.py
@@ -27,9 +27,11 @@ _UNPARSED_SQL = text(
     """
     SELECT DISTINCT u.sha256, u.user_id
       FROM ingest.user_uploads u
+      JOIN ingest.game_log_files g ON g.sha256 = u.sha256
       LEFT JOIN parser.matches m
         ON m.sha256 = u.sha256 AND m.user_id = u.user_id
      WHERE m.id IS NULL
+       AND g.content_type = 'match-log'
      LIMIT :batch_size
     """
 )
@@ -46,7 +48,7 @@ async def scan_unparsed(
     if not rows:
         return 0
 
-    _log.info("backfill_scan_found", count=len(rows))
+    _log.info("backfill scan found %d unparsed files", len(rows))
     processed = 0
     for sha256, user_id in rows:
         try:
@@ -54,9 +56,9 @@ async def scan_unparsed(
             if result is not None:
                 processed += 1
         except Exception:  # noqa: BLE001
-            _log.exception("backfill_parse_failed", sha256=sha256, user_id=user_id)
+            _log.exception("backfill parse failed sha256=%s user_id=%s", sha256, user_id)
 
-    _log.info("backfill_scan_complete", found=len(rows), processed=processed)
+    _log.info("backfill scan complete found=%d processed=%d", len(rows), processed)
     return processed
 
 

--- a/services/parser/parser_service/backfill.py
+++ b/services/parser/parser_service/backfill.py
@@ -1,0 +1,78 @@
+"""Backfill scanner — finds ingested files that were never parsed.
+
+Runs as a periodic task inside the parser service. Queries across
+the ingest and parser schemas to find (sha256, user_id) pairs that
+exist in ``ingest.user_uploads`` but have no corresponding row in
+``parser.matches``, then feeds them through the normal parse pipeline.
+
+This closes the reliability gap in the Redis pub/sub delivery: if the
+parser misses a ``file.ingested`` event (downtime, DB outage, Redis
+blip), the backfill scan picks it up on the next pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from parser_service.consumer import ParserConsumer
+
+_log = logging.getLogger("parser.backfill")
+
+_UNPARSED_SQL = text(
+    """
+    SELECT DISTINCT u.sha256, u.user_id
+      FROM ingest.user_uploads u
+      LEFT JOIN parser.matches m
+        ON m.sha256 = u.sha256 AND m.user_id = u.user_id
+     WHERE m.id IS NULL
+     LIMIT :batch_size
+    """
+)
+
+
+async def scan_unparsed(
+    sm: async_sessionmaker[AsyncSession],
+    consumer: ParserConsumer,
+    batch_size: int = 100,
+) -> int:
+    async with sm() as session:
+        rows = (await session.execute(_UNPARSED_SQL, {"batch_size": batch_size})).all()
+
+    if not rows:
+        return 0
+
+    _log.info("backfill_scan_found", count=len(rows))
+    processed = 0
+    for sha256, user_id in rows:
+        try:
+            result = await consumer.handle_event(str(sha256), int(user_id))
+            if result is not None:
+                processed += 1
+        except Exception:  # noqa: BLE001
+            _log.exception("backfill_parse_failed", sha256=sha256, user_id=user_id)
+
+    _log.info("backfill_scan_complete", found=len(rows), processed=processed)
+    return processed
+
+
+async def backfill_loop(
+    sm: async_sessionmaker[AsyncSession],
+    consumer: ParserConsumer,
+    interval_seconds: int,
+    stop_event: asyncio.Event,
+) -> None:
+    _log.info("backfill scanner started interval=%ds", interval_seconds)
+    while not stop_event.is_set():
+        try:
+            await scan_unparsed(sm, consumer)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            _log.exception("backfill scan iteration failed")
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)

--- a/services/parser/parser_service/main.py
+++ b/services/parser/parser_service/main.py
@@ -19,6 +19,7 @@ from common.logging import configure_logging
 from common.metrics import mount_metrics
 from common.redis_client import EventPublisher, get_redis
 from parser_service import models as _models  # noqa: F401 — load Base.metadata
+from parser_service.backfill import backfill_loop
 from parser_service.consumer import ParserConsumer
 from parser_service.db import get_sessionmaker
 from parser_service.parsing import LogParser
@@ -31,17 +32,21 @@ _log = logging.getLogger("parser.main")
 
 _consumer: ParserConsumer | None = None
 _consumer_task: asyncio.Task[None] | None = None
+_backfill_task: asyncio.Task[None] | None = None
+_backfill_stop: asyncio.Event | None = None
 
 
 def reset_consumer() -> None:
     """Test hook."""
-    global _consumer, _consumer_task
+    global _consumer, _consumer_task, _backfill_task, _backfill_stop
     _consumer = None
     _consumer_task = None
+    _backfill_task = None
+    _backfill_stop = None
 
 
 async def _start_consumer() -> None:
-    global _consumer, _consumer_task
+    global _consumer, _consumer_task, _backfill_task, _backfill_stop
     settings = get_settings()
     client = await get_redis(settings.redis_url)
     sm = get_sessionmaker()
@@ -56,9 +61,29 @@ async def _start_consumer() -> None:
     _consumer_task = asyncio.create_task(_consumer.run(), name="parser-consumer")
     _log.info("parser consumer task started")
 
+    _backfill_stop = asyncio.Event()
+    _backfill_task = asyncio.create_task(
+        backfill_loop(sm, _consumer, settings.backfill_interval_seconds, _backfill_stop),
+        name="parser-backfill",
+    )
+
 
 async def _stop_consumer() -> None:
-    global _consumer, _consumer_task
+    global _consumer, _consumer_task, _backfill_task, _backfill_stop
+    if _backfill_stop is not None:
+        _backfill_stop.set()
+    if _backfill_task is not None:
+        try:
+            await asyncio.wait_for(_backfill_task, timeout=5.0)
+        except TimeoutError:
+            _backfill_task.cancel()
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            _log.exception("backfill task raised on shutdown")
+    _backfill_task = None
+    _backfill_stop = None
+
     if _consumer is not None:
         _consumer.stop()
     if _consumer_task is not None:

--- a/services/parser/parser_service/settings.py
+++ b/services/parser/parser_service/settings.py
@@ -23,6 +23,8 @@ class ParserSettings(BaseServiceSettings):
     parser_raw_path: Path = Path("/data/raw/")
     # Hard ceiling on log size we'll buffer in memory while parsing.
     parser_max_log_bytes: int = 50 * 1024 * 1024
+    # Interval (seconds) between backfill scans for ingested-but-not-parsed files.
+    backfill_interval_seconds: int = 300
 
 
 _settings: ParserSettings | None = None


### PR DESCRIPTION
## Summary
- Adds a periodic backfill task to the parser service that finds `(sha256, user_id)` pairs in `ingest.user_uploads` with no corresponding `parser.matches` row
- Processes up to 100 orphaned files per scan through the existing parse pipeline
- Configurable interval via `DA_BACKFILL_INTERVAL_SECONDS` (default 300s / 5 min)
- Closes the reliability gap in fire-and-forget Redis pub/sub delivery: once ingest commits a file, parsing is guaranteed

## Test plan
- [x] `pytest services/parser/tests/` — 37 tests pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI compose-smoke E2E gate (automated on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)