### PR TITLE
feat: 0.8.x fixes — scraper, gateway, format inference, UX cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,3 @@ DA_REFRESH_TOKEN_TTL_SECONDS=2592000
 # no plaintext file is written in that case.
 # DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=admin@sentania.net
 # DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=<set-if-you-want-scripted-install>
-
-# Caddy / ACME
-# The public hostname Caddy serves and obtains a certificate for.
-GATEWAY_DOMAIN=deepanalysis.sentania.net
-# Let's Encrypt contact email for ACME certificate issuance.
-DEEP_ANALYSIS_ACME_EMAIL=ops@example.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,17 +139,10 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     steps:
       - uses: actions/checkout@v4
-      - name: Map deepanalysis.local to loopback
-        run: echo "127.0.0.1 deepanalysis.local" | sudo tee -a /etc/hosts
       - name: Seed .env for compose
         run: |
           cp .env.example .env
-          echo 'GATEWAY_DOMAIN=deepanalysis.local' >> .env
-          echo 'DEEP_ANALYSIS_ACME_EMAIL=ci@example.com' >> .env
           echo 'DA_DATABASE_URL=postgresql+asyncpg://da:changeme@postgres:5432/deep_analysis' >> .env
-          # auth-migrate runs inside the compose network, so postgres is
-          # reachable as `postgres`, not `localhost`. Override .env.example's
-          # host-side default.
           echo 'DATABASE_URL=postgresql+psycopg://da:changeme@postgres:5432/deep_analysis' >> .env
       - name: Create external networks
         run: docker network create edge-slots
@@ -158,7 +151,7 @@ jobs:
       - name: Wait for gateway
         run: |
           for i in $(seq 1 30); do
-            if curl -sk -o /dev/null -w "%{http_code}" https://deepanalysis.local/health | grep -q 200; then
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health | grep -q 200; then
               echo "gateway up after ${i} tries"
               exit 0
             fi
@@ -169,14 +162,10 @@ jobs:
           docker compose logs --tail=200
           exit 1
       - name: Wait for upstream services
-        # Gateway /health is answered by Caddy directly, so it doesn't
-        # imply upstreams are ready. Without this wait, the route-prefix
-        # smoke races the FastAPI services and gets 502s ("connection
-        # refused") from Caddy. Each /<svc>/healthz is unauthenticated.
         run: |
           for svc in auth ingest web; do
             for i in $(seq 1 60); do
-              code=$(curl -sk -o /dev/null -w "%{http_code}" "https://deepanalysis.local/${svc}/healthz")
+              code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8080/${svc}/healthz")
               if [ "$code" = "200" ]; then
                 echo "${svc} up after ${i} tries"
                 break
@@ -191,16 +180,13 @@ jobs:
             done
           done
       - name: Route prefix smoke (v0.4.2 fix verification)
-        # Verifies gateway routing + auth-gate behavior without needing
-        # an admin account. Full E2E (login → upload → 201) is a follow-up
-        # once compose-smoke DB bootstrap is stabilized (TODO: W9.5 follow-up).
         run: |
-          BASE=https://deepanalysis.local
+          BASE=http://localhost:8080
           FAIL=0
 
           check() {
             local label="$1" expected="$2"
-            actual=$(curl -sk -o /dev/null -w "%{http_code}" "${@:3}")
+            actual=$(curl -s -o /dev/null -w "%{http_code}" "${@:3}")
             if [ "$actual" = "$expected" ]; then
               echo "  PASS: $label (got $actual)"
             else
@@ -253,17 +239,10 @@ jobs:
         uses: astral-sh/setup-uv@v3
       - name: uv sync
         run: uv sync --all-packages --dev
-      - name: Map deepanalysis.local to loopback
-        run: echo "127.0.0.1 deepanalysis.local" | sudo tee -a /etc/hosts
       - name: Seed .env for compose (with bootstrap admin)
         run: |
           cp .env.example .env
-          echo 'GATEWAY_DOMAIN=deepanalysis.local' >> .env
-          echo 'DEEP_ANALYSIS_ACME_EMAIL=ci@example.com' >> .env
           echo 'DA_DATABASE_URL=postgresql+asyncpg://da:changeme@postgres:5432/deep_analysis' >> .env
-          # auth-migrate runs inside the compose network. The job-level
-          # DATABASE_URL above (localhost:5432) is for host-side alembic;
-          # the .env value is what the container reads.
           echo 'DATABASE_URL=postgresql+psycopg://da:changeme@postgres:5432/deep_analysis' >> .env
           echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" >> .env
           echo "DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}" >> .env
@@ -302,17 +281,14 @@ jobs:
       - name: Wait for gateway + auth bootstrap
         run: |
           for i in $(seq 1 60); do
-            if curl -sk -o /dev/null -w "%{http_code}" https://deepanalysis.local/health | grep -q 200; then
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health | grep -q 200; then
               break
             fi
             sleep 2
           done
-          # Bootstrap admin is created during the auth container's
-          # lifespan startup — give it a few extra seconds after the
-          # gateway answers to finish the DB write.
           for i in $(seq 1 30); do
-            code=$(curl -sk -o /dev/null -w "%{http_code}" \
-              -X POST https://deepanalysis.local/auth/login \
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X POST http://localhost:8080/auth/login \
               -H 'Content-Type: application/json' \
               -d "{\"email\":\"${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}\",\"password\":\"${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}\"}")
             if [ "$code" = "200" ]; then
@@ -326,7 +302,7 @@ jobs:
           docker compose logs --tail=200
           exit 1
       - name: Run UI smoke
-        run: bash ci/smoke_ui.sh https://deepanalysis.local
+        run: bash ci/smoke_ui.sh http://localhost:8080
       - name: Dump logs on failure
         if: failure()
         run: docker compose logs --tail=200

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,68 @@ Shipped versions are recorded in [CHANGELOG.md](CHANGELOG.md). Tactical bugs liv
 
 The next 1–3 outcomes to pick up. Priority 1 is current focus.
 
-### 1. Admin user invitation & role management
+### 1. User profile expansion + hero identification
+
+Lets users record MTGO username(s) so the system can distinguish hero from opponent. Without this, the dashboard sometimes shows the user as their own opponent.
+
+- **Design approach:**
+  - **Upload ownership is the access boundary.** MTGO username does not grant access to matches — it's purely for attribution accuracy within a user's own uploads. This holds for future team/sharing features too: sharing carries the username mapping with it, so recipients see correct hero attribution without username-based access control.
+  - **Auto-detection from upload patterns.** After parsing, the system counts player-name frequency across a user's uploads. The name appearing most often is almost certainly the uploader. Surface as a suggestion: "We think your MTGO username is **X** — confirm?" Runs as a post-parse hook so the suggestion improves with each upload.
+  - **User confirms on profile.** User reviews the suggestion and confirms, edits, or adds alt account names. `_classify_match` in `stats.py` uses the confirmed list instead of the current `players[0]` convention.
+  - **Deferred attribution.** Before the user has 2+ uploads or confirms their name, show both players neutrally — don't guess hero/opponent from a single match.
+  - **Display-time resolution.** Hero vs opponent is resolved at query time, not parse time. No re-parsing or backfill needed — existing matches retroactively show correct attribution the moment the user confirms their username.
+- **Acceptance criteria:**
+  - User profile fields: name, contact info, MTGO username(s) (in addition to existing email)
+  - Users can edit their own values via `/profile/edit`
+  - MTGO username has a format-validity check; contact info is free-form
+  - Auto-detection: system suggests MTGO username based on upload frequency analysis
+  - `_classify_match` uses confirmed MTGO username(s) for hero identification
+  - Existing matches show correct hero/opponent after username is confirmed (no re-parse)
+  - New fields surface in the admin user view
+- **Dependencies:** None
+- **Status:** Not started
+
+### 2. Data scraping configuration
+
+Admin UI to define where archetype/decklist data is pulled from. Feeds #3.
+
+- **Acceptance criteria:**
+  - Admin can enable, disable, and configure data sources (MTGGoldfish, Untapped, MTGTop8, others)
+  - Per-source: credentials if needed, scrape frequency, last-run status, last-success timestamp
+  - Data lands in a normalized internal format that the archetype detector consumes
+- **Dependencies:** None
+- **Status:** Not started
+
+### 3. Archetype detection & management
+
+Admin-managed catalog of MTG archetypes plus automatic classification of decks into them.
+
+- **Acceptance criteria:**
+  - Admin-managed archetype catalog: name, format, defining cards, sample decklists
+  - Catalog seeded from scraped sources (#2) and editable/overridable by admin
+  - Auto-classifier: given a decklist, returns the closest archetype + confidence
+  - Surfaces in the match list and per-match detail views
+- **Dependencies:** Depends on #2 when archetype data is sourced externally
+- **Status:** Not started
+
+---
+
+## Next up
+
+In rough priority order. Re-shuffle freely when a different next-pick makes more sense.
+
+### 4. Game state reconstruction from gamelog
+
+The parser walks an MTGO gamelog and produces a structured game-state object per game. This is the foundation for richer match analysis (#7) and the virtual-replay stretch goal.
+
+- **Acceptance criteria:**
+  - Per game: structured state including zones (battlefield, hand, library, graveyard, exile), permanents with attached counters/auras, life totals, mana pool, the stack
+  - State is queryable per turn and per player
+  - Stored alongside the parsed match record
+- **Dependencies:** None
+- **Status:** Not started
+
+### 5. Admin user invitation & role management
 
 Extends the existing invite system so admins can invite other admin users, and gives the original installer (the very first registered user, UID=1) tools to manage them.
 
@@ -24,7 +85,7 @@ Extends the existing invite system so admins can invite other admin users, and g
 - **Dependencies:** None
 - **Status:** Not started
 
-### 2. CI auto-deploy on release
+### 6. CI auto-deploy on release
 
 When the repo has deploy credentials configured, tagging a release automatically updates the running containers on the target host. Silent no-op when credentials are absent so forks still build cleanly.
 
@@ -37,13 +98,18 @@ When the repo has deploy credentials configured, tagging a release automatically
 - **Dependencies:** None — parallel work, can run alongside any other outcome
 - **Status:** Not started
 
----
+### 7. Match analysis (the core product)
 
-## Next up
+Per-user dashboard for what users actually want from the product: how they're performing.
 
-In rough priority order. Re-shuffle freely when a different next-pick makes more sense.
+- **Acceptance criteria:**
+  - Performance breakdowns: win rate by archetype played, by archetype faced, by format, by event type, by opponent
+  - Time-window filtering, sortable tables, basic charts
+  - Read-only API surface so the AI add-on can subscribe and query
+- **Dependencies:** Depends on #4 (game state) and #3 (archetypes)
+- **Status:** Not started
 
-### 3. Extended user account actions
+### 8. Extended user account actions
 
 Admin tooling to manage individual user accounts beyond the current "delete + reset password" surface.
 
@@ -51,10 +117,10 @@ Admin tooling to manage individual user accounts beyond the current "delete + re
   - Admin can disable a user (login refused; existing sessions revoked); ban is the same disable with no expiry
   - Admin can edit any user's name, contact info, and MTGO username
   - Edit and disable actions are recorded in an audit log
-- **Dependencies:** Soft dep on #1 for shared role-management UI patterns
+- **Dependencies:** Soft dep on #5 for shared role-management UI patterns
 - **Status:** Not started
 
-### 4. Cross-user agent management
+### 9. Cross-user agent management
 
 Extends the existing cross-user revoke functionality to also support key rotation and full deletion.
 
@@ -62,22 +128,10 @@ Extends the existing cross-user revoke functionality to also support key rotatio
   - Admin can trigger a key rotation on any user's agent (revoke existing key, issue new one without deleting the agent)
   - Admin can delete any user's agent entirely
   - Both actions surface in the existing cross-user agents view alongside revoke
-- **Dependencies:** None — can run parallel to #3
+- **Dependencies:** None — can run parallel to #8
 - **Status:** Not started
 
-### 5. User profile expansion
-
-Lets users record more about themselves than just their email.
-
-- **Acceptance criteria:**
-  - User profile fields: name, contact info, MTGO username (in addition to existing email)
-  - Users can edit their own values via `/profile/edit`
-  - MTGO username has a format-validity check; contact info is free-form
-  - New fields surface in the admin user view
-- **Dependencies:** None
-- **Status:** Not started
-
-### 6. Server config UI: notifications backend
+### 10. Server config UI: notifications backend
 
 Admin-configurable notification transport, starting with email. Foundation that the future Discord bot ping idea plugs into.
 
@@ -88,60 +142,15 @@ Admin-configurable notification transport, starting with email. Foundation that 
 - **Dependencies:** None
 - **Status:** Not started
 
-### 7. Game state reconstruction from gamelog
-
-The parser walks an MTGO gamelog and produces a structured game-state object per game. This is the foundation for richer match analysis (#10) and the virtual-replay stretch goal.
-
-- **Acceptance criteria:**
-  - Per game: structured state including zones (battlefield, hand, library, graveyard, exile), permanents with attached counters/auras, life totals, mana pool, the stack
-  - State is queryable per turn and per player
-  - Stored alongside the parsed match record
-- **Dependencies:** None
-- **Status:** Not started
-
-### 8. Data scraping configuration
-
-Admin UI to define where archetype/decklist data is pulled from. Feeds #9.
-
-- **Acceptance criteria:**
-  - Admin can enable, disable, and configure data sources (MTGGoldfish, Untapped, MTGTop8, others)
-  - Per-source: credentials if needed, scrape frequency, last-run status, last-success timestamp
-  - Data lands in a normalized internal format that the archetype detector consumes
-- **Dependencies:** None
-- **Status:** Not started
-
-### 9. Archetype detection & management
-
-Admin-managed catalog of MTG archetypes plus automatic classification of decks into them.
-
-- **Acceptance criteria:**
-  - Admin-managed archetype catalog: name, format, defining cards, sample decklists
-  - Catalog seeded from scraped sources (#8) and editable/overridable by admin
-  - Auto-classifier: given a decklist, returns the closest archetype + confidence
-  - Surfaces in the macro match view (#11) and per-match analysis (#10)
-- **Dependencies:** Depends on #8 when archetype data is sourced externally
-- **Status:** Not started
-
-### 10. Match analysis (the core product)
-
-Per-user dashboard for what users actually want from the product: how they're performing.
-
-- **Acceptance criteria:**
-  - Performance breakdowns: win rate by archetype played, by archetype faced, by format, by event type, by opponent
-  - Time-window filtering, sortable tables, basic charts
-  - Read-only API surface so the AI add-on can subscribe and query
-- **Dependencies:** Depends on #7 (game state) and #9 (archetypes)
-- **Status:** Not started
-
 ### 11. Macro match view in admin
 
 System-wide match-and-analysis surface for admins.
 
 - **Acceptance criteria:**
   - All matches across all users, with filtering by user, archetype, format, and date range
-  - Drill into a single match for game-by-game state from #7
+  - Drill into a single match for game-by-game state from #4
   - Read-only — no admin-edit on match data
-- **Dependencies:** Depends on #10
+- **Dependencies:** Depends on #7
 - **Status:** Not started
 
 ---
@@ -150,6 +159,7 @@ System-wide match-and-analysis surface for admins.
 
 Tactical bugs and small tech-debt items. Resolve when convenient or alongside related work.
 
+- **Admin server version display** — show the running server version somewhere in the admin UI (footer, about page, or admin dashboard). Admin-only; users don't need it.
 - **Issue #4** — `change_password` form lost its inline "wrong current password" error after the AuthForbidden refactor. Falls through to a generic banner instead.
 - **Issue #5** — wrong template renders on `/profile` subpages when the auth service is unreachable. Returns a generic 503 instead of the contextual `_service_unavailable` template.
 

--- a/alembic/versions/009_card_legalities_and_format_source.py
+++ b/alembic/versions/009_card_legalities_and_format_source.py
@@ -1,0 +1,44 @@
+"""catalog.cards: add legalities JSONB; parser.matches: add format_source.
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-05-12
+
+Legalities support format inference from card pools. The Scryfall
+bulk sync already downloads legality data per card; this migration
+adds the column to persist it.
+
+format_source tracks whether the match format was inferred from the
+card pool, inherited from a scraped MTGO event, or set by the user.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "cards",
+        sa.Column(
+            "legalities",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        schema="catalog",
+    )
+    op.add_column(
+        "matches",
+        sa.Column("format_source", sa.String(length=32), nullable=True),
+        schema="parser",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("matches", "format_source", schema="parser")
+    op.drop_column("cards", "legalities", schema="catalog")

--- a/alembic/versions/009_card_legalities_and_format_source.py
+++ b/alembic/versions/009_card_legalities_and_format_source.py
@@ -13,8 +13,9 @@ card pool, inherited from a scraped MTGO event, or set by the user.
 """
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql  # noqa: I001
+
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 revision = "009"
 down_revision = "008"

--- a/alembic/versions/009_card_legalities_and_format_source.py
+++ b/alembic/versions/009_card_legalities_and_format_source.py
@@ -12,8 +12,8 @@ format_source tracks whether the match format was inferred from the
 card pool, inherited from a scraped MTGO event, or set by the user.
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision = "009"

--- a/ci/Caddyfile.ci
+++ b/ci/Caddyfile.ci
@@ -7,6 +7,10 @@
         respond "ok" 200
     }
 
+    handle / {
+        redir /dashboard 302
+    }
+
     handle /auth/* {
         reverse_proxy auth:8000
     }

--- a/ci/Caddyfile.ci
+++ b/ci/Caddyfile.ci
@@ -1,26 +1,12 @@
 {
-    # CI-only: tls internal avoids ACME DNS dependency.
+    auto_https off
 }
 
-:80 {
-    handle /health {
-        respond "ok" 200
-    }
-    handle {
-        redir https://{host}{uri} 301
-    }
-}
-
-deepanalysis.local {
-    tls internal
-
+:8080 {
     handle /health {
         respond "ok" 200
     }
 
-    # Use `handle` (preserve path) not `handle_path` (strip prefix) — backends
-    # register full paths like /auth/login, /ingest/upload. See commit fac34b2
-    # for the production Caddyfile fix this mirrors.
     handle /auth/* {
         reverse_proxy auth:8000
     }
@@ -33,9 +19,6 @@ deepanalysis.local {
         reverse_proxy analytics:8000
     }
 
-    # /admin/* serves the web admin UI (W3.5-C); mirrors the production
-    # Caddyfile. Auth's JSON /admin/* endpoints stay reachable on the
-    # internal compose network for service-to-service calls.
     handle {
         reverse_proxy web:8000
     }

--- a/ci/docker-compose.ci.yml
+++ b/ci/docker-compose.ci.yml
@@ -1,6 +1,6 @@
 # ci/docker-compose.ci.yml — CI override for compose-smoke and smoke-ui.
 #
-# Switches the gateway from ACME (needs public DNS) to tls internal for CI.
+# Mounts the CI Caddyfile (identical config, kept separate for clarity).
 #
 # JWT key handling for smoke-ui:
 # The auth service generates the RS256 keypair at container startup if the
@@ -11,9 +11,8 @@
 # DA_JWT_KEYS_DIR in the CI environment (defaults to /tmp/ci-jwt-keys).
 services:
   gateway:
-    environment:
-      GATEWAY_DOMAIN: deepanalysis.local
-      DEEP_ANALYSIS_ACME_EMAIL: ""  # not used with tls internal
+    ports:
+      - "8080:8080"
     volumes:
       - ./ci/Caddyfile.ci:/etc/caddy/Caddyfile:ro
 

--- a/ci/smoke_e2e.sh
+++ b/ci/smoke_e2e.sh
@@ -16,14 +16,14 @@
 # Usage:
 #   DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=... \
 #   DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=... \
-#   bash ci/smoke_e2e.sh https://deepanalysis.local
+#   bash ci/smoke_e2e.sh http://localhost:8080
 #
 # Exit code 0 = all checks passed.
 # Exit code 1 = one or more checks failed.
 
 set -euo pipefail
 
-BASE_URL="${1:-https://deepanalysis.local}"
+BASE_URL="${1:-http://localhost:8080}"
 
 PASS=0
 FAIL=0
@@ -43,11 +43,11 @@ check() {
 
 http_status() {
     # Returns just the HTTP status code; -k skips TLS verify (self-signed in CI).
-    curl -sk -o /dev/null -w "%{http_code}" "$@"
+    curl -s -o /dev/null -w "%{http_code}" "$@"
 }
 
 http_body() {
-    curl -sk "$@"
+    curl -s "$@"
 }
 
 echo "=== Deep Analysis E2E smoke — $BASE_URL ==="

--- a/ci/smoke_ui.sh
+++ b/ci/smoke_ui.sh
@@ -13,13 +13,13 @@
 # Usage:
 #   DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL=... \
 #   DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD=... \
-#   bash ci/smoke_ui.sh https://deepanalysis.local
+#   bash ci/smoke_ui.sh http://localhost:8080
 #
 # Exit 0 = all checks passed. Exit 1 = one or more failed.
 
 set -euo pipefail
 
-BASE_URL="${1:-https://deepanalysis.local}"
+BASE_URL="${1:-http://localhost:8080}"
 
 PASS=0
 FAIL=0
@@ -93,7 +93,7 @@ echo "=== Deep Analysis UI smoke — $BASE_URL ==="
 echo ""
 echo "--- 1. GET /login ---"
 
-login_body=$(curl -sk -o - -w "\n%{http_code}" "$BASE_URL/login")
+login_body=$(curl -s -o - -w "\n%{http_code}" "$BASE_URL/login")
 login_status=$(echo "$login_body" | tail -n1)
 login_html=$(echo "$login_body" | sed '$d')
 check "GET /login → 200" "200" "$login_status"
@@ -105,7 +105,7 @@ check_contains "GET /login contains <form" "<form" "$login_html"
 echo ""
 echo "--- 2. POST /login (valid creds) ---"
 
-post_head=$(curl -sk -D - -o /dev/null \
+post_head=$(curl -s -D - -o /dev/null \
     -c "$COOKIE_JAR" \
     -X POST "$BASE_URL/login" \
     --data-urlencode "email=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" \
@@ -135,7 +135,7 @@ fi
 echo ""
 echo "--- 3. GET /dashboard (admin authenticated) ---"
 
-dash_head=$(curl -sk -D - -o /dev/null -b "$COOKIE_JAR" "$BASE_URL/dashboard")
+dash_head=$(curl -s -D - -o /dev/null -b "$COOKIE_JAR" "$BASE_URL/dashboard")
 dash_status=$(echo "$dash_head" | head -n1 | awk '{print $2}')
 check "GET /dashboard (admin cookie) → 302" "302" "$dash_status"
 check_contains "GET /dashboard (admin) redirects to /admin/users" "/admin/users" "$dash_head"
@@ -146,7 +146,7 @@ check_contains "GET /dashboard (admin) redirects to /admin/users" "/admin/users"
 echo ""
 echo "--- 4. GET /dashboard (unauthenticated) ---"
 
-noauth_head=$(curl -sk -D - -o /dev/null "$BASE_URL/dashboard")
+noauth_head=$(curl -s -D - -o /dev/null "$BASE_URL/dashboard")
 noauth_status=$(echo "$noauth_head" | head -n1 | awk '{print $2}')
 check "GET /dashboard (no cookie) → 302" "302" "$noauth_status"
 check_contains "Redirect targets /login?next=/dashboard" "/login?next=/dashboard" "$noauth_head"
@@ -159,7 +159,7 @@ echo "--- 5. POST /settings/password (rotate) ---"
 
 NEW_PASSWORD="ui-smoke-${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}"
 
-pw_head=$(curl -sk -D - -o /dev/null \
+pw_head=$(curl -s -D - -o /dev/null \
     -b "$COOKIE_JAR" \
     -c "$PW_COOKIE" \
     -X POST "$BASE_URL/settings/password" \
@@ -182,7 +182,7 @@ else
 fi
 
 # Restore the bootstrap password for any follow-up smoke runs.
-restore_status=$(curl -sk -o /dev/null -w "%{http_code}" \
+restore_status=$(curl -s -o /dev/null -w "%{http_code}" \
     -b "$PW_COOKIE" \
     -c "$PW_COOKIE" \
     -X POST "$BASE_URL/settings/password" \
@@ -199,21 +199,21 @@ echo "--- 6. /profile* admin bounce ---"
 
 # Step 5's password rotation revoked the cookie in $COOKIE_JAR. Log in fresh
 # so the bounce checks are independent of the rotation flow.
-curl -sk -o /dev/null -c "$PROFILE_COOKIE" \
+curl -s -o /dev/null -c "$PROFILE_COOKIE" \
     -X POST "$BASE_URL/login" \
     --data-urlencode "email=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" \
     --data-urlencode "password=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}"
 
 # Each /profile* GET as an admin redirects (302) to /admin/users.
 for path in "/profile" "/profile/edit" "/profile/agents"; do
-    bounce_head=$(curl -sk -D - -o /dev/null -b "$PROFILE_COOKIE" "$BASE_URL$path")
+    bounce_head=$(curl -s -D - -o /dev/null -b "$PROFILE_COOKIE" "$BASE_URL$path")
     bounce_status=$(echo "$bounce_head" | head -n1 | awk '{print $2}')
     check "GET $path (admin cookie) → 302" "302" "$bounce_status"
     check_contains "GET $path (admin) → /admin/users" "/admin/users" "$bounce_head"
 done
 
 # Unauthenticated /profile must still redirect to /login (not /admin/users).
-noauth_profile=$(curl -sk -D - -o /dev/null "$BASE_URL/profile")
+noauth_profile=$(curl -s -D - -o /dev/null "$BASE_URL/profile")
 noauth_profile_status=$(echo "$noauth_profile" | head -n1 | awk '{print $2}')
 check "GET /profile (no cookie) → 302" "302" "$noauth_profile_status"
 check_contains "/profile (no cookie) redirect targets /login" "/login" "$noauth_profile"
@@ -225,7 +225,7 @@ echo ""
 echo "--- 7. /admin/users admin panel ---"
 
 # The bootstrap admin from $PROFILE_COOKIE is still authenticated.
-admin_out=$(curl -sk -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" "$BASE_URL/admin/users")
+admin_out=$(curl -s -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" "$BASE_URL/admin/users")
 admin_status=$(echo "$admin_out" | tail -n1)
 admin_html=$(echo "$admin_out" | sed '$d')
 check "GET /admin/users (admin cookie) → 200" "200" "$admin_status"
@@ -234,7 +234,7 @@ check_contains "GET /admin/users contains the admin email" \
 check_contains "GET /admin/users mentions Users heading" "Users" "$admin_html"
 
 # Unauthenticated must redirect to /login.
-noauth_admin=$(curl -sk -D - -o /dev/null "$BASE_URL/admin/users")
+noauth_admin=$(curl -s -D - -o /dev/null "$BASE_URL/admin/users")
 noauth_admin_status=$(echo "$noauth_admin" | head -n1 | awk '{print $2}')
 check "GET /admin/users (no cookie) → 302" "302" "$noauth_admin_status"
 check_contains "/admin/users redirect targets /login" "/login" "$noauth_admin"
@@ -305,7 +305,7 @@ for u in d.get("users", []):
         # We check this before deleting testuser@local so the agents view
         # has at least the migrated agent row to render against.
         # ------------------------------------------------------------------
-        agents_out=$(curl -sk -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" "$BASE_URL/admin/agents")
+        agents_out=$(curl -s -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" "$BASE_URL/admin/agents")
         agents_status=$(echo "$agents_out" | tail -n1)
         agents_html=$(echo "$agents_out" | sed '$d')
         check "GET /admin/agents (admin cookie) → 200" "200" "$agents_status"
@@ -315,7 +315,7 @@ for u in d.get("users", []):
         check_contains "GET /admin/agents has Last seen column" "Last seen" "$agents_html"
 
         # /admin/agents must be admin-only — unauth bounces to /login.
-        noauth_agents=$(curl -sk -D - -o /dev/null "$BASE_URL/admin/agents")
+        noauth_agents=$(curl -s -D - -o /dev/null "$BASE_URL/admin/agents")
         noauth_agents_status=$(echo "$noauth_agents" | head -n1 | awk '{print $2}')
         check "GET /admin/agents (no cookie) → 302" "302" "$noauth_agents_status"
         check_contains "/admin/agents redirect targets /login" "/login" "$noauth_agents"
@@ -330,14 +330,14 @@ for u in d.get("users", []):
             | head -n1 \
             | sed -E 's|/admin/agents/([0-9a-f-]+)/revoke|\1|' || true)
         if [ -n "$AGENT_ID" ]; then
-            revoke_head=$(curl -sk -D - -o /dev/null -b "$PROFILE_COOKIE" \
+            revoke_head=$(curl -s -D - -o /dev/null -b "$PROFILE_COOKIE" \
                 -X POST "$BASE_URL/admin/agents/${AGENT_ID}/revoke")
             revoke_status=$(echo "$revoke_head" | head -n1 | awk '{print $2}')
             check "POST /admin/agents/{id}/revoke → 303" "303" "$revoke_status"
             check_contains "Revoke redirects back to /admin/agents" \
                 "/admin/agents" "$revoke_head"
 
-            post_revoke_html=$(curl -sk -b "$PROFILE_COOKIE" "$BASE_URL/admin/agents")
+            post_revoke_html=$(curl -s -b "$PROFILE_COOKIE" "$BASE_URL/admin/agents")
             if echo "$post_revoke_html" | grep -q "/admin/agents/${AGENT_ID}/revoke"; then
                 check "Revoke action removed from refreshed list" "ok" \
                     "FAILED (revoke action still rendered)"
@@ -351,7 +351,7 @@ for u in d.get("users", []):
         # ------------------------------------------------------------------
         # W3.6.3 — /admin/settings reachable, registration mode toggle.
         # ------------------------------------------------------------------
-        settings_out=$(curl -sk -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" "$BASE_URL/admin/settings")
+        settings_out=$(curl -s -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" "$BASE_URL/admin/settings")
         settings_status=$(echo "$settings_out" | tail -n1)
         settings_html=$(echo "$settings_out" | sed '$d')
         check "GET /admin/settings (admin cookie) → 200" "200" "$settings_status"
@@ -365,22 +365,22 @@ for u in d.get("users", []):
         fi
 
         # /admin/settings must be admin-only — unauth bounces to /login.
-        noauth_settings=$(curl -sk -D - -o /dev/null "$BASE_URL/admin/settings")
+        noauth_settings=$(curl -s -D - -o /dev/null "$BASE_URL/admin/settings")
         noauth_settings_status=$(echo "$noauth_settings" | head -n1 | awk '{print $2}')
         check "GET /admin/settings (no cookie) → 302" "302" "$noauth_settings_status"
         check_contains "/admin/settings redirect targets /login" "/login" "$noauth_settings"
 
         # Toggle to open and back to invite_only — full round-trip.
-        toggle_open_head=$(curl -sk -D - -o /dev/null -b "$PROFILE_COOKIE" \
+        toggle_open_head=$(curl -s -D - -o /dev/null -b "$PROFILE_COOKIE" \
             -X POST "$BASE_URL/admin/settings/registration-mode" \
             --data-urlencode "mode=open")
         toggle_open_status=$(echo "$toggle_open_head" | head -n1 | awk '{print $2}')
         check "POST /admin/settings/registration-mode (mode=open) → 303" "303" "$toggle_open_status"
 
-        post_toggle_html=$(curl -sk -b "$PROFILE_COOKIE" "$BASE_URL/admin/settings")
+        post_toggle_html=$(curl -s -b "$PROFILE_COOKIE" "$BASE_URL/admin/settings")
         check_contains "Settings page reflects mode=open" "<strong>open</strong>" "$post_toggle_html"
 
-        toggle_back_status=$(curl -sk -o /dev/null -w "%{http_code}" -b "$PROFILE_COOKIE" \
+        toggle_back_status=$(curl -s -o /dev/null -w "%{http_code}" -b "$PROFILE_COOKIE" \
             -X POST "$BASE_URL/admin/settings/registration-mode" \
             --data-urlencode "mode=invite_only")
         check "POST /admin/settings/registration-mode (mode=invite_only) → 303" "303" "$toggle_back_status"
@@ -390,20 +390,20 @@ for u in d.get("users", []):
         # /register?token=... happy path in invite_only mode;
         # /register without token blocked in invite_only mode.
         # ------------------------------------------------------------------
-        invites_out=$(curl -sk -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" "$BASE_URL/admin/invites")
+        invites_out=$(curl -s -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" "$BASE_URL/admin/invites")
         invites_status=$(echo "$invites_out" | tail -n1)
         invites_html=$(echo "$invites_out" | sed '$d')
         check "GET /admin/invites (admin cookie) → 200" "200" "$invites_status"
         check_contains "GET /admin/invites has Pending invites heading" "Pending invites" "$invites_html"
 
         # /admin/invites must be admin-only — unauth bounces to /login.
-        noauth_invites=$(curl -sk -D - -o /dev/null "$BASE_URL/admin/invites")
+        noauth_invites=$(curl -s -D - -o /dev/null "$BASE_URL/admin/invites")
         noauth_invites_status=$(echo "$noauth_invites" | head -n1 | awk '{print $2}')
         check "GET /admin/invites (no cookie) → 302" "302" "$noauth_invites_status"
         check_contains "/admin/invites redirect targets /login" "/login" "$noauth_invites"
 
         # Create an invite — response page renders the plaintext token.
-        create_invite_out=$(curl -sk -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" \
+        create_invite_out=$(curl -s -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" \
             -X POST "$BASE_URL/admin/invites" \
             --data-urlencode "expires_in_hours=168")
         create_invite_status=$(echo "$create_invite_out" | tail -n1)
@@ -423,7 +423,7 @@ for u in d.get("users", []):
         fi
 
         # /register?token=<plaintext> renders the form (invite_only default).
-        register_form_out=$(curl -sk -o - -w "\n%{http_code}" \
+        register_form_out=$(curl -s -o - -w "\n%{http_code}" \
             "$BASE_URL/register?token=${SMOKE_INVITE_TOKEN}")
         register_form_status=$(echo "$register_form_out" | tail -n1)
         register_form_html=$(echo "$register_form_out" | sed '$d')
@@ -432,7 +432,7 @@ for u in d.get("users", []):
 
         # /register without a token in invite_only mode renders the
         # "registration is invite-only" page.
-        register_blocked_out=$(curl -sk -o - -w "\n%{http_code}" "$BASE_URL/register")
+        register_blocked_out=$(curl -s -o - -w "\n%{http_code}" "$BASE_URL/register")
         register_blocked_status=$(echo "$register_blocked_out" | tail -n1)
         register_blocked_html=$(echo "$register_blocked_out" | sed '$d')
         check "GET /register (no token, invite_only) → 200" "200" "$register_blocked_status"
@@ -440,7 +440,7 @@ for u in d.get("users", []):
 
         # Reset-password through the web admin UI — temp password is
         # rendered inline in the response HTML.
-        reset_out=$(curl -sk -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" \
+        reset_out=$(curl -s -b "$PROFILE_COOKIE" -o - -w "\n%{http_code}" \
             -X POST "$BASE_URL/admin/users/${TEST_USER_ID}/reset-password")
         reset_status=$(echo "$reset_out" | tail -n1)
         reset_html=$(echo "$reset_out" | sed '$d')
@@ -453,20 +453,20 @@ for u in d.get("users", []):
             "curl -s -H 'Authorization: Bearer ${ADMIN_JWT}' http://localhost:8000/auth/me" \
             | sed -n 's/.*"user_id":\s*\([0-9]\+\).*/\1/p' || true)
         if [ -n "$admin_user_id" ]; then
-            self_del_status=$(curl -sk -o /dev/null -w "%{http_code}" -b "$PROFILE_COOKIE" \
+            self_del_status=$(curl -s -o /dev/null -w "%{http_code}" -b "$PROFILE_COOKIE" \
                 -X POST "$BASE_URL/admin/users/${admin_user_id}/delete")
             check "POST /admin/users/{self}/delete → 400" "400" "$self_del_status"
         fi
 
         # Delete through the web admin UI — should redirect back to /admin/users.
-        delete_head=$(curl -sk -D - -o /dev/null -b "$PROFILE_COOKIE" \
+        delete_head=$(curl -s -D - -o /dev/null -b "$PROFILE_COOKIE" \
             -X POST "$BASE_URL/admin/users/${TEST_USER_ID}/delete")
         delete_status=$(echo "$delete_head" | head -n1 | awk '{print $2}')
         check "POST /admin/users/{id}/delete → 303" "303" "$delete_status"
         check_contains "Delete redirects to /admin/users" "/admin/users" "$delete_head"
 
         # Confirm testuser@local is gone from the rendered list.
-        post_delete_html=$(curl -sk -b "$PROFILE_COOKIE" "$BASE_URL/admin/users")
+        post_delete_html=$(curl -s -b "$PROFILE_COOKIE" "$BASE_URL/admin/users")
         if echo "$post_delete_html" | grep -q "testuser@local"; then
             check "testuser@local removed from list" "ok" "FAILED (still listed)"
         else
@@ -487,12 +487,12 @@ echo ""
 echo "--- 8. POST /logout ---"
 
 # First log in fresh so we have a live cookie to logout with.
-curl -sk -o /dev/null -c "$LOGOUT_COOKIE" \
+curl -s -o /dev/null -c "$LOGOUT_COOKIE" \
     -X POST "$BASE_URL/login" \
     --data-urlencode "email=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_EMAIL}" \
     --data-urlencode "password=${DEEP_ANALYSIS_BOOTSTRAP_ADMIN_PASSWORD}"
 
-logout_head=$(curl -sk -D - -o /dev/null \
+logout_head=$(curl -s -D - -o /dev/null \
     -b "$LOGOUT_COOKIE" \
     -c "$LOGOUT_COOKIE" \
     -X POST "$BASE_URL/logout")

--- a/common/format_inference.py
+++ b/common/format_inference.py
@@ -30,12 +30,21 @@ _FORMAT_HIERARCHY: list[str] = [
     "vintage",
 ]
 
-_BASIC_LANDS = frozenset({
-    "Plains", "Island", "Swamp", "Mountain", "Forest",
-    "Snow-Covered Plains", "Snow-Covered Island", "Snow-Covered Swamp",
-    "Snow-Covered Mountain", "Snow-Covered Forest",
-    "Wastes",
-})
+_BASIC_LANDS = frozenset(
+    {
+        "Plains",
+        "Island",
+        "Swamp",
+        "Mountain",
+        "Forest",
+        "Snow-Covered Plains",
+        "Snow-Covered Island",
+        "Snow-Covered Swamp",
+        "Snow-Covered Mountain",
+        "Snow-Covered Forest",
+        "Wastes",
+    }
+)
 
 _LEGALITIES_SQL = text(
     """
@@ -91,9 +100,7 @@ async def infer_format_for_match(
     if not filtered:
         return None
 
-    rows = (
-        await session.execute(_LEGALITIES_SQL, {"names": filtered})
-    ).mappings().all()
+    rows = (await session.execute(_LEGALITIES_SQL, {"names": filtered})).mappings().all()
 
     if not rows:
         _log.debug(

--- a/common/format_inference.py
+++ b/common/format_inference.py
@@ -110,6 +110,7 @@ async def infer_format_for_match(
 
     result = infer_format_from_cards(card_legalities)
     if result:
+        result = result.title()
         _log.info(
             "format inferred",
             extra={"format": result, "cards_checked": len(card_legalities)},

--- a/common/format_inference.py
+++ b/common/format_inference.py
@@ -1,0 +1,117 @@
+"""Infer match format from the card pool.
+
+Cross-references card names from a parsed match against
+``catalog.cards.legalities`` to find the narrowest format where every
+card is legal. Basic lands are excluded since they're legal everywhere
+and don't help discriminate.
+
+The inference is best-effort: if no cards are found in the catalog
+(pre-sync, or all tokens/emblems), returns None.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from parser_service.parsing.models import ParsedMatch
+
+_log = logging.getLogger("analytics.format_inference")
+
+_FORMAT_HIERARCHY: list[str] = [
+    "standard",
+    "pioneer",
+    "modern",
+    "legacy",
+    "vintage",
+]
+
+_BASIC_LANDS = frozenset({
+    "Plains", "Island", "Swamp", "Mountain", "Forest",
+    "Snow-Covered Plains", "Snow-Covered Island", "Snow-Covered Swamp",
+    "Snow-Covered Mountain", "Snow-Covered Forest",
+    "Wastes",
+})
+
+_LEGALITIES_SQL = text(
+    """
+    SELECT DISTINCT ON (name) name, legalities
+      FROM catalog.cards
+     WHERE name = ANY(:names)
+       AND legalities IS NOT NULL
+     ORDER BY name, synced_at DESC
+    """
+)
+
+
+def collect_card_names(parsed: ParsedMatch) -> list[str]:
+    """Extract unique card names from all games in a parsed match."""
+    names: set[str] = set()
+    for game in parsed.games:
+        for turn in game.turns:
+            for snap in turn.players.values():
+                names.update(snap.zones.battlefield)
+    return sorted(names)
+
+
+def infer_format_from_cards(
+    card_legalities: dict[str, dict[str, str]],
+) -> str | None:
+    """Pure function: given {card_name: {format: status}}, return the
+    narrowest format where every card is legal or restricted.
+
+    Returns None if no cards have legality data.
+    """
+    if not card_legalities:
+        return None
+
+    for fmt in _FORMAT_HIERARCHY:
+        all_legal = True
+        for _card, legs in card_legalities.items():
+            status = legs.get(fmt)
+            if status not in ("legal", "restricted"):
+                all_legal = False
+                break
+        if all_legal:
+            return fmt
+
+    return None
+
+
+async def infer_format_for_match(
+    session: AsyncSession,
+    card_names: list[str],
+) -> str | None:
+    """Look up legalities from catalog.cards and infer format."""
+    filtered = [n for n in card_names if n not in _BASIC_LANDS]
+    if not filtered:
+        return None
+
+    rows = (
+        await session.execute(_LEGALITIES_SQL, {"names": filtered})
+    ).mappings().all()
+
+    if not rows:
+        _log.debug(
+            "format inference: no catalog matches",
+            extra={"card_count": len(filtered)},
+        )
+        return None
+
+    card_legalities: dict[str, dict[str, str]] = {}
+    for row in rows:
+        legs = row["legalities"]
+        if isinstance(legs, dict):
+            card_legalities[row["name"]] = legs
+
+    result = infer_format_from_cards(card_legalities)
+    if result:
+        _log.info(
+            "format inferred",
+            extra={"format": result, "cards_checked": len(card_legalities)},
+        )
+    return result

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pyjwt[crypto]>=2.8",
     "pydantic>=2.7",
     "pydantic-settings>=2.3",
+    "sqlalchemy>=2.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -28,3 +29,4 @@ bypass-selection = true
 "settings.py" = "common/settings.py"
 "agent_auth.py" = "common/agent_auth.py"
 "token_utils.py" = "common/token_utils.py"
+"format_inference.py" = "common/format_inference.py"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,18 @@
 
 name: deep-analysis
 
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "3"
+
 services:
 
   postgres:
     image: postgres:16
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_DB: deep_analysis
       POSTGRES_USER: ${POSTGRES_USER}
@@ -31,6 +38,7 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    logging: *default-logging
     command: ["redis-server", "--save", ""]
     networks:
       - backend
@@ -109,25 +117,20 @@ services:
   gateway:
     image: caddy:2-alpine
     restart: unless-stopped
-    environment:
-      GATEWAY_DOMAIN: ${GATEWAY_DOMAIN}
-      DEEP_ANALYSIS_ACME_EMAIL: ${DEEP_ANALYSIS_ACME_EMAIL}
+    logging: *default-logging
     volumes:
       - ./gateway/Caddyfile:/etc/caddy/Caddyfile:ro
-      - caddy_data:/data
-    ports:
-      - "80:80"
-      - "443:443"
     networks:
       - frontend
       - backend
+      - edge-slots
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -138,6 +141,7 @@ services:
       context: .
       dockerfile: services/auth/Dockerfile
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - backend
       - edge-slots
@@ -172,6 +176,7 @@ services:
       context: .
       dockerfile: services/ingest/Dockerfile
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - backend
       - edge-slots
@@ -204,6 +209,7 @@ services:
       context: .
       dockerfile: services/parser/Dockerfile
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - backend
     environment:
@@ -233,6 +239,7 @@ services:
       context: .
       dockerfile: services/analytics/Dockerfile
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - backend
       - edge-slots
@@ -261,6 +268,7 @@ services:
       context: .
       dockerfile: services/web/Dockerfile
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - frontend
       - backend
@@ -293,5 +301,4 @@ networks:
 
 volumes:
   postgres_data:
-  caddy_data:
   raw_archive:

--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -1,26 +1,14 @@
-# gateway/Caddyfile — production config.
+# gateway/Caddyfile — slot-internal reverse proxy.
 #
-# Env vars an operator must set (see .env.example):
-#   GATEWAY_DOMAIN             Public hostname Caddy serves (e.g. deepanalysis.example.com).
-#                              Must have a public DNS A/CNAME record pointing at this host
-#                              for ACME certificate issuance to succeed.
-#   DEEP_ANALYSIS_ACME_EMAIL   Contact email Let's Encrypt uses for ACME registration.
-#
-# For local-only / no-DNS testing, override via docker-compose.override.yml to mount
-# a Caddyfile with `tls internal` instead. See docs/deploy.md.
+# Fleet-caddy on the host terminates TLS for the public FQDN and
+# forwards to this container over the edge-slots bridge network.
+# This gateway runs plaintext only — no ACME, no TLS.
 
-:80 {
-    handle /health {
-        respond "ok" 200
-    }
-    handle {
-        redir https://{host}{uri} 301
-    }
+{
+    auto_https off
 }
 
-{$GATEWAY_DOMAIN} {
-    tls {$DEEP_ANALYSIS_ACME_EMAIL}
-
+:8080 {
     handle /health {
         respond "ok" 200
     }
@@ -37,11 +25,6 @@
         reverse_proxy analytics:8000
     }
 
-    # /admin/* serves the web admin UI (W3.5-C). The auth service still
-    # exposes JSON /admin/* endpoints for internal service-to-service use
-    # (web -> auth) but those are no longer reachable via the gateway.
-    # Operators who need raw API access connect to auth directly on the
-    # internal compose network (docker exec or port-forward).
     handle {
         reverse_proxy web:8000
     }

--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -13,6 +13,10 @@
         respond "ok" 200
     }
 
+    handle / {
+        redir /dashboard 302
+    }
+
     handle /auth/* {
         reverse_proxy auth:8000
     }

--- a/services/analytics/analytics_service/matches.py
+++ b/services/analytics/analytics_service/matches.py
@@ -22,11 +22,22 @@ from analytics_service.deps import AuthenticatedUser, require_user
 router = APIRouter(prefix="/analytics/matches", tags=["matches"])
 
 
-_VALID_FORMATS = frozenset({
-    "standard", "pioneer", "modern", "legacy", "vintage",
-    "pauper", "commander", "draft", "sealed", "historic",
-    "premodern", "cube",
-})
+_VALID_FORMATS = frozenset(
+    {
+        "standard",
+        "pioneer",
+        "modern",
+        "legacy",
+        "vintage",
+        "pauper",
+        "commander",
+        "draft",
+        "sealed",
+        "historic",
+        "premodern",
+        "cube",
+    }
+)
 
 
 class GameDetail(BaseModel):

--- a/services/analytics/analytics_service/matches.py
+++ b/services/analytics/analytics_service/matches.py
@@ -22,6 +22,13 @@ from analytics_service.deps import AuthenticatedUser, require_user
 router = APIRouter(prefix="/analytics/matches", tags=["matches"])
 
 
+_VALID_FORMATS = frozenset({
+    "standard", "pioneer", "modern", "legacy", "vintage",
+    "pauper", "commander", "draft", "sealed", "historic",
+    "premodern", "cube",
+})
+
+
 class GameDetail(BaseModel):
     game_number: int
     winner: str | None = None
@@ -33,9 +40,14 @@ class MatchDetail(BaseModel):
 
     match_id: str
     format_: str | None = Field(default=None, alias="format")
+    format_source: str | None = None
     players: list[str] = Field(default_factory=list)
     played_at: datetime | None = None
     games: list[GameDetail] = Field(default_factory=list)
+
+
+class FormatUpdate(BaseModel):
+    format: str
 
 
 @router.get("/{match_id}", response_model=MatchDetail)
@@ -48,7 +60,7 @@ async def get_match(
         await db.execute(
             text(
                 """
-                SELECT id, format, players,
+                SELECT id, format, format_source, players,
                        COALESCE(played_at, parsed_at) AS played_at
                 FROM parser.matches
                 WHERE id = :match_id AND user_id = :user_id
@@ -62,7 +74,7 @@ async def get_match(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"error": "match_not_found"},
         )
-    row_id, fmt, players, played_at = match_row
+    row_id, fmt, fmt_source, players, played_at = match_row
     game_rows = (
         await db.execute(
             text(
@@ -91,7 +103,39 @@ async def get_match(
     return MatchDetail(
         match_id=str(row_id),
         format=fmt,
+        format_source=fmt_source,
         players=[str(p) for p in raw_players],
         played_at=played_at,
         games=games,
     )
+
+
+@router.patch("/{match_id}/format", status_code=status.HTTP_204_NO_CONTENT)
+async def update_match_format(
+    match_id: uuid.UUID,
+    body: FormatUpdate,
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> None:
+    fmt = body.format.lower().strip()
+    if fmt not in _VALID_FORMATS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"error": "invalid_format", "valid": sorted(_VALID_FORMATS)},
+        )
+    result = await db.execute(
+        text(
+            """
+            UPDATE parser.matches
+               SET format = :format, format_source = 'user'
+             WHERE id = :match_id AND user_id = :user_id
+            """
+        ),
+        {"format": fmt, "match_id": match_id, "user_id": user.user_id},
+    )
+    if result.rowcount == 0:  # type: ignore[attr-defined]
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "match_not_found"},
+        )
+    await db.commit()

--- a/services/analytics/analytics_service/matches.py
+++ b/services/analytics/analytics_service/matches.py
@@ -117,8 +117,8 @@ async def update_match_format(
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    fmt = body.format.lower().strip()
-    if fmt not in _VALID_FORMATS:
+    key = body.format.lower().strip()
+    if key not in _VALID_FORMATS:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"error": "invalid_format", "valid": sorted(_VALID_FORMATS)},
@@ -131,7 +131,7 @@ async def update_match_format(
              WHERE id = :match_id AND user_id = :user_id
             """
         ),
-        {"format": fmt, "match_id": match_id, "user_id": user.user_id},
+        {"format": key.title(), "match_id": match_id, "user_id": user.user_id},
     )
     if result.rowcount == 0:  # type: ignore[attr-defined]
         raise HTTPException(

--- a/services/analytics/analytics_service/mtgo_scraper.py
+++ b/services/analytics/analytics_service/mtgo_scraper.py
@@ -277,6 +277,10 @@ def extract_decklists_from_html(html: str, event_url: str) -> list[dict[str, Any
         )
         return []
 
+    decklists = _extract_decklists_strategy_mtgo_js_data(soup)
+    if decklists:
+        return decklists
+
     decklists = _extract_decklists_strategy_player_blocks(soup)
     if decklists:
         return decklists
@@ -290,7 +294,8 @@ def extract_decklists_from_html(html: str, event_url: str) -> list[dict[str, Any
         extra={
             "event_url": event_url,
             "expected": (
-                "player blocks with class containing 'deck'/'player' "
+                "window.MTGO.decklists.data JS payload, "
+                "player blocks with class containing 'deck'/'player', "
                 "or an embedded application/json deck payload"
             ),
             "html_snippet": html[:_SNIPPET_CHARS],
@@ -299,10 +304,89 @@ def extract_decklists_from_html(html: str, event_url: str) -> list[dict[str, Any
     return []
 
 
+_MTGO_JS_DATA_RE = re.compile(r"window\.MTGO\.decklists\.data\s*=\s*")
+
+
+def _extract_decklists_strategy_mtgo_js_data(
+    soup: BeautifulSoup,
+) -> list[dict[str, Any]]:
+    """Primary strategy: ``window.MTGO.decklists.data = {...}`` in a script tag.
+
+    mtgo.com renders decklist data as a JS object assignment. The
+    ``main_deck`` array contains all cards; each entry's ``sideboard``
+    field (string ``"true"``/``"false"``) discriminates board membership.
+    """
+    for script in soup.find_all("script"):
+        if not isinstance(script, Tag):
+            continue
+        raw = script.string or script.get_text() or ""
+        match = _MTGO_JS_DATA_RE.search(raw)
+        if not match:
+            continue
+        json_start = match.end()
+        try:
+            data, _ = json.JSONDecoder().raw_decode(raw, json_start)
+        except (ValueError, TypeError):
+            _log.debug(
+                "mtgo event page: found MTGO.decklists.data but JSON decode failed",
+                extra={"snippet": raw[json_start : json_start + 200]},
+            )
+            continue
+        if not isinstance(data, dict):
+            continue
+        entries = data.get("decklists")
+        if not isinstance(entries, list):
+            continue
+        return _decklists_from_mtgo_js(entries)
+    return []
+
+
+def _decklists_from_mtgo_js(entries: list[Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        player = entry.get("player")
+        if not isinstance(player, str) or not player.strip():
+            continue
+        main: dict[str, int] = {}
+        side: dict[str, int] = {}
+        for card in entry.get("main_deck") or []:
+            if not isinstance(card, dict):
+                continue
+            attrs = card.get("card_attributes")
+            if not isinstance(attrs, dict):
+                continue
+            name = attrs.get("card_name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            try:
+                qty = int(card.get("qty", 0))
+            except (TypeError, ValueError):
+                continue
+            if qty <= 0:
+                continue
+            name = name.strip()
+            is_side = str(card.get("sideboard", "false")).lower() == "true"
+            target = side if is_side else main
+            target[name] = target.get(name, 0) + qty
+        if not main and not side:
+            continue
+        out.append(
+            {
+                "player_name": player.strip(),
+                "placement": None,
+                "decklist_main": main,
+                "decklist_sideboard": side,
+            }
+        )
+    return out
+
+
 def _extract_decklists_strategy_player_blocks(
     soup: BeautifulSoup,
 ) -> list[dict[str, Any]]:
-    """Primary strategy: per-player blocks with mainboard/sideboard sections."""
+    """Fallback strategy: per-player blocks with mainboard/sideboard sections."""
     out: list[dict[str, Any]] = []
     deck_blocks = soup.find_all(attrs={"class": re.compile(r"(deck|player)", re.IGNORECASE)})
     for block in deck_blocks:

--- a/services/analytics/analytics_service/scryfall_sync.py
+++ b/services/analytics/analytics_service/scryfall_sync.py
@@ -67,11 +67,11 @@ _UPSERT_SQL = text(
     """
     INSERT INTO catalog.cards (
         scryfall_id, name, oracle_text, type_line, mana_cost,
-        colors, set_code, image_uri, art_crop_uri, synced_at
+        colors, set_code, image_uri, art_crop_uri, legalities, synced_at
     ) VALUES (
         :scryfall_id, :name, :oracle_text, :type_line, :mana_cost,
         CAST(:colors AS jsonb), :set_code, :image_uri, :art_crop_uri,
-        :synced_at
+        CAST(:legalities AS jsonb), :synced_at
     )
     ON CONFLICT (scryfall_id) DO UPDATE SET
         name = EXCLUDED.name,
@@ -82,6 +82,7 @@ _UPSERT_SQL = text(
         set_code = EXCLUDED.set_code,
         image_uri = EXCLUDED.image_uri,
         art_crop_uri = EXCLUDED.art_crop_uri,
+        legalities = EXCLUDED.legalities,
         synced_at = EXCLUDED.synced_at
     """
 )
@@ -98,6 +99,7 @@ def _card_row(card: dict[str, Any], synced_at: datetime) -> dict[str, Any]:
     """
     image_uris = card.get("image_uris") or {}
     colors = card.get("colors")
+    legalities = card.get("legalities")
     return {
         "scryfall_id": card["id"],
         "name": card["name"],
@@ -110,6 +112,7 @@ def _card_row(card: dict[str, Any], synced_at: datetime) -> dict[str, Any]:
         "set_code": card.get("set"),
         "image_uri": image_uris.get("normal"),
         "art_crop_uri": image_uris.get("art_crop"),
+        "legalities": _jsonb_param(legalities),
         "synced_at": synced_at,
     }
 

--- a/services/analytics/tests/test_format_inference.py
+++ b/services/analytics/tests/test_format_inference.py
@@ -42,10 +42,14 @@ def test_modern_card_pool() -> None:
 def test_legacy_card_pool() -> None:
     cards = {
         "Force of Will": _legs(
-            standard="not_legal", pioneer="not_legal", modern="not_legal",
+            standard="not_legal",
+            pioneer="not_legal",
+            modern="not_legal",
         ),
         "Brainstorm": _legs(
-            standard="not_legal", pioneer="not_legal", modern="not_legal",
+            standard="not_legal",
+            pioneer="not_legal",
+            modern="not_legal",
         ),
     }
     assert infer_format_from_cards(cards) == "legacy"
@@ -54,12 +58,18 @@ def test_legacy_card_pool() -> None:
 def test_vintage_restricted() -> None:
     cards = {
         "Black Lotus": _legs(
-            standard="not_legal", pioneer="not_legal",
-            modern="not_legal", legacy="banned", vintage="restricted",
+            standard="not_legal",
+            pioneer="not_legal",
+            modern="not_legal",
+            legacy="banned",
+            vintage="restricted",
         ),
         "Ancestral Recall": _legs(
-            standard="not_legal", pioneer="not_legal",
-            modern="not_legal", legacy="banned", vintage="restricted",
+            standard="not_legal",
+            pioneer="not_legal",
+            modern="not_legal",
+            legacy="banned",
+            vintage="restricted",
         ),
     }
     assert infer_format_from_cards(cards) == "vintage"
@@ -68,8 +78,11 @@ def test_vintage_restricted() -> None:
 def test_banned_in_all_returns_none() -> None:
     cards = {
         "Fake Broken Card": {
-            "standard": "banned", "pioneer": "banned",
-            "modern": "banned", "legacy": "banned", "vintage": "banned",
+            "standard": "banned",
+            "pioneer": "banned",
+            "modern": "banned",
+            "legacy": "banned",
+            "vintage": "banned",
         },
     }
     assert infer_format_from_cards(cards) is None

--- a/services/analytics/tests/test_format_inference.py
+++ b/services/analytics/tests/test_format_inference.py
@@ -1,0 +1,87 @@
+"""Unit tests for format inference from card legalities."""
+
+from common.format_inference import infer_format_from_cards
+
+_ALL_LEGAL = {
+    "standard": "legal",
+    "pioneer": "legal",
+    "modern": "legal",
+    "legacy": "legal",
+    "vintage": "legal",
+}
+
+
+def _legs(**overrides: str) -> dict[str, str]:
+    return {**_ALL_LEGAL, **overrides}
+
+
+def test_all_standard_legal() -> None:
+    cards = {
+        "Lightning Strike": _legs(),
+        "Opt": _legs(),
+    }
+    assert infer_format_from_cards(cards) == "standard"
+
+
+def test_pioneer_not_standard() -> None:
+    cards = {
+        "Thoughtseize": _legs(standard="not_legal"),
+        "Opt": _legs(),
+    }
+    assert infer_format_from_cards(cards) == "pioneer"
+
+
+def test_modern_card_pool() -> None:
+    cards = {
+        "Lightning Bolt": _legs(standard="not_legal", pioneer="not_legal"),
+        "Goblin Guide": _legs(standard="not_legal", pioneer="not_legal"),
+    }
+    assert infer_format_from_cards(cards) == "modern"
+
+
+def test_legacy_card_pool() -> None:
+    cards = {
+        "Force of Will": _legs(
+            standard="not_legal", pioneer="not_legal", modern="not_legal",
+        ),
+        "Brainstorm": _legs(
+            standard="not_legal", pioneer="not_legal", modern="not_legal",
+        ),
+    }
+    assert infer_format_from_cards(cards) == "legacy"
+
+
+def test_vintage_restricted() -> None:
+    cards = {
+        "Black Lotus": _legs(
+            standard="not_legal", pioneer="not_legal",
+            modern="not_legal", legacy="banned", vintage="restricted",
+        ),
+        "Ancestral Recall": _legs(
+            standard="not_legal", pioneer="not_legal",
+            modern="not_legal", legacy="banned", vintage="restricted",
+        ),
+    }
+    assert infer_format_from_cards(cards) == "vintage"
+
+
+def test_banned_in_all_returns_none() -> None:
+    cards = {
+        "Fake Broken Card": {
+            "standard": "banned", "pioneer": "banned",
+            "modern": "banned", "legacy": "banned", "vintage": "banned",
+        },
+    }
+    assert infer_format_from_cards(cards) is None
+
+
+def test_empty_returns_none() -> None:
+    assert infer_format_from_cards({}) is None
+
+
+def test_mixed_pool_picks_narrowest() -> None:
+    cards = {
+        "Opt": _legs(),
+        "Tarmogoyf": _legs(standard="not_legal", pioneer="not_legal"),
+    }
+    assert infer_format_from_cards(cards) == "modern"

--- a/services/analytics/tests/test_matches.py
+++ b/services/analytics/tests/test_matches.py
@@ -121,7 +121,7 @@ async def test_match_detail_returns_match_with_games(app_client: httpx.AsyncClie
     session = _FakeSession(
         queue=[
             # match row
-            [(match_id, "Modern", ["alice", "bob"], played_at)],
+            [(match_id, "Modern", "inferred", ["alice", "bob"], played_at)],
             # games rows: (game_id, game_number, winner, turns)
             [
                 (game_1_id, 1, "alice", 8),
@@ -192,7 +192,7 @@ async def test_match_detail_handles_missing_turns_gracefully(
     game_id = uuid.uuid4()
     session = _FakeSession(
         queue=[
-            [(match_id, None, ["alice", "bob"], None)],
+            [(match_id, None, None, ["alice", "bob"], None)],
             # turns column is NULL when the parser didn't store game states
             [(game_id, 1, "alice", None)],
         ]

--- a/services/analytics/tests/test_mtgo_scraper.py
+++ b/services/analytics/tests/test_mtgo_scraper.py
@@ -85,8 +85,71 @@ def test_extract_events_malformed_html_does_not_raise() -> None:
 # --------------------------------------------------------------------------- #
 
 
+def _card(name: str, qty: int, *, side: bool = False) -> dict:
+    return {
+        "qty": str(qty),
+        "sideboard": str(side).lower(),
+        "card_attributes": {"card_name": name},
+    }
+
+
+def test_extract_decklists_mtgo_js_data() -> None:
+    """Primary strategy: window.MTGO.decklists.data JS payload."""
+    import json
+
+    data = {
+        "event_id": "12345",
+        "description": "Modern Challenge 32",
+        "decklists": [
+            {
+                "player": "Alice",
+                "main_deck": [
+                    _card("Lightning Bolt", 4),
+                    _card("Goblin Guide", 4),
+                    _card("Smash to Smithereens", 2, side=True),
+                ],
+            },
+            {
+                "player": "Bob",
+                "main_deck": [
+                    _card("Karn Liberated", 4),
+                    _card("Nature's Claim", 3, side=True),
+                ],
+            },
+        ],
+    }
+    html = f"""
+    <html><body>
+      <script type="text/javascript">
+        window.MTGO = window.MTGO || {{}};
+        window.MTGO.decklists = window.MTGO.decklists || {{}};
+        window.MTGO.decklists.data = {json.dumps(data)};
+      </script>
+    </body></html>
+    """
+    decks = extract_decklists_from_html(html, "https://example.com/event")
+    assert len(decks) == 2
+    by_player = {d["player_name"]: d for d in decks}
+    alice = by_player["Alice"]
+    assert alice["decklist_main"] == {"Lightning Bolt": 4, "Goblin Guide": 4}
+    assert alice["decklist_sideboard"] == {"Smash to Smithereens": 2}
+    bob = by_player["Bob"]
+    assert bob["decklist_main"] == {"Karn Liberated": 4}
+    assert bob["decklist_sideboard"] == {"Nature's Claim": 3}
+
+
+def test_extract_decklists_mtgo_js_data_bad_json() -> None:
+    """JS data strategy gracefully handles malformed JSON."""
+    html = """
+    <html><body>
+      <script>window.MTGO.decklists.data = {not valid json};</script>
+    </body></html>
+    """
+    assert extract_decklists_from_html(html, "https://example.com") == []
+
+
 def test_extract_decklists_player_blocks() -> None:
-    """Primary strategy: per-player decklist blocks with main + sideboard."""
+    """Fallback strategy: per-player decklist blocks with main + sideboard."""
     html = """
     <html><body>
       <div class="deck-block">

--- a/services/parser/parser_service/consumer.py
+++ b/services/parser/parser_service/consumer.py
@@ -28,6 +28,7 @@ import redis.asyncio as redis
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from common.events import FILE_INGESTED, MATCH_PARSED, FileIngestedPayload, MatchParsedPayload
+from common.format_inference import collect_card_names, infer_format_for_match
 from common.redis_client import EventPublisher
 from parser_service.parsing import LogParser, ParsedMatch
 from parser_service.persistence import persist_match
@@ -143,6 +144,18 @@ class ParserConsumer:
                 _log.exception("persist failed sha=%s user_id=%s", sha256, user_id)
                 await session.rollback()
                 return parsed
+
+            if not match.format:
+                try:
+                    card_names = collect_card_names(parsed)
+                    if card_names:
+                        fmt = await infer_format_for_match(session, card_names)
+                        if fmt:
+                            match.format = fmt
+                            match.format_source = "inferred"
+                            await session.commit()
+                except Exception:  # noqa: BLE001
+                    _log.debug("format inference failed sha=%s", sha256)
 
         out: MatchParsedPayload = {
             "match_id": str(match.id),

--- a/services/parser/parser_service/models.py
+++ b/services/parser/parser_service/models.py
@@ -56,6 +56,7 @@ class Match(Base):
     sha256: Mapped[str] = mapped_column(String(64), nullable=False)
     user_id: Mapped[int] = mapped_column(Integer, nullable=False)
     format: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    format_source: Mapped[str | None] = mapped_column(String(32), nullable=True)
     event_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
     players: Mapped[list[Any]] = mapped_column(JSONB, nullable=False, server_default="[]")
     match_result: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/services/web/tests/test_auth_client_self_service.py
+++ b/services/web/tests/test_auth_client_self_service.py
@@ -425,17 +425,34 @@ async def test_revoke_my_agent_translates_transport_error(
 
 
 @pytest.mark.asyncio
-async def test_change_password_raises_auth_forbidden_on_401(
+async def test_change_password_invalid_credentials_returns_inline_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """401 from /auth/password/change means auth no longer accepts the
-    session (revoked, expired, or current password rejected). Callers
-    redirect to /login rather than rendering an inline form error."""
+    """401 with invalid_credentials returns a business error so the
+    caller can re-render the form with an inline message (issue #4)."""
     from web_service import auth_client
 
     _stub_post(
         monkeypatch,
         httpx.Response(401, json={"detail": {"error": "invalid_credentials"}}),
+    )
+
+    ok, err = await auth_client.change_password("http://auth:8000", "tok", "old-pw", "new-pw-9876")
+    assert ok is False
+    assert err == "invalid_credentials"
+
+
+@pytest.mark.asyncio
+async def test_change_password_expired_session_401_raises_auth_forbidden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """401 without invalid_credentials (e.g. expired session) still
+    raises AuthForbidden so the caller redirects to /login."""
+    from web_service import auth_client
+
+    _stub_post(
+        monkeypatch,
+        httpx.Response(401, json={"detail": {"error": "session_expired"}}),
     )
 
     with pytest.raises(auth_client.AuthForbidden):

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -518,9 +518,7 @@ async def get_match_detail(base_url: str, token: str, match_id: str) -> MatchDet
     return _to_match_detail(resp.json())
 
 
-async def update_match_format(
-    base_url: str, token: str, match_id: str, format_: str
-) -> bool:
+async def update_match_format(base_url: str, token: str, match_id: str, format_: str) -> bool:
     """PATCH the format on a match. Returns True on success."""
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
@@ -530,19 +528,13 @@ async def update_match_format(
                 json={"format": format_},
             )
     except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics PATCH /matches/{{id}}/format error: {exc}"
-        ) from exc
+        raise AnalyticsClientError(f"analytics PATCH /matches/{{id}}/format error: {exc}") from exc
     if resp.status_code == 204:
         return True
     if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics PATCH format returned {resp.status_code}"
-        )
+        raise AnalyticsForbidden(f"analytics PATCH format returned {resp.status_code}")
     if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics PATCH format returned {resp.status_code}"
-        )
+        raise AnalyticsClientError(f"analytics PATCH format returned {resp.status_code}")
     return True
 
 

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -518,6 +518,34 @@ async def get_match_detail(base_url: str, token: str, match_id: str) -> MatchDet
     return _to_match_detail(resp.json())
 
 
+async def update_match_format(
+    base_url: str, token: str, match_id: str, format_: str
+) -> bool:
+    """PATCH the format on a match. Returns True on success."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.patch(
+                f"{base_url}/analytics/matches/{match_id}/format",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"format": format_},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics PATCH /matches/{{id}}/format error: {exc}"
+        ) from exc
+    if resp.status_code == 204:
+        return True
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(
+            f"analytics PATCH format returned {resp.status_code}"
+        )
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics PATCH format returned {resp.status_code}"
+        )
+    return True
+
+
 async def get_stats_by_opponent(base_url: str, token: str) -> list[OpponentStatItem]:
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -163,6 +163,13 @@ async def change_password(
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):
+        if resp.status_code == 401:
+            try:
+                detail = resp.json().get("detail") or {}
+                if isinstance(detail, dict) and detail.get("error") == "invalid_credentials":
+                    return False, "invalid_credentials"
+            except ValueError:
+                pass
         raise AuthForbidden(f"auth /password/change returned {resp.status_code}")
     if resp.status_code == 400:
         try:

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -9,6 +9,7 @@ independent and coexist in the compose stack.
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from pathlib import Path
 from typing import Annotated, Any
@@ -43,6 +44,7 @@ app = FastAPI(title=f"deep-analysis-{SERVICE_NAME}")
 mount_metrics(app, SERVICE_NAME)
 
 templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+templates.env.globals["app_version"] = os.environ.get("APP_VERSION", "dev")
 app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
 
 # Browser-auth redirect handler — converts BrowserAuthRedirect into a
@@ -355,7 +357,9 @@ async def profile_edit_form(
         return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
     except auth_client.AuthClientError:
         _log.exception("auth /me call failed")
-        return _service_unavailable(request, user)
+        return _service_unavailable(
+            request, user, "profile_edit.html", {"email": ""},
+        )
     return templates.TemplateResponse(
         request,
         "profile_edit.html",
@@ -459,7 +463,10 @@ async def profile_agents(
         return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
     except auth_client.AuthClientError:
         _log.exception("auth /me/agents call failed")
-        return _service_unavailable(request, user)
+        return _service_unavailable(
+            request, user, "profile_agents.html",
+            {"agents": [], "page": 1, "total_pages": 0, "total": 0},
+        )
     return templates.TemplateResponse(
         request,
         "profile_agents.html",
@@ -489,7 +496,10 @@ async def profile_agents_generate_code(
         return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
     except auth_client.AuthClientError:
         _log.exception("auth /agent/registration-code call failed")
-        return _service_unavailable(request, user)
+        return _service_unavailable(
+            request, user, "profile_agents.html",
+            {"agents": [], "page": 1, "total_pages": 0, "total": 0},
+        )
 
     # Re-render the agents page with the freshly minted code. List
     # fetch is best-effort — surfacing the code matters more than the
@@ -626,19 +636,55 @@ async def match_detail_page(
             "user": user,
             "match": match,
             "overall_result": overall_result,
+            "format_options": [
+                "Standard", "Pioneer", "Modern", "Legacy", "Vintage",
+                "Pauper", "Commander", "Draft", "Sealed", "Historic",
+                "Premodern", "Cube",
+            ],
         },
     )
 
 
-def _service_unavailable(request: Request, user: BrowserUser) -> Response:
+@app.post("/matches/{match_id}/format")
+async def match_set_format(
+    match_id: uuid.UUID,
+    request: Request,
+    format: Annotated[str, Form()],
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    try:
+        await analytics_client.update_match_format(
+            settings.analytics_service_url, user.token,
+            str(match_id), format,
+        )
+    except analytics_client.AnalyticsForbidden:
+        return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics PATCH format failed match_id=%s", match_id)
+    return RedirectResponse(
+        url=f"/matches/{match_id}",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+def _service_unavailable(
+    request: Request,
+    user: BrowserUser,
+    template: str = "profile.html",
+    extra_context: dict[str, Any] | None = None,
+) -> Response:
+    ctx: dict[str, Any] = {
+        "user": user,
+        "me": None,
+        "error": "Authentication service unavailable. Please try again.",
+    }
+    if extra_context:
+        ctx.update(extra_context)
     return templates.TemplateResponse(
         request,
-        "profile.html",
-        {
-            "user": user,
-            "me": None,
-            "error": "Authentication service unavailable. Please try again.",
-        },
+        template,
+        ctx,
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
     )
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -358,7 +358,10 @@ async def profile_edit_form(
     except auth_client.AuthClientError:
         _log.exception("auth /me call failed")
         return _service_unavailable(
-            request, user, "profile_edit.html", {"email": ""},
+            request,
+            user,
+            "profile_edit.html",
+            {"email": ""},
         )
     return templates.TemplateResponse(
         request,
@@ -464,7 +467,9 @@ async def profile_agents(
     except auth_client.AuthClientError:
         _log.exception("auth /me/agents call failed")
         return _service_unavailable(
-            request, user, "profile_agents.html",
+            request,
+            user,
+            "profile_agents.html",
             {"agents": [], "page": 1, "total_pages": 0, "total": 0},
         )
     return templates.TemplateResponse(
@@ -497,7 +502,9 @@ async def profile_agents_generate_code(
     except auth_client.AuthClientError:
         _log.exception("auth /agent/registration-code call failed")
         return _service_unavailable(
-            request, user, "profile_agents.html",
+            request,
+            user,
+            "profile_agents.html",
             {"agents": [], "page": 1, "total_pages": 0, "total": 0},
         )
 
@@ -637,9 +644,18 @@ async def match_detail_page(
             "match": match,
             "overall_result": overall_result,
             "format_options": [
-                "Standard", "Pioneer", "Modern", "Legacy", "Vintage",
-                "Pauper", "Commander", "Draft", "Sealed", "Historic",
-                "Premodern", "Cube",
+                "Standard",
+                "Pioneer",
+                "Modern",
+                "Legacy",
+                "Vintage",
+                "Pauper",
+                "Commander",
+                "Draft",
+                "Sealed",
+                "Historic",
+                "Premodern",
+                "Cube",
             ],
         },
     )
@@ -655,8 +671,10 @@ async def match_set_format(
 ) -> Response:
     try:
         await analytics_client.update_match_format(
-            settings.analytics_service_url, user.token,
-            str(match_id), format,
+            settings.analytics_service_url,
+            user.token,
+            str(match_id),
+            format,
         )
     except analytics_client.AnalyticsForbidden:
         return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)

--- a/services/web/web_service/static/favicon.svg
+++ b/services/web/web_service/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#1e5fbf"/>
+  <text x="16" y="23" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="20" fill="#fff">DA</text>
+</svg>

--- a/services/web/web_service/templates/base.html
+++ b/services/web/web_service/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Deep Analysis{% endblock %}</title>
+    <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
@@ -32,6 +33,7 @@
 
     <footer class="site-footer">
         <span>Deep Analysis &middot; self-hosted match analytics</span>
+        <span class="site-version">v{{ app_version }}</span>
     </footer>
 </body>
 </html>

--- a/services/web/web_service/templates/match_detail.html
+++ b/services/web/web_service/templates/match_detail.html
@@ -13,7 +13,9 @@
         <li><strong>Format:</strong>
             <form method="post" action="/matches/{{ match.match_id }}/format" class="inline-form">
                 <select name="format" onchange="this.form.submit()">
-                    <option value="">—</option>
+                    {% if not match.format_ %}
+                    <option value="" disabled selected>—</option>
+                    {% endif %}
                     {% for fmt in format_options %}
                     <option value="{{ fmt }}"
                         {% if match.format_ and match.format_|lower == fmt|lower %}selected{% endif %}>

--- a/services/web/web_service/templates/match_detail.html
+++ b/services/web/web_service/templates/match_detail.html
@@ -10,7 +10,19 @@
         <li><strong>Date:</strong>
             {{ match.played_at.strftime("%Y-%m-%d %H:%M") if match.played_at else "—" }}
         </li>
-        <li><strong>Format:</strong> {{ match.format_ or "—" }}</li>
+        <li><strong>Format:</strong>
+            <form method="post" action="/matches/{{ match.match_id }}/format" class="inline-form">
+                <select name="format" onchange="this.form.submit()">
+                    <option value="">—</option>
+                    {% for fmt in format_options %}
+                    <option value="{{ fmt }}"
+                        {% if match.format_ and match.format_|lower == fmt|lower %}selected{% endif %}>
+                        {{ fmt }}
+                    </option>
+                    {% endfor %}
+                </select>
+            </form>
+        </li>
         <li><strong>Players:</strong>
             {% if match.players %}
                 {{ match.players|join(", ") }}
@@ -72,5 +84,7 @@
 .result-win { background: #d4edda; color: #155724; }
 .result-loss { background: #f8d7da; color: #721c24; }
 .result-draw { background: #fff3cd; color: #856404; }
+.inline-form { display: inline; }
+.inline-form select { font-size: inherit; padding: 0.15rem 0.3rem; }
 </style>
 {% endblock %}

--- a/services/web/web_service/templates/profile_agents.html
+++ b/services/web/web_service/templates/profile_agents.html
@@ -5,6 +5,9 @@
 {% block content %}
 <section class="panel">
     <h1>My agents</h1>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
     <p><a href="/profile">&larr; Back to profile</a></p>
 
     <section class="register-agent">

--- a/tests/test_route_prefix_convention.py
+++ b/tests/test_route_prefix_convention.py
@@ -72,6 +72,7 @@ _WEB_BROWSER_PATHS = frozenset(
         "/register",
         "/cards",
         "/matches/{match_id}",
+        "/matches/{match_id}/format",
     }
 )
 


### PR DESCRIPTION
## Summary

- **MTGO scraper fix**: mtgo.com moved decklist data to `window.MTGO.decklists.data` JS payload. New primary extraction strategy parses this; old HTML strategies kept as fallbacks. Scraper was extracting 0 decklists per page.
- **Gateway ACME stripped**: slot-internal Caddy now serves plaintext on `:8080` with `auto_https off`. Fleet-caddy owns TLS. Removes dangling ZeroSSL account registration, `caddy_data` volume, ports 80/443.
- **Format inference**: infers match format from card pool legalities at parse time (narrowest format where all cards are legal/restricted). Scryfall sync now persists legality data. User can override format via dropdown on match detail page.
- **Issue #4**: `change_password` wrong-password 401 now renders inline error instead of redirecting to login
- **Issue #5**: `_service_unavailable` renders correct template per profile subpage
- **Log rotation**: 50MB/3-file cap on all 8 compose services
- **Admin version**: `APP_VERSION` shown in footer
- **Favicon**: SVG with DA initials
- **CI**: all URLs switched from `https://deepanalysis.local` to `http://localhost:8080`, removed DNS mapping and TLS skip flags

## New files

- `alembic/versions/009_card_legalities_and_format_source.py` — adds `catalog.cards.legalities` JSONB + `parser.matches.format_source`
- `common/format_inference.py` — card-pool format inference logic
- `services/analytics/tests/test_format_inference.py` — 8 unit tests
- `services/web/web_service/static/favicon.svg`

## Test plan

- [x] 49 analytics tests pass (scraper, format inference, matches, stats)
- [x] ruff clean
- [x] mypy clean (120 source files)
- [ ] CI compose-smoke + smoke-ui pass with new plaintext gateway
- [ ] Deploy to edge.int, verify scraper picks up decklists on next scheduled run
- [ ] Test format dropdown on match detail page
- [ ] Verify Scryfall sync populates legalities column after next sync cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)