### PR TITLE
feat: MTGO username(s) for hero/opponent attribution

### DIFF
--- a/services/analytics/analytics_service/stats.py
+++ b/services/analytics/analytics_service/stats.py
@@ -75,17 +75,26 @@ class OpponentStat(BaseModel):
 def _classify_match(
     players: list[Any] | None,
     game_wins_by_player: dict[str, int],
+    mtgo_usernames: list[str] | None = None,
 ) -> tuple[str, str | None, int, int]:
     """Return (result, opponent, player_wins, player_losses).
 
-    - The "user" within the match is taken to be ``players[0]``.
-    - W/L/D is derived from per-game wins, not the match-level
-      ``winner`` column, so ties and unknowns produce the right shape.
+    If ``mtgo_usernames`` is provided, the user is identified by
+    matching against the player list. Falls back to ``players[0]``
+    when no username matches.
     """
     if not players:
         return "", None, 0, 0
-    user = str(players[0]) if players else None
-    opponent = str(players[1]) if len(players) > 1 else None
+    user: str | None = None
+    if mtgo_usernames:
+        names_lower = {n.lower() for n in mtgo_usernames}
+        for p in players:
+            if str(p).lower() in names_lower:
+                user = str(p)
+                break
+    if user is None:
+        user = str(players[0])
+    opponent = next((str(p) for p in players if str(p) != user), None)
     if user is None:
         return "", opponent, 0, 0
     user_wins = game_wins_by_player.get(user, 0)
@@ -97,6 +106,21 @@ def _classify_match(
     if user_wins < opp_wins:
         return "L", opponent, user_wins, opp_wins
     return "D", opponent, user_wins, opp_wins
+
+
+async def _load_mtgo_usernames(db: AsyncSession, user_id: int) -> list[str] | None:
+    try:
+        row = (
+            await db.execute(
+                text("SELECT mtgo_usernames FROM auth.users WHERE id = :uid"),
+                {"uid": user_id},
+            )
+        ).scalar_one_or_none()
+    except Exception:  # noqa: BLE001
+        return None
+    if row and isinstance(row, list):
+        return row
+    return None
 
 
 async def _load_user_matches(db: AsyncSession, user_id: int) -> list[dict[str, Any]]:
@@ -149,13 +173,20 @@ async def _load_user_matches(db: AsyncSession, user_id: int) -> list[dict[str, A
     return out
 
 
-def _summarize(matches: list[dict[str, Any]]) -> StatsSummary:
+def _summarize(
+    matches: list[dict[str, Any]],
+    mtgo_usernames: list[str] | None = None,
+) -> StatsSummary:
     if not matches:
         return StatsSummary()
     wins = losses = draws = 0
     recent: list[RecentMatch] = []
     for m in matches:
-        result, opponent, pw, pl = _classify_match(m["players"], m["wins_by_player"])
+        result, opponent, pw, pl = _classify_match(
+            m["players"],
+            m["wins_by_player"],
+            mtgo_usernames,
+        )
         if result == "W":
             wins += 1
         elif result == "L":
@@ -192,7 +223,8 @@ async def get_summary(
     db: AsyncSession = Depends(get_session),
 ) -> StatsSummary:
     matches = await _load_user_matches(db, user.user_id)
-    return _summarize(matches)
+    names = await _load_mtgo_usernames(db, user.user_id)
+    return _summarize(matches, names)
 
 
 @router.get("/by-format", response_model=list[FormatStat])
@@ -203,12 +235,17 @@ async def get_by_format(
     matches = await _load_user_matches(db, user.user_id)
     if not matches:
         return []
+    names = await _load_mtgo_usernames(db, user.user_id)
     buckets: dict[str, dict[str, int]] = {}
     for m in matches:
         fmt = m["format"] or "Unknown"
         bucket = buckets.setdefault(fmt, {"matches": 0, "wins": 0, "losses": 0, "draws": 0})
         bucket["matches"] += 1
-        result, _opp, _pw, _pl = _classify_match(m["players"], m["wins_by_player"])
+        result, _opp, _pw, _pl = _classify_match(
+            m["players"],
+            m["wins_by_player"],
+            names,
+        )
         if result == "W":
             bucket["wins"] += 1
         elif result == "L":
@@ -240,9 +277,14 @@ async def get_by_opponent(
     matches = await _load_user_matches(db, user.user_id)
     if not matches:
         return []
+    names = await _load_mtgo_usernames(db, user.user_id)
     buckets: dict[str, dict[str, int]] = {}
     for m in matches:
-        result, opponent, _pw, _pl = _classify_match(m["players"], m["wins_by_player"])
+        result, opponent, _pw, _pl = _classify_match(
+            m["players"],
+            m["wins_by_player"],
+            names,
+        )
         if not opponent:
             continue
         bucket = buckets.setdefault(opponent, {"matches": 0, "wins": 0, "losses": 0, "draws": 0})
@@ -268,3 +310,33 @@ async def get_by_opponent(
             )
         )
     return out
+
+
+class UsernameSuggestion(BaseModel):
+    username: str
+    match_count: int
+
+
+@router.get("/username-suggestion", response_model=list[UsernameSuggestion])
+async def get_username_suggestion(
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> list[UsernameSuggestion]:
+    """Count player-name frequency across a user's matches and return
+    the most common names as MTGO username suggestions."""
+    rows = (
+        await db.execute(
+            text(
+                """
+                SELECT name, COUNT(*) AS n
+                FROM parser.matches, jsonb_array_elements_text(players) AS name
+                WHERE user_id = :user_id
+                GROUP BY name
+                ORDER BY n DESC
+                LIMIT 5
+                """
+            ),
+            {"user_id": user.user_id},
+        )
+    ).all()
+    return [UsernameSuggestion(username=str(name), match_count=int(n)) for name, n in rows]

--- a/services/auth/alembic/versions/006_mtgo_usernames.py
+++ b/services/auth/alembic/versions/006_mtgo_usernames.py
@@ -1,0 +1,36 @@
+"""auth.users: add mtgo_usernames JSONB column.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-05-12
+
+Stores the user's confirmed MTGO username(s) as a JSON array of
+strings. Used by the analytics service at query time to identify
+which player in a match is the uploader (hero vs opponent).
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql  # noqa: I001
+
+from alembic import op
+
+revision = "006"
+down_revision = "005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "mtgo_usernames",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        schema="auth",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "mtgo_usernames", schema="auth")

--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -53,6 +53,7 @@ def _user_view(u: User) -> UserView:
         role=u.role,
         disabled=u.disabled,
         must_change_password=u.must_change_password,
+        mtgo_usernames=u.mtgo_usernames,
         created_at=u.created_at,
         updated_at=u.updated_at,
     )

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -289,12 +289,17 @@ async def logout(
 
 
 @app.get("/auth/me", response_model=MeResponse)
-async def me(user: AuthenticatedUser = Depends(get_current_user)) -> MeResponse:
+async def me(
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MeResponse:
+    row = (await db.execute(select(User).where(User.id == user.user_id))).scalar_one_or_none()
     return MeResponse(
         user_id=user.user_id,
         email=user.email,
         role=user.role,
         must_change_password=user.must_change_password,
+        mtgo_usernames=row.mtgo_usernames if row else None,
     )
 
 
@@ -307,35 +312,37 @@ async def update_me(
     caller: AuthenticatedUser = Depends(require_user_role),
     db: AsyncSession = Depends(get_session),
 ) -> UpdateMeResponse:
-    new_email = body.email.strip().lower()
-    if not new_email:
-        # min_length on the schema covers blank, but a whitespace-only
-        # string would slip through — guard explicitly.
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={"error": "invalid_email"},
-        )
-
     user = (await db.execute(select(User).where(User.id == caller.user_id))).scalar_one_or_none()
     if user is None or user.disabled:
         raise _INVALID_CREDENTIALS
 
-    if new_email != user.email.lower():
-        clash = (
-            await db.execute(
-                select(User).where(
-                    func.lower(User.email) == new_email,
-                    User.id != user.id,
-                )
-            )
-        ).scalar_one_or_none()
-        if clash is not None:
+    if body.email is not None:
+        new_email = body.email.strip().lower()
+        if not new_email:
             raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail={"error": "email_already_exists"},
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"error": "invalid_email"},
             )
+        if new_email != user.email.lower():
+            clash = (
+                await db.execute(
+                    select(User).where(
+                        func.lower(User.email) == new_email,
+                        User.id != user.id,
+                    )
+                )
+            ).scalar_one_or_none()
+            if clash is not None:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={"error": "email_already_exists"},
+                )
+        user.email = new_email
 
-    user.email = new_email
+    if body.mtgo_usernames is not None:
+        cleaned = [n.strip() for n in body.mtgo_usernames if n.strip()]
+        user.mtgo_usernames = cleaned or None
+
     user.updated_at = datetime.now(UTC)
     await db.commit()
     await db.refresh(user)
@@ -357,6 +364,7 @@ async def update_me(
         email=user.email,
         role=user.role,
         must_change_password=user.must_change_password,
+        mtgo_usernames=user.mtgo_usernames,
         access_token=fresh_access,
         expires_in=settings.access_token_ttl_seconds,
     )

--- a/services/auth/auth_service/models.py
+++ b/services/auth/auth_service/models.py
@@ -56,6 +56,7 @@ class User(Base):
     must_change_password: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
     )
+    mtgo_usernames: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
     disabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -87,6 +87,7 @@ class UserView(BaseModel):
     role: str
     disabled: bool
     must_change_password: bool
+    mtgo_usernames: list[str] | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -35,10 +35,12 @@ class MeResponse(BaseModel):
     email: str
     role: str
     must_change_password: bool
+    mtgo_usernames: list[str] | None = None
 
 
 class UpdateMeRequest(BaseModel):
-    email: str = Field(min_length=1, max_length=320)
+    email: str | None = Field(default=None, min_length=1, max_length=320)
+    mtgo_usernames: list[str] | None = None
 
 
 class UpdateMeResponse(MeResponse):

--- a/services/web/tests/test_profile_routes.py
+++ b/services/web/tests/test_profile_routes.py
@@ -140,7 +140,9 @@ async def test_post_profile_edit_success_redirects(
     from web_service import deps as _deps
     from web_service import main as _main
 
-    async def fake_update_me(_url: str, _token: str, _email: str) -> auth_client.UpdateMeResult:
+    async def fake_update_me(
+        _url: str, _token: str, _email: str, **_kw: Any
+    ) -> auth_client.UpdateMeResult:
         return auth_client.UpdateMeResult(
             ok=True,
             error=None,
@@ -176,7 +178,9 @@ async def test_post_profile_edit_success_rotates_session_cookie(
     from web_service import deps as _deps
     from web_service import main as _main
 
-    async def fake_update_me(_url: str, _token: str, _email: str) -> auth_client.UpdateMeResult:
+    async def fake_update_me(
+        _url: str, _token: str, _email: str, **_kw: Any
+    ) -> auth_client.UpdateMeResult:
         return auth_client.UpdateMeResult(
             ok=True,
             error=None,
@@ -207,7 +211,9 @@ async def test_post_profile_edit_email_taken_renders_inline(
     from web_service import deps as _deps
     from web_service import main as _main
 
-    async def fake_update_me(_url: str, _token: str, _email: str) -> auth_client.UpdateMeResult:
+    async def fake_update_me(
+        _url: str, _token: str, _email: str, **_kw: Any
+    ) -> auth_client.UpdateMeResult:
         return auth_client.UpdateMeResult(ok=False, error="email_taken")
 
     monkeypatch.setattr(auth_client, "update_me", fake_update_me)
@@ -236,7 +242,9 @@ async def test_post_profile_edit_invalid_email_renders_inline(
     from web_service import deps as _deps
     from web_service import main as _main
 
-    async def fake_update_me(_url: str, _token: str, _email: str) -> auth_client.UpdateMeResult:
+    async def fake_update_me(
+        _url: str, _token: str, _email: str, **_kw: Any
+    ) -> auth_client.UpdateMeResult:
         return auth_client.UpdateMeResult(ok=False, error="invalid_email")
 
     monkeypatch.setattr(auth_client, "update_me", fake_update_me)
@@ -711,7 +719,9 @@ async def test_email_change_then_password_change_chain_uses_new_email(
     async def dep() -> _deps.BrowserUser:
         return state["user"]
 
-    async def fake_update_me(_url: str, _token: str, email: str) -> auth_client.UpdateMeResult:
+    async def fake_update_me(
+        _url: str, _token: str, email: str, **_kw: Any
+    ) -> auth_client.UpdateMeResult:
         # Auth mints a new token for the rotated email claim; web
         # sets the cookie. Mirror the post-rotation user state so the
         # next request resolves the new identity.

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -61,6 +61,7 @@ class UserItem:
     role: str
     disabled: bool
     must_change_password: bool
+    mtgo_usernames: list[str] | None
     created_at: datetime | None
     updated_at: datetime | None
 
@@ -374,6 +375,7 @@ async def admin_list_users(
             role=str(u["role"]),
             disabled=bool(u["disabled"]),
             must_change_password=bool(u["must_change_password"]),
+            mtgo_usernames=u.get("mtgo_usernames"),
             created_at=_parse_dt(u.get("created_at")),
             updated_at=_parse_dt(u.get("updated_at")),
         )

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -29,6 +29,7 @@ class MeResult:
     email: str
     role: str
     must_change_password: bool
+    mtgo_usernames: list[str] | None = None
 
 
 @dataclass
@@ -216,6 +217,7 @@ async def get_me(base_url: str, token: str) -> MeResult:
         email=str(data["email"]),
         role=str(data["role"]),
         must_change_password=bool(data["must_change_password"]),
+        mtgo_usernames=data.get("mtgo_usernames"),
     )
 
 
@@ -263,8 +265,10 @@ async def update_me(
     base_url: str,
     token: str,
     email: str,
+    *,
+    mtgo_usernames: list[str] | None = None,
 ) -> UpdateMeResult:
-    """Try to update the caller's email.
+    """Try to update the caller's profile fields.
 
     On 200, returns ``UpdateMeResult(ok=True, access_token=..., expires_in=...)``
     — the auth response carries a freshly-minted token because email is a
@@ -277,12 +281,15 @@ async def update_me(
     401/403 raise :class:`AuthForbidden`; 5xx / transport raise
     :class:`AuthClientError`.
     """
+    body: dict[str, object] = {"email": email}
+    if mtgo_usernames is not None:
+        body["mtgo_usernames"] = mtgo_usernames
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.patch(
                 f"{base_url}/auth/me",
                 headers={"Authorization": f"Bearer {token}"},
-                json={"email": email},
+                json=body,
             )
     except httpx.HTTPError as exc:
         raise AuthClientError(f"auth /me PATCH transport error: {exc}") from exc

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -61,9 +61,9 @@ class UserItem:
     role: str
     disabled: bool
     must_change_password: bool
-    mtgo_usernames: list[str] | None
-    created_at: datetime | None
-    updated_at: datetime | None
+    mtgo_usernames: list[str] | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 @dataclass

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -363,10 +363,16 @@ async def profile_edit_form(
             "profile_edit.html",
             {"email": ""},
         )
+    names_str = ", ".join(me.mtgo_usernames) if me.mtgo_usernames else ""
     return templates.TemplateResponse(
         request,
         "profile_edit.html",
-        {"user": user, "email": me.email, "error": None},
+        {
+            "user": user,
+            "email": me.email,
+            "mtgo_usernames_str": names_str,
+            "error": None,
+        },
     )
 
 
@@ -374,6 +380,7 @@ async def profile_edit_form(
 async def profile_edit_submit(
     request: Request,
     email: Annotated[str, Form()],
+    mtgo_usernames: Annotated[str, Form()] = "",
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
 ) -> Response:
@@ -381,12 +388,18 @@ async def profile_edit_submit(
     if bounce is not None:
         return bounce
     submitted = email.strip()
+    names_list = [n.strip() for n in mtgo_usernames.split(",") if n.strip()]
 
     def _render_error(message: str, code: int) -> Response:
         return templates.TemplateResponse(
             request,
             "profile_edit.html",
-            {"user": user, "email": submitted, "error": message},
+            {
+                "user": user,
+                "email": submitted,
+                "mtgo_usernames_str": mtgo_usernames,
+                "error": message,
+            },
             status_code=code,
         )
 
@@ -394,7 +407,12 @@ async def profile_edit_submit(
         return _render_error("Email is required.", status.HTTP_400_BAD_REQUEST)
 
     try:
-        result = await auth_client.update_me(settings.auth_service_url, user.token, submitted)
+        result = await auth_client.update_me(
+            settings.auth_service_url,
+            user.token,
+            submitted,
+            mtgo_usernames=names_list or None,
+        )
     except auth_client.AuthForbidden:
         _log.info("profile.edit.update_me.forbidden", extra={"user_id": user.user_id})
         return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -411,7 +411,7 @@ async def profile_edit_submit(
             settings.auth_service_url,
             user.token,
             submitted,
-            mtgo_usernames=names_list or None,
+            mtgo_usernames=names_list,
         )
     except auth_client.AuthForbidden:
         _log.info("profile.edit.update_me.forbidden", extra={"user_id": user.user_id})

--- a/services/web/web_service/templates/admin_users.html
+++ b/services/web/web_service/templates/admin_users.html
@@ -40,6 +40,7 @@
                 <tr>
                     <th>ID</th>
                     <th>Email</th>
+                    <th>MTGO</th>
                     <th>Role</th>
                     <th>Status</th>
                     <th>Must change pw</th>
@@ -52,6 +53,7 @@
                 <tr id="user-{{ u.id }}">
                     <td>{{ u.id }}</td>
                     <td>{{ u.email }}</td>
+                    <td>{{ u.mtgo_usernames | join(", ") if u.mtgo_usernames else "—" }}</td>
                     <td>{{ u.role }}</td>
                     <td>
                         {% if u.disabled %}disabled{% else %}active{% endif %}

--- a/services/web/web_service/templates/profile_edit.html
+++ b/services/web/web_service/templates/profile_edit.html
@@ -14,6 +14,13 @@
             <input type="email" name="email" autocomplete="email" required autofocus
                    value="{{ email or '' }}">
         </label>
+        <label class="field">
+            <span>MTGO Username(s)</span>
+            <input type="text" name="mtgo_usernames"
+                   placeholder="e.g. sentania, MyAltAccount"
+                   value="{{ mtgo_usernames_str or '' }}">
+            <small class="field-hint">Comma-separated. Used to identify you in match results.</small>
+        </label>
         <div class="form-actions">
             <button type="submit" class="btn btn-primary">Save</button>
             <a href="/profile" class="btn btn-secondary">Cancel</a>


### PR DESCRIPTION
## Summary

- Users record MTGO username(s) on their profile (comma-separated, e.g. "sentania, MyAlt")
- Stats engine uses confirmed usernames to identify the uploader in each match, replacing the fragile `players[0]` convention
- Existing matches retroactively show correct hero/opponent attribution — display-time resolution, no re-parse
- Auto-detection endpoint suggests likely usernames based on player-name frequency across uploads

## Changes

- **Auth migration 006**: `auth.users.mtgo_usernames` JSONB column
- **Auth service**: `GET/PATCH /auth/me` returns and accepts `mtgo_usernames`
- **Analytics**: `_classify_match` matches against confirmed usernames (case-insensitive fallback to `players[0]`)
- **Analytics**: `GET /analytics/stats/username-suggestion` — top 5 player names by frequency
- **Web**: profile edit page gains MTGO username(s) text field

## Test plan

- [x] 49 analytics tests pass (stats tests verify graceful fallback when auth schema unavailable)
- [x] ruff + mypy clean
- [ ] CI green
- [ ] Deploy, set MTGO username on profile, verify dashboard shows correct W/L attribution
- [ ] Verify username-suggestion endpoint returns sensible results with existing match data

🤖 Generated with [Claude Code](https://claude.com/claude-code)