### PR TITLE
feat(auth): return upload_count in agent heartbeat response

### DIFF
--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, status
 from redis.asyncio import Redis
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -811,8 +811,17 @@ async def agent_heartbeat(
     await db.commit()
     await db.refresh(row)
 
+    # Cross-schema read: count uploads attributed to this user so the
+    # agent can detect server-side data loss and trigger a re-sync.
+    upload_count_row = await db.execute(
+        text("SELECT COUNT(*) FROM ingest.user_uploads WHERE user_id = :user_id"),
+        {"user_id": agent.user_id},
+    )
+    upload_count: int = upload_count_row.scalar_one()
+
     return AgentHeartbeatResponse(
         status="ok",
         registered_at=row.created_at,
         revoked=row.revoked_at is not None,
+        upload_count=upload_count,
     )

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -79,6 +79,7 @@ class AgentHeartbeatResponse(BaseModel):
     status: str
     registered_at: datetime
     revoked: bool
+    upload_count: int = 0
 
 
 class UserView(BaseModel):

--- a/services/auth/tests/conftest.py
+++ b/services/auth/tests/conftest.py
@@ -30,6 +30,7 @@ from alembic import command
 REPO_ROOT = Path(__file__).resolve().parents[3]
 ROOT_ALEMBIC_INI = REPO_ROOT / "alembic.ini"
 AUTH_ALEMBIC_INI = REPO_ROOT / "services" / "auth" / "alembic.ini"
+INGEST_ALEMBIC_INI = REPO_ROOT / "services" / "ingest" / "alembic.ini"
 
 DEFAULT_DB_URL = "postgresql+psycopg://postgres:postgres@localhost:5432/deep_analysis"
 
@@ -100,8 +101,15 @@ def _migrate(_keys: Any, sync_db_url: str) -> Iterator[None]:
         )
         auth_cfg.set_main_option("sqlalchemy.url", sync_db_url)
 
+        ingest_cfg = Config(str(INGEST_ALEMBIC_INI))
+        ingest_cfg.set_main_option(
+            "script_location", str(REPO_ROOT / "services" / "ingest" / "alembic")
+        )
+        ingest_cfg.set_main_option("sqlalchemy.url", sync_db_url)
+
         command.upgrade(root_cfg, "head")
         command.upgrade(auth_cfg, "head")
+        command.upgrade(ingest_cfg, "head")
         yield
     finally:
         eng.dispose()

--- a/services/auth/tests/test_agent_heartbeat.py
+++ b/services/auth/tests/test_agent_heartbeat.py
@@ -55,6 +55,7 @@ async def test_heartbeat_valid_token(
     body = r.json()
     assert body["status"] == "ok"
     assert body["revoked"] is False
+    assert body["upload_count"] == 0
 
     db_session.expire_all()
     after_row = (


### PR DESCRIPTION
## Summary

- Adds `upload_count: int = 0` to `AgentHeartbeatResponse` schema so the agent can detect server-side data loss and trigger a re-sync
- Heartbeat endpoint queries `ingest.user_uploads` via cross-schema `text()` SQL to count uploads for the authenticated user
- Auth test conftest now runs ingest Alembic migrations so the `ingest.user_uploads` table exists in the test database; heartbeat test asserts the new field

## Test plan

- [ ] CI lint (ruff check + ruff format) passes
- [ ] CI pytest for auth service passes — heartbeat tests assert `upload_count == 0` for a fresh agent with no uploads
- [ ] Verify cross-schema query works in compose-smoke E2E (agent heartbeat returns `upload_count` reflecting actual uploads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)