### PR TITLE
fix: Caddy global block parse error (gateway crash loop)

### DIFF
--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -1,9 +1,6 @@
-# gateway/Caddyfile — slot-internal reverse proxy.
-#
-# Fleet-caddy on the host terminates TLS for the public FQDN and
-# forwards to this container over the edge-slots bridge network.
-# This gateway runs plaintext only — no ACME, no TLS.
 {
+	# Slot-internal reverse proxy. Fleet-caddy terminates TLS;
+	# this gateway runs plaintext only.
 	auto_https off
 }
 


### PR DESCRIPTION
## Summary
- Caddy 2.9 rejects comments before the `{` opening the global options block — interprets them as a keyless server block
- Moved comments inside the block; gateway will now start cleanly

## Context
The gateway container has been crash-looping since deploy with: `server block without any key is global configuration, and if used, it must be first`. Fleet-caddy was routing around it directly to services, so the site worked but without the gateway's security headers.

## Test plan
- [x] CI Caddyfile (`ci/Caddyfile.ci`) already has the correct format (no leading comments)
- [ ] Deploy and verify `docker logs deep-analysis-gateway-1` shows successful startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)