### PR TITLE
fix: deploy script must scp gateway/Caddyfile to host

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -101,6 +101,11 @@ ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
 echo ">> pushing compose file to $DEPLOY_HOST:$DEPLOY_PATH/docker-compose.yml"
 scp "${SCP_OPTS[@]}" "$PROD_COMPOSE" "$DEPLOY_HOST:$DEPLOY_PATH/docker-compose.yml"
 
+echo ">> pushing gateway Caddyfile to $DEPLOY_HOST:$DEPLOY_PATH/gateway/"
+ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" "mkdir -p $DEPLOY_PATH/gateway"
+scp "${SCP_OPTS[@]}" "$SCRIPT_DIR/../gateway/Caddyfile" \
+    "$DEPLOY_HOST:$DEPLOY_PATH/gateway/Caddyfile"
+
 echo ">> pushing fleet-caddy snippets to /srv/fleet-caddy/conf.d/deep-analysis-server/"
 scp "${SCP_OPTS[@]}" "$CADDY_SNIPPET" \
     "$DEPLOY_HOST:/srv/fleet-caddy/conf.d/deep-analysis-server/deep-analysis-server.caddy"


### PR DESCRIPTION
## Summary
Deploy script pushed compose file and fleet-caddy snippets but never updated `gateway/Caddyfile` on the host. The bind mount served a stale TLS/ACME config from initial setup, causing the gateway crash loop.

## Root cause
The old Caddyfile on disk used `{$GATEWAY_DOMAIN}` which evaluates to empty when the env var isn't set → Caddy sees "server block without any key" → crash loop. The repo's Caddyfile was rewritten to plaintext-only in v0.8.2 but the deploy script never SCPd it.

## Fix
Added `scp gateway/Caddyfile` to `deploy.sh` between the compose file push and the fleet-caddy snippet push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)