### PR TITLE
fix: deploy script scps gateway/Caddyfile (no mkdir)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -102,7 +102,6 @@ echo ">> pushing compose file to $DEPLOY_HOST:$DEPLOY_PATH/docker-compose.yml"
 scp "${SCP_OPTS[@]}" "$PROD_COMPOSE" "$DEPLOY_HOST:$DEPLOY_PATH/docker-compose.yml"
 
 echo ">> pushing gateway Caddyfile to $DEPLOY_HOST:$DEPLOY_PATH/gateway/"
-ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" "mkdir -p $DEPLOY_PATH/gateway"
 scp "${SCP_OPTS[@]}" "$SCRIPT_DIR/../gateway/Caddyfile" \
     "$DEPLOY_HOST:$DEPLOY_PATH/gateway/Caddyfile"
 


### PR DESCRIPTION
## Summary
SCP the gateway/Caddyfile to the host during deploy. No `ssh mkdir` — the directory already exists from initial setup, and the deploy-wrapper allowlist blocks raw shell commands.

## Context
v0.8.6 deploy failed because the previous fix (#50) used `ssh mkdir -p` which the deploy-wrapper rejects. This version just SCPs the file directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)