### PR TITLE
fix: scope reingest + parsed count to per-agent

### DIFF
--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -234,23 +234,26 @@ async def list_agents(
         )
     ).all()
 
-    # Cross-schema read: count parsed matches per user so the admin
-    # agents page can compare local_file_count vs parsed_count.
-    user_ids = list({a.user_id for a, _ in rows})
-    parsed_counts: dict[int, int] = {}
-    if user_ids:
+    # Cross-schema read: count parsed matches *per agent* by joining
+    # through ingest.user_uploads so each row shows only the matches
+    # that were uploaded by that specific agent.
+    agent_ids = [a.id for a, _ in rows]
+    parsed_counts: dict[str, int] = {}
+    if agent_ids:
         pc_rows = (
             await db.execute(
                 text(
-                    "SELECT user_id, COUNT(*) AS cnt"
-                    " FROM parser.matches"
-                    " WHERE user_id = ANY(:uids)"
-                    " GROUP BY user_id"
+                    "SELECT u.agent_registration_id, COUNT(DISTINCT m.id) AS cnt"
+                    " FROM parser.matches m"
+                    " JOIN ingest.user_uploads u"
+                    "   ON u.sha256 = m.sha256 AND u.user_id = m.user_id"
+                    " WHERE u.agent_registration_id = ANY(:aids)"
+                    " GROUP BY u.agent_registration_id"
                 ),
-                {"uids": user_ids},
+                {"aids": [str(a) for a in agent_ids]},
             )
         ).all()
-        parsed_counts = {int(r[0]): int(r[1]) for r in pc_rows}
+        parsed_counts = {str(r[0]): int(r[1]) for r in pc_rows}
 
     agents = [
         AgentView(
@@ -260,7 +263,7 @@ async def list_agents(
             machine_name=a.machine_name,
             client_version=a.client_version,
             local_file_count=a.local_file_count,
-            parsed_count=parsed_counts.get(a.user_id, 0),
+            parsed_count=parsed_counts.get(str(a.id), 0),
             created_at=a.created_at,
             last_seen_at=a.last_seen_at,
             revoked_at=a.revoked_at,

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -399,13 +399,26 @@ async def list_my_agents(
         .scalars()
         .all()
     )
-    # Cross-schema read: count parsed matches per user so the agent
-    # page can compare local_file_count vs parsed_count.
-    parsed_row = await db.execute(
-        text("SELECT COUNT(*) FROM parser.matches WHERE user_id = :uid"),
-        {"uid": caller.user_id},
-    )
-    parsed_count: int = parsed_row.scalar_one()
+    # Cross-schema read: count parsed matches *per agent* by joining
+    # through ingest.user_uploads so each row shows only the matches
+    # that were uploaded by that specific agent.
+    agent_ids = [a.id for a in rows]
+    parsed_counts: dict[str, int] = {}
+    if agent_ids:
+        pc_rows = (
+            await db.execute(
+                text(
+                    "SELECT u.agent_registration_id, COUNT(DISTINCT m.id) AS cnt"
+                    " FROM parser.matches m"
+                    " JOIN ingest.user_uploads u"
+                    "   ON u.sha256 = m.sha256 AND u.user_id = m.user_id"
+                    " WHERE u.agent_registration_id = ANY(:aids)"
+                    " GROUP BY u.agent_registration_id"
+                ),
+                {"aids": [str(a) for a in agent_ids]},
+            )
+        ).all()
+        parsed_counts = {str(r[0]): int(r[1]) for r in pc_rows}
 
     agents = [
         AgentView(
@@ -415,7 +428,7 @@ async def list_my_agents(
             machine_name=a.machine_name,
             client_version=a.client_version,
             local_file_count=a.local_file_count,
-            parsed_count=parsed_count,
+            parsed_count=parsed_counts.get(str(a.id), 0),
             created_at=a.created_at,
             last_seen_at=a.last_seen_at,
             revoked_at=a.revoked_at,

--- a/services/parser/parser_service/reingest.py
+++ b/services/parser/parser_service/reingest.py
@@ -43,18 +43,24 @@ def _parse_iso_dt(raw: str | None) -> datetime | None:
 async def delete_my_matches(
     after: str | None = Query(default=None, description="ISO date lower bound on played_at"),
     before: str | None = Query(default=None, description="ISO date upper bound on played_at"),
+    agent_id: str | None = Query(
+        default=None,
+        description="Scope deletion to matches uploaded by this agent",
+    ),
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ) -> DeletedCountResponse:
     """Delete all parsed matches for the authenticated user.
 
     Games and game_states are CASCADE-deleted by the FK constraints.
-    Optional date filtering on played_at.
+    Optional date filtering on played_at.  When ``agent_id`` is
+    provided, only matches whose sha256 was uploaded by that agent
+    are deleted.
     """
-    count = await _delete_matches_for_user(db, user.user_id, after, before)
+    count = await _delete_matches_for_user(db, user.user_id, after, before, agent_id=agent_id)
     _log.info(
         "parser.reingest.user",
-        extra={"user_id": user.user_id, "deleted_count": count},
+        extra={"user_id": user.user_id, "agent_id": agent_id, "deleted_count": count},
     )
     return DeletedCountResponse(deleted_count=count)
 
@@ -64,14 +70,22 @@ async def admin_delete_user_matches(
     user_id: int,
     after: str | None = Query(default=None, description="ISO date lower bound on played_at"),
     before: str | None = Query(default=None, description="ISO date upper bound on played_at"),
+    agent_id: str | None = Query(
+        default=None,
+        description="Scope deletion to matches uploaded by this agent",
+    ),
     _admin: AuthenticatedUser = Depends(require_admin),
     db: AsyncSession = Depends(get_session),
 ) -> DeletedCountResponse:
-    """Admin: delete all parsed matches for a specific user."""
-    count = await _delete_matches_for_user(db, user_id, after, before)
+    """Admin: delete parsed matches for a specific user.
+
+    When ``agent_id`` is provided, only matches whose sha256 was
+    uploaded by that agent are deleted.
+    """
+    count = await _delete_matches_for_user(db, user_id, after, before, agent_id=agent_id)
     _log.info(
         "parser.reingest.admin_user",
-        extra={"target_user_id": user_id, "deleted_count": count},
+        extra={"target_user_id": user_id, "agent_id": agent_id, "deleted_count": count},
     )
     return DeletedCountResponse(deleted_count=count)
 
@@ -97,8 +111,14 @@ async def _delete_matches_for_user(
     user_id: int,
     after_raw: str | None,
     before_raw: str | None,
+    *,
+    agent_id: str | None = None,
 ) -> int:
-    """Delete matches (and cascaded children) for a single user."""
+    """Delete matches (and cascaded children) for a single user.
+
+    When *agent_id* is provided, only matches whose ``sha256`` exists
+    in ``ingest.user_uploads`` for that agent are deleted.
+    """
     after_dt = _parse_iso_dt(after_raw)
     if after_raw is not None and after_dt is None:
         raise HTTPException(status_code=422, detail={"error": "invalid_date", "field": "after"})
@@ -108,7 +128,26 @@ async def _delete_matches_for_user(
 
     # Find matching match IDs first, then cascade-delete children
     # explicitly since bulk DELETE doesn't trigger ORM cascades.
-    conditions = [Match.user_id == user_id]
+    if agent_id is not None:
+        # Scope to matches uploaded by this specific agent via the
+        # ingest.user_uploads join table.
+        from sqlalchemy import text as _text
+
+        sha_rows = await db.execute(
+            _text(
+                "SELECT sha256 FROM ingest.user_uploads"
+                " WHERE agent_registration_id = :agent_id"
+                " AND user_id = :user_id"
+            ),
+            {"agent_id": agent_id, "user_id": user_id},
+        )
+        agent_shas = [r[0] for r in sha_rows.all()]
+        if not agent_shas:
+            return 0
+        conditions = [Match.user_id == user_id, Match.sha256.in_(agent_shas)]
+    else:
+        conditions = [Match.user_id == user_id]
+
     if after_dt is not None:
         conditions.append(Match.played_at >= after_dt)
     if before_dt is not None:

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -619,18 +619,21 @@ async def profile_agents_generate_code(
     )
 
 
-@app.post("/profile/agents/reingest")
+@app.post("/profile/agents/{agent_id}/reingest")
 async def profile_agents_reingest(
+    agent_id: uuid.UUID,
     request: Request,
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
 ) -> Response:
-    """Force reingest: delete all parsed matches for the current user."""
+    """Force reingest: delete parsed matches uploaded by a specific agent."""
     bounce = _bounce_admin_to_panel(user)
     if bounce is not None:
         return bounce
     try:
-        result = await parser_client.delete_my_matches(settings.parser_service_url, user.token)
+        result = await parser_client.delete_my_matches(
+            settings.parser_service_url, user.token, agent_id=str(agent_id)
+        )
     except parser_client.ParserForbidden:
         _log.info("profile.agents.reingest.forbidden", extra={"user_id": user.user_id})
         return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
@@ -1240,9 +1243,9 @@ async def admin_agents_list(
     )
 
 
-@app.post("/admin/agents/{user_id}/reingest")
+@app.post("/admin/agents/{agent_id}/reingest")
 async def admin_agent_reingest(
-    user_id: int,
+    agent_id: uuid.UUID,
     request: Request,
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
@@ -1251,21 +1254,26 @@ async def admin_agent_reingest(
         int,
         Query(ge=1, le=_ADMIN_AGENTS_MAX_PER_PAGE),
     ] = _ADMIN_AGENTS_DEFAULT_PER_PAGE,
+    user_id: Annotated[int, Query(ge=1)] = 0,
 ) -> Response:
-    """Admin: force reingest for a specific user."""
+    """Admin: force reingest for a specific agent."""
     blocked = _require_admin_or_403(request, user)
     if blocked is not None:
         return blocked
 
     try:
         result = await parser_client.admin_delete_user_matches(
-            settings.parser_service_url, user.token, user_id
+            settings.parser_service_url, user.token, user_id, agent_id=str(agent_id)
         )
     except parser_client.ParserForbidden:
         _log.info("admin.agents.reingest.forbidden", extra={"user_id": user.user_id})
         return _admin_forbidden(request, user)
     except parser_client.ParserClientError:
-        _log.exception("parser DELETE /parser/admin/matches/%s call failed", user_id)
+        _log.exception(
+            "parser DELETE /parser/admin/matches/%s?agent_id=%s call failed",
+            user_id,
+            agent_id,
+        )
         return Response(
             content="Parser service unavailable. Please try again.",
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/services/web/web_service/parser_client.py
+++ b/services/web/web_service/parser_client.py
@@ -27,16 +27,23 @@ class DeletedCountResult:
 async def delete_my_matches(
     base_url: str,
     token: str,
+    *,
+    agent_id: str | None = None,
 ) -> DeletedCountResult:
-    """Delete all parsed matches for the authenticated user.
+    """Delete parsed matches for the authenticated user.
 
-    Returns the count of deleted matches.
+    When *agent_id* is provided, only matches uploaded by that agent
+    are deleted.  Returns the count of deleted matches.
     """
+    params: dict[str, str] = {}
+    if agent_id is not None:
+        params["agent_id"] = agent_id
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.delete(
                 f"{base_url}/parser/matches",
                 headers={"Authorization": f"Bearer {token}"},
+                params=params,
             )
     except httpx.HTTPError as exc:
         raise ParserClientError(f"parser DELETE /parser/matches transport error: {exc}") from exc
@@ -54,13 +61,23 @@ async def admin_delete_user_matches(
     base_url: str,
     token: str,
     user_id: int,
+    *,
+    agent_id: str | None = None,
 ) -> DeletedCountResult:
-    """Admin: delete all parsed matches for a specific user."""
+    """Admin: delete parsed matches for a specific user.
+
+    When *agent_id* is provided, only matches uploaded by that agent
+    are deleted.
+    """
+    params: dict[str, str] = {}
+    if agent_id is not None:
+        params["agent_id"] = agent_id
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.delete(
                 f"{base_url}/parser/admin/matches/{user_id}",
                 headers={"Authorization": f"Bearer {token}"},
+                params=params,
             )
     except httpx.HTTPError as exc:
         raise ParserClientError(

--- a/services/web/web_service/templates/admin_agents.html
+++ b/services/web/web_service/templates/admin_agents.html
@@ -78,7 +78,7 @@
                             <button type="submit" class="btn btn-danger">Revoke</button>
                         </form>
                         <form method="post"
-                              action="/admin/agents/{{ a.user_id }}/reingest?page={{ page }}&per_page={{ per_page }}"
+                              action="/admin/agents/{{ a.agent_id }}/reingest?page={{ page }}&per_page={{ per_page }}&user_id={{ a.user_id }}"
                               class="inline-form reingest-form"
                               data-user-email="{{ a.user_email }}">
                             <button type="submit" class="btn">Reingest</button>
@@ -136,7 +136,7 @@
         form.addEventListener('submit', function (e) {
             var ue = form.dataset.userEmail || '';
             var msg = 'Force reingest for ' + ue +
-                '? This deletes all parsed matches for this user. ' +
+                '? This deletes parsed matches uploaded by this agent. ' +
                 'The backfill scanner will re-parse them.';
             if (!window.confirm(msg)) {
                 e.preventDefault();

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -105,8 +105,8 @@
                         {{ match.played_at.strftime("%Y-%m-%d") if match.played_at else match.match_id[:8] }}
                     </a>
                 </td>
-                <td>{{ match.opponent or "&mdash;" }}</td>
-                <td>{{ match.format_ or "&mdash;" }}</td>
+                <td>{{ match.opponent or "—" }}</td>
+                <td>{{ match.format_ or "—" }}</td>
                 <td>
                     {% if match.result == "W" %}
                         <span class="result-badge result-win">W</span>

--- a/services/web/web_service/templates/profile_agents.html
+++ b/services/web/web_service/templates/profile_agents.html
@@ -109,7 +109,7 @@
                             <button type="submit" class="btn btn-danger">Revoke</button>
                         </form>
                         <form method="post"
-                              action="/profile/agents/reingest"
+                              action="/profile/agents/{{ a.agent_id }}/reingest"
                               class="inline-form reingest-form">
                             <button type="submit" class="btn">Reingest</button>
                         </form>
@@ -156,7 +156,7 @@
     });
     document.querySelectorAll('.reingest-form').forEach(function (form) {
         form.addEventListener('submit', function (e) {
-            if (!window.confirm('Force reingest? This deletes all your parsed matches. The backfill scanner will re-parse them.')) {
+            if (!window.confirm('Force reingest? This deletes parsed matches uploaded by this agent. The backfill scanner will re-parse them.')) {
                 e.preventDefault();
             }
         });


### PR DESCRIPTION
## Summary

- **Reingest per-agent**: The "Reingest" button on both user and admin agents pages was deleting ALL matches for the user instead of only matches uploaded by that specific agent. Added `agent_id` query param to `DELETE /parser/matches` and `DELETE /parser/admin/matches/{user_id}` endpoints; the web routes and templates now pass the agent_id through the form URL. The scoping works by joining `parser.matches.sha256` to `ingest.user_uploads` filtered by `agent_registration_id`.

- **Em-dash rendering**: Dashboard opponent and format columns showed literal `&mdash;` text because Jinja2 auto-escapes HTML entities inside `{{ }}` expressions. Replaced with the actual Unicode em-dash character. Other `&mdash;` occurrences in templates were already in raw HTML context (outside expressions) and rendered correctly.

- **Per-agent parsed count**: The "Parsed" column on both user and admin agents pages showed the same number for every agent because the query counted all `parser.matches` for the `user_id`. Changed to join through `ingest.user_uploads` and group by `agent_registration_id` to show per-agent counts.

## Test plan

- [ ] User agents page: each agent row shows its own parsed count (not the user total)
- [ ] Admin agents page: each agent row shows its own parsed count
- [ ] User agents page: clicking Reingest on agent A only deletes matches from agent A's uploads
- [ ] Admin agents page: clicking Reingest on an agent only deletes that agent's matches
- [ ] Dashboard opponent/format columns show em-dash (not literal `&mdash;`) for null values
- [ ] Ruff check and format pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)