### PR TITLE
feat: v0.8.8 — agent-scoped reingest, min version, opponent UI, Scryfall fix

### DIFF
--- a/alembic/versions/010_parsed_with_version.py
+++ b/alembic/versions/010_parsed_with_version.py
@@ -1,0 +1,30 @@
+"""parser.matches: add parsed_with_version column for versioned reparse.
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-05-13
+
+Tracks which parser version produced each match row so the backfill
+scanner can detect stale parses and queue them for re-processing.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "010"
+down_revision = "009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "matches",
+        sa.Column("parsed_with_version", sa.Text(), nullable=True),
+        schema="parser",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("matches", "parsed_with_version", schema="parser")

--- a/ci/Caddyfile.ci
+++ b/ci/Caddyfile.ci
@@ -14,10 +14,6 @@
         respond "ok" 200
     }
 
-    handle / {
-        redir /dashboard 302
-    }
-
     handle /auth/* {
         reverse_proxy auth:8000
     }

--- a/common/format_inference.py
+++ b/common/format_inference.py
@@ -26,8 +26,11 @@ _FORMAT_HIERARCHY: list[str] = [
     "standard",
     "pioneer",
     "modern",
+    "pauper",
     "legacy",
     "vintage",
+    # Limited/Draft and Cube are not detectable by legality alone —
+    # they need set-code analysis or cube-list matching (v0.9.x).
 ]
 
 _BASIC_LANDS = frozenset(

--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -17,10 +17,6 @@
         respond "ok" 200
     }
 
-    handle / {
-        redir /dashboard 302
-    }
-
     handle /auth/* {
         reverse_proxy auth:8000
     }

--- a/services/analytics/analytics_service/mtgo_scraper.py
+++ b/services/analytics/analytics_service/mtgo_scraper.py
@@ -49,7 +49,7 @@ _log = logging.getLogger("analytics.mtgo_scraper")
 
 USER_AGENT = "DeepAnalysis/0.8 (personal MTGO analytics; contact: ops@sentania.net)"
 LISTING_URL = "https://www.mtgo.com/decklists"
-REQUEST_TIMEOUT = 30.0
+REQUEST_TIMEOUT = 60.0
 POLITE_DELAY_SECONDS = 2.0
 BROKEN_THRESHOLD = 3
 SCRAPER_NAME = "mtgo"
@@ -610,15 +610,41 @@ def _strip_placement(text_value: str) -> str:
 # --------------------------------------------------------------------------- #
 
 
+_RETRY_ATTEMPTS = 2
+_RETRY_BACKOFF_SECONDS = 5.0
+
+
+async def _get_with_retry(
+    client: httpx.AsyncClient,
+    url: str,
+) -> httpx.Response:
+    """GET *url* with a single retry on timeout errors."""
+    last_exc: httpx.TimeoutException | None = None
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            return await client.get(url)
+        except httpx.TimeoutException as exc:
+            last_exc = exc
+            if attempt + 1 < _RETRY_ATTEMPTS:
+                _log.warning(
+                    "request timed out, retrying in %.0fs url=%s attempt=%d",
+                    _RETRY_BACKOFF_SECONDS,
+                    url,
+                    attempt + 1,
+                )
+                await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
+    raise last_exc  # type: ignore[misc]
+
+
 async def fetch_event_listing(client: httpx.AsyncClient) -> tuple[int, str]:
-    response = await client.get(LISTING_URL)
+    response = await _get_with_retry(client, LISTING_URL)
     return response.status_code, response.text
 
 
 async def fetch_event_page(client: httpx.AsyncClient, url: str) -> tuple[int, str]:
     """Fetch a single event page after a polite delay."""
     await asyncio.sleep(POLITE_DELAY_SECONDS)
-    response = await client.get(url)
+    response = await _get_with_retry(client, url)
     return response.status_code, response.text
 
 

--- a/services/analytics/analytics_service/scryfall_sync.py
+++ b/services/analytics/analytics_service/scryfall_sync.py
@@ -175,7 +175,7 @@ async def stream_sync_cards(
 
 
 async def should_sync(session: AsyncSession) -> bool:
-    """True if ``catalog.cards`` is empty or the last sync is stale."""
+    """True if ``catalog.cards`` is empty, stale, or missing legality data."""
     settings = get_settings()
     last = (
         await session.execute(text("SELECT MAX(synced_at) FROM catalog.cards"))
@@ -183,7 +183,14 @@ async def should_sync(session: AsyncSession) -> bool:
     if last is None:
         return True
     cutoff = datetime.now(UTC) - timedelta(days=settings.scryfall_sync_interval_days)
-    return last < cutoff
+    if last < cutoff:
+        return True
+    has_legalities = (
+        await session.execute(
+            text("SELECT EXISTS(SELECT 1 FROM catalog.cards WHERE legalities IS NOT NULL)")
+        )
+    ).scalar_one()
+    return not has_legalities
 
 
 async def run_sync(sessionmaker: async_sessionmaker[AsyncSession]) -> SyncResult:

--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -234,23 +234,26 @@ async def list_agents(
         )
     ).all()
 
-    # Cross-schema read: count parsed matches per user so the admin
-    # agents page can compare local_file_count vs parsed_count.
-    user_ids = list({a.user_id for a, _ in rows})
-    parsed_counts: dict[int, int] = {}
-    if user_ids:
+    # Cross-schema read: count parsed matches *per agent* by joining
+    # through ingest.user_uploads so each row shows only the matches
+    # that were uploaded by that specific agent.
+    agent_ids = [a.id for a, _ in rows]
+    parsed_counts: dict[str, int] = {}
+    if agent_ids:
         pc_rows = (
             await db.execute(
                 text(
-                    "SELECT user_id, COUNT(*) AS cnt"
-                    " FROM parser.matches"
-                    " WHERE user_id = ANY(:uids)"
-                    " GROUP BY user_id"
+                    "SELECT u.agent_registration_id, COUNT(DISTINCT m.id) AS cnt"
+                    " FROM parser.matches m"
+                    " JOIN ingest.user_uploads u"
+                    "   ON u.sha256 = m.sha256 AND u.user_id = m.user_id"
+                    " WHERE u.agent_registration_id = ANY(:aids)"
+                    " GROUP BY u.agent_registration_id"
                 ),
-                {"uids": user_ids},
+                {"aids": [str(a) for a in agent_ids]},
             )
         ).all()
-        parsed_counts = {int(r[0]): int(r[1]) for r in pc_rows}
+        parsed_counts = {str(r[0]): int(r[1]) for r in pc_rows}
 
     agents = [
         AgentView(
@@ -260,7 +263,7 @@ async def list_agents(
             machine_name=a.machine_name,
             client_version=a.client_version,
             local_file_count=a.local_file_count,
-            parsed_count=parsed_counts.get(a.user_id, 0),
+            parsed_count=parsed_counts.get(str(a.id), 0),
             created_at=a.created_at,
             last_seen_at=a.last_seen_at,
             revoked_at=a.revoked_at,

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -852,9 +852,11 @@ async def agent_heartbeat(
     except Exception:
         upload_count = 0
 
+    settings = get_settings()
     return AgentHeartbeatResponse(
         status="ok",
         registered_at=row.created_at,
         revoked=row.revoked_at is not None,
         upload_count=upload_count,
+        min_agent_version=settings.MIN_AGENT_VERSION,
     )

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -399,13 +399,26 @@ async def list_my_agents(
         .scalars()
         .all()
     )
-    # Cross-schema read: count parsed matches per user so the agent
-    # page can compare local_file_count vs parsed_count.
-    parsed_row = await db.execute(
-        text("SELECT COUNT(*) FROM parser.matches WHERE user_id = :uid"),
-        {"uid": caller.user_id},
-    )
-    parsed_count: int = parsed_row.scalar_one()
+    # Cross-schema read: count parsed matches *per agent* by joining
+    # through ingest.user_uploads so each row shows only the matches
+    # that were uploaded by that specific agent.
+    agent_ids = [a.id for a in rows]
+    parsed_counts: dict[str, int] = {}
+    if agent_ids:
+        pc_rows = (
+            await db.execute(
+                text(
+                    "SELECT u.agent_registration_id, COUNT(DISTINCT m.id) AS cnt"
+                    " FROM parser.matches m"
+                    " JOIN ingest.user_uploads u"
+                    "   ON u.sha256 = m.sha256 AND u.user_id = m.user_id"
+                    " WHERE u.agent_registration_id = ANY(:aids)"
+                    " GROUP BY u.agent_registration_id"
+                ),
+                {"aids": [str(a) for a in agent_ids]},
+            )
+        ).all()
+        parsed_counts = {str(r[0]): int(r[1]) for r in pc_rows}
 
     agents = [
         AgentView(
@@ -415,7 +428,7 @@ async def list_my_agents(
             machine_name=a.machine_name,
             client_version=a.client_version,
             local_file_count=a.local_file_count,
-            parsed_count=parsed_count,
+            parsed_count=parsed_counts.get(str(a.id), 0),
             created_at=a.created_at,
             last_seen_at=a.last_seen_at,
             revoked_at=a.revoked_at,

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -81,6 +81,7 @@ class AgentHeartbeatResponse(BaseModel):
     registered_at: datetime
     revoked: bool
     upload_count: int = 0
+    min_agent_version: str | None = None
 
 
 class UserView(BaseModel):

--- a/services/auth/auth_service/settings.py
+++ b/services/auth/auth_service/settings.py
@@ -49,6 +49,12 @@ class AuthSettings(BaseServiceSettings):
     )
     initial_admin_secret_path: Path = Path("/data/secrets/initial_admin.txt")
 
+    # Minimum agent version the server considers current.  Returned in
+    # heartbeat responses so the agent can warn or self-update.  This is
+    # a code-level constant, NOT admin-configurable — bump it here when
+    # a new agent release ships a breaking change or required fix.
+    MIN_AGENT_VERSION: str = "0.4.14"
+
 
 _settings: AuthSettings | None = None
 

--- a/services/parser/parser_service/backfill.py
+++ b/services/parser/parser_service/backfill.py
@@ -8,6 +8,10 @@ exist in ``ingest.user_uploads`` but have no corresponding row in
 This closes the reliability gap in the Redis pub/sub delivery: if the
 parser misses a ``file.ingested`` event (downtime, DB outage, Redis
 blip), the backfill scan picks it up on the next pass.
+
+Additionally, matches where ``parsed_with_version`` is NULL or older
+than :data:`~parser_service.settings.REPARSE_MIN_VERSION` are queued
+for reparse so that parser improvements can be applied retroactively.
 """
 
 from __future__ import annotations
@@ -20,6 +24,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from parser_service.consumer import ParserConsumer
+from parser_service.settings import REPARSE_MIN_VERSION
 
 _log = logging.getLogger("parser.backfill")
 
@@ -30,8 +35,12 @@ _UNPARSED_SQL = text(
       JOIN ingest.game_log_files g ON g.sha256 = u.sha256
       LEFT JOIN parser.matches m
         ON m.sha256 = u.sha256 AND m.user_id = u.user_id
-     WHERE m.id IS NULL
-       AND g.content_type = 'match-log'
+     WHERE g.content_type = 'match-log'
+       AND (
+           m.id IS NULL
+           OR m.parsed_with_version IS NULL
+           OR m.parsed_with_version < :min_version
+       )
      LIMIT :batch_size
     """
 )
@@ -43,7 +52,12 @@ async def scan_unparsed(
     batch_size: int = 100,
 ) -> int:
     async with sm() as session:
-        rows = (await session.execute(_UNPARSED_SQL, {"batch_size": batch_size})).all()
+        rows = (
+            await session.execute(
+                _UNPARSED_SQL,
+                {"batch_size": batch_size, "min_version": REPARSE_MIN_VERSION},
+            )
+        ).all()
 
     if not rows:
         return 0

--- a/services/parser/parser_service/models.py
+++ b/services/parser/parser_service/models.py
@@ -32,6 +32,7 @@ from sqlalchemy import (
     Integer,
     MetaData,
     String,
+    Text,
     UniqueConstraint,
     func,
 )
@@ -66,6 +67,7 @@ class Match(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
     played_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    parsed_with_version: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     __table_args__ = (
         UniqueConstraint("sha256", "user_id", name="uq_matches_sha256_user"),

--- a/services/parser/parser_service/persistence.py
+++ b/services/parser/parser_service/persistence.py
@@ -44,7 +44,7 @@ async def persist_match(
         played_at=parsed.played_at,
         parsed_with_version=PARSER_VERSION,
     )
-    insert_stmt = insert_stmt.on_conflict_do_update(
+    upsert_stmt = insert_stmt.on_conflict_do_update(
         constraint="uq_matches_sha256_user",
         set_={
             "format": insert_stmt.excluded.format,
@@ -59,7 +59,7 @@ async def persist_match(
         },
     ).returning(Match.id)
 
-    match_id = (await session.execute(insert_stmt)).scalar_one()
+    match_id = (await session.execute(upsert_stmt)).scalar_one()
 
     # If this was an upsert (reparse), the id is the existing row's id,
     # not new_id. Either way we need to (re-)write children.

--- a/services/parser/parser_service/persistence.py
+++ b/services/parser/parser_service/persistence.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from parser_service.models import Game, GameState, Match
 from parser_service.parsing.models import ParsedMatch
+from parser_service.settings import PARSER_VERSION
 
 
 async def persist_match(
@@ -19,51 +20,59 @@ async def persist_match(
     sha256: str,
     user_id: int,
 ) -> Match:
-    """Insert a parsed match (plus games and per-turn states).
+    """Insert or update a parsed match (plus games and per-turn states).
 
     Idempotent on ``(sha256, user_id)`` at the database layer — uses
-    ``INSERT ... ON CONFLICT (sha256, user_id) DO NOTHING RETURNING id``
-    so two consumers racing on the same upload cannot both create child
-    rows. If the conflict path is hit, we resolve the existing row and
-    skip the child writes entirely (they were already persisted by the
-    winner).
+    ``INSERT ... ON CONFLICT (sha256, user_id) DO UPDATE`` so that
+    re-parses (e.g. from the backfill scanner after a parser upgrade)
+    overwrite the previous row's metadata and stamp the current
+    ``parsed_with_version``.
     """
+    now = datetime.now(UTC)
     new_id = uuid.uuid4()
-    insert_stmt = (
-        pg_insert(Match)
-        .values(
-            id=new_id,
-            sha256=sha256,
-            user_id=user_id,
-            format=parsed.format,
-            event_type=parsed.event_type,
-            players=parsed.players,
-            match_result=parsed.match_result,
-            winner=parsed.winner,
-            game_count=parsed.game_count,
-            parsed_at=datetime.now(UTC),
-            played_at=parsed.played_at,
-        )
-        .on_conflict_do_nothing(constraint="uq_matches_sha256_user")
-        .returning(Match.id)
+    insert_stmt = pg_insert(Match).values(
+        id=new_id,
+        sha256=sha256,
+        user_id=user_id,
+        format=parsed.format,
+        event_type=parsed.event_type,
+        players=parsed.players,
+        match_result=parsed.match_result,
+        winner=parsed.winner,
+        game_count=parsed.game_count,
+        parsed_at=now,
+        played_at=parsed.played_at,
+        parsed_with_version=PARSER_VERSION,
     )
-    inserted_id = (await session.execute(insert_stmt)).scalar_one_or_none()
+    insert_stmt = insert_stmt.on_conflict_do_update(
+        constraint="uq_matches_sha256_user",
+        set_={
+            "format": insert_stmt.excluded.format,
+            "event_type": insert_stmt.excluded.event_type,
+            "players": insert_stmt.excluded.players,
+            "match_result": insert_stmt.excluded.match_result,
+            "winner": insert_stmt.excluded.winner,
+            "game_count": insert_stmt.excluded.game_count,
+            "parsed_at": insert_stmt.excluded.parsed_at,
+            "played_at": insert_stmt.excluded.played_at,
+            "parsed_with_version": insert_stmt.excluded.parsed_with_version,
+        },
+    ).returning(Match.id)
 
-    if inserted_id is None:
-        # Another worker won the race — return the canonical row, do not
-        # re-insert children.
-        existing = (
-            await session.execute(
-                select(Match).where(Match.sha256 == sha256, Match.user_id == user_id)
-            )
-        ).scalar_one()
-        await session.commit()
-        return existing
+    match_id = (await session.execute(insert_stmt)).scalar_one()
+
+    # If this was an upsert (reparse), the id is the existing row's id,
+    # not new_id. Either way we need to (re-)write children.
+    is_reparse = match_id != new_id
+    if is_reparse:
+        # Clear stale children before re-inserting.
+        # CASCADE on games.match_id → game_states.game_id handles states.
+        await session.execute(delete(Game).where(Game.match_id == match_id))
 
     for parsed_game in parsed.games:
         game = Game(
             id=uuid.uuid4(),
-            match_id=inserted_id,
+            match_id=match_id,
             game_number=parsed_game.game_number,
             winner=parsed_game.winner,
             result=parsed_game.result,
@@ -96,5 +105,5 @@ async def persist_match(
             await session.execute(gs_stmt)
 
     await session.commit()
-    match = (await session.execute(select(Match).where(Match.id == inserted_id))).scalar_one()
+    match = (await session.execute(select(Match).where(Match.id == match_id))).scalar_one()
     return match

--- a/services/parser/parser_service/reingest.py
+++ b/services/parser/parser_service/reingest.py
@@ -10,6 +10,7 @@ Routes:
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -106,6 +107,17 @@ async def admin_delete_all_matches(
     return DeletedCountResponse(deleted_count=count)
 
 
+def _validate_uuid(value: str, field: str) -> None:
+    """Raise 422 if *value* is not a valid UUID."""
+    try:
+        uuid.UUID(value)
+    except (ValueError, AttributeError):
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "invalid_uuid", "field": field},
+        ) from None
+
+
 async def _delete_matches_for_user(
     db: AsyncSession,
     user_id: int,
@@ -119,6 +131,9 @@ async def _delete_matches_for_user(
     When *agent_id* is provided, only matches whose ``sha256`` exists
     in ``ingest.user_uploads`` for that agent are deleted.
     """
+    if agent_id is not None:
+        _validate_uuid(agent_id, "agent_id")
+
     after_dt = _parse_iso_dt(after_raw)
     if after_raw is not None and after_dt is None:
         raise HTTPException(status_code=422, detail={"error": "invalid_date", "field": "after"})

--- a/services/parser/parser_service/reingest.py
+++ b/services/parser/parser_service/reingest.py
@@ -43,18 +43,24 @@ def _parse_iso_dt(raw: str | None) -> datetime | None:
 async def delete_my_matches(
     after: str | None = Query(default=None, description="ISO date lower bound on played_at"),
     before: str | None = Query(default=None, description="ISO date upper bound on played_at"),
+    agent_id: str | None = Query(
+        default=None,
+        description="Scope deletion to matches uploaded by this agent",
+    ),
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ) -> DeletedCountResponse:
     """Delete all parsed matches for the authenticated user.
 
     Games and game_states are CASCADE-deleted by the FK constraints.
-    Optional date filtering on played_at.
+    Optional date filtering on played_at.  When ``agent_id`` is
+    provided, only matches whose sha256 was uploaded by that agent
+    are deleted.
     """
-    count = await _delete_matches_for_user(db, user.user_id, after, before)
+    count = await _delete_matches_for_user(db, user.user_id, after, before, agent_id=agent_id)
     _log.info(
         "parser.reingest.user",
-        extra={"user_id": user.user_id, "deleted_count": count},
+        extra={"user_id": user.user_id, "agent_id": agent_id, "deleted_count": count},
     )
     return DeletedCountResponse(deleted_count=count)
 
@@ -64,14 +70,22 @@ async def admin_delete_user_matches(
     user_id: int,
     after: str | None = Query(default=None, description="ISO date lower bound on played_at"),
     before: str | None = Query(default=None, description="ISO date upper bound on played_at"),
+    agent_id: str | None = Query(
+        default=None,
+        description="Scope deletion to matches uploaded by this agent",
+    ),
     _admin: AuthenticatedUser = Depends(require_admin),
     db: AsyncSession = Depends(get_session),
 ) -> DeletedCountResponse:
-    """Admin: delete all parsed matches for a specific user."""
-    count = await _delete_matches_for_user(db, user_id, after, before)
+    """Admin: delete parsed matches for a specific user.
+
+    When ``agent_id`` is provided, only matches whose sha256 was
+    uploaded by that agent are deleted.
+    """
+    count = await _delete_matches_for_user(db, user_id, after, before, agent_id=agent_id)
     _log.info(
         "parser.reingest.admin_user",
-        extra={"target_user_id": user_id, "deleted_count": count},
+        extra={"target_user_id": user_id, "agent_id": agent_id, "deleted_count": count},
     )
     return DeletedCountResponse(deleted_count=count)
 
@@ -97,8 +111,14 @@ async def _delete_matches_for_user(
     user_id: int,
     after_raw: str | None,
     before_raw: str | None,
+    *,
+    agent_id: str | None = None,
 ) -> int:
-    """Delete matches (and cascaded children) for a single user."""
+    """Delete matches (and cascaded children) for a single user.
+
+    When *agent_id* is provided, only matches whose ``sha256`` exists
+    in ``ingest.user_uploads`` for that agent are deleted.
+    """
     after_dt = _parse_iso_dt(after_raw)
     if after_raw is not None and after_dt is None:
         raise HTTPException(status_code=422, detail={"error": "invalid_date", "field": "after"})
@@ -108,7 +128,26 @@ async def _delete_matches_for_user(
 
     # Find matching match IDs first, then cascade-delete children
     # explicitly since bulk DELETE doesn't trigger ORM cascades.
-    conditions = [Match.user_id == user_id]
+    if agent_id is not None:
+        # Scope to matches uploaded by this specific agent via the
+        # ingest.user_uploads join table.
+        from sqlalchemy import text as _text
+
+        sha_rows = await db.execute(
+            _text(
+                "SELECT sha256 FROM ingest.user_uploads"
+                " WHERE agent_registration_id = :agent_id"
+                " AND user_id = :user_id"
+            ),
+            {"agent_id": agent_id, "user_id": user_id},
+        )
+        agent_shas = [r[0] for r in sha_rows.all()]
+        if not agent_shas:
+            return 0
+        conditions = [Match.user_id == user_id, Match.sha256.in_(agent_shas)]
+    else:
+        conditions = [Match.user_id == user_id]
+
     if after_dt is not None:
         conditions.append(Match.played_at >= after_dt)
     if before_dt is not None:

--- a/services/parser/parser_service/settings.py
+++ b/services/parser/parser_service/settings.py
@@ -8,6 +8,15 @@ from pydantic_settings import SettingsConfigDict
 
 from common.settings import BaseServiceSettings
 
+# Stamped on every match row at parse time so we can detect matches
+# parsed by an older version and queue them for reparse.
+PARSER_VERSION = "0.8.8"
+
+# Backfill scanner picks up matches where ``parsed_with_version`` is
+# NULL or less than this threshold, ensuring they get re-parsed with
+# the current parser logic.
+REPARSE_MIN_VERSION = "0.8.8"
+
 
 class ParserSettings(BaseServiceSettings):
     model_config = SettingsConfigDict(

--- a/services/web/tests/test_admin_agents_routes.py
+++ b/services/web/tests/test_admin_agents_routes.py
@@ -684,7 +684,9 @@ async def test_post_reingest_success_renders_result(
     from web_service import deps as _deps
     from web_service import main as _main
 
-    async def fake_delete(_url: str, _token: str, user_id: int) -> parser_client.DeletedCountResult:
+    async def fake_delete(
+        _url: str, _token: str, user_id: int, *, agent_id: str | None = None
+    ) -> parser_client.DeletedCountResult:
         return parser_client.DeletedCountResult(deleted_count=7)
 
     async def fake_list(
@@ -696,8 +698,9 @@ async def test_post_reingest_success_renders_result(
     monkeypatch.setattr(auth_client, "admin_list_agents", fake_list)
     dep, _ = _override_admin()
     _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    agent_id = "00000000-0000-0000-0000-000000000002"
     try:
-        r = await app_client.post("/admin/agents/2/reingest")
+        r = await app_client.post(f"/admin/agents/{agent_id}/reingest?user_id=2")
     finally:
         _main.app.dependency_overrides.clear()
 
@@ -714,8 +717,9 @@ async def test_post_reingest_forbidden_for_non_admin(
 
     dep, _ = _override_non_admin()
     _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    agent_id = "00000000-0000-0000-0000-000000000002"
     try:
-        r = await app_client.post("/admin/agents/2/reingest")
+        r = await app_client.post(f"/admin/agents/{agent_id}/reingest?user_id=2")
     finally:
         _main.app.dependency_overrides.clear()
 
@@ -737,8 +741,9 @@ async def test_post_reingest_503_when_parser_unreachable(
     monkeypatch.setattr(parser_client, "admin_delete_user_matches", boom)
     dep, _ = _override_admin()
     _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    agent_id = "00000000-0000-0000-0000-000000000002"
     try:
-        r = await app_client.post("/admin/agents/2/reingest")
+        r = await app_client.post(f"/admin/agents/{agent_id}/reingest?user_id=2")
     finally:
         _main.app.dependency_overrides.clear()
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -619,18 +619,21 @@ async def profile_agents_generate_code(
     )
 
 
-@app.post("/profile/agents/reingest")
+@app.post("/profile/agents/{agent_id}/reingest")
 async def profile_agents_reingest(
+    agent_id: uuid.UUID,
     request: Request,
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
 ) -> Response:
-    """Force reingest: delete all parsed matches for the current user."""
+    """Force reingest: delete parsed matches uploaded by a specific agent."""
     bounce = _bounce_admin_to_panel(user)
     if bounce is not None:
         return bounce
     try:
-        result = await parser_client.delete_my_matches(settings.parser_service_url, user.token)
+        result = await parser_client.delete_my_matches(
+            settings.parser_service_url, user.token, agent_id=str(agent_id)
+        )
     except parser_client.ParserForbidden:
         _log.info("profile.agents.reingest.forbidden", extra={"user_id": user.user_id})
         return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
@@ -1240,9 +1243,9 @@ async def admin_agents_list(
     )
 
 
-@app.post("/admin/agents/{user_id}/reingest")
+@app.post("/admin/agents/{agent_id}/reingest")
 async def admin_agent_reingest(
-    user_id: int,
+    agent_id: uuid.UUID,
     request: Request,
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
@@ -1251,21 +1254,26 @@ async def admin_agent_reingest(
         int,
         Query(ge=1, le=_ADMIN_AGENTS_MAX_PER_PAGE),
     ] = _ADMIN_AGENTS_DEFAULT_PER_PAGE,
+    user_id: Annotated[int, Query(ge=1)] = 0,
 ) -> Response:
-    """Admin: force reingest for a specific user."""
+    """Admin: force reingest for a specific agent."""
     blocked = _require_admin_or_403(request, user)
     if blocked is not None:
         return blocked
 
     try:
         result = await parser_client.admin_delete_user_matches(
-            settings.parser_service_url, user.token, user_id
+            settings.parser_service_url, user.token, user_id, agent_id=str(agent_id)
         )
     except parser_client.ParserForbidden:
         _log.info("admin.agents.reingest.forbidden", extra={"user_id": user.user_id})
         return _admin_forbidden(request, user)
     except parser_client.ParserClientError:
-        _log.exception("parser DELETE /parser/admin/matches/%s call failed", user_id)
+        _log.exception(
+            "parser DELETE /parser/admin/matches/%s?agent_id=%s call failed",
+            user_id,
+            agent_id,
+        )
         return Response(
             content="Parser service unavailable. Please try again.",
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -187,6 +187,8 @@ async def login_submit(
 
 _DASHBOARD_DEFAULT_PER_PAGE = 20
 _DASHBOARD_MAX_PER_PAGE = 100
+_OPPONENT_DEFAULT_PER_PAGE = 20
+_OPPONENT_MAX_PER_PAGE = 100
 
 
 @app.get("/dashboard", response_class=HTMLResponse)
@@ -196,6 +198,7 @@ async def dashboard(
     settings: WebSettings = Depends(get_settings),
     page: Annotated[int, Query(ge=1)] = 1,
     per_page: Annotated[int, Query(ge=1, le=_DASHBOARD_MAX_PER_PAGE)] = _DASHBOARD_DEFAULT_PER_PAGE,
+    opp_page: Annotated[int, Query(ge=1)] = 1,
     format: Annotated[str, Query(alias="format")] = "",
     opponent: Annotated[str, Query()] = "",
     result: Annotated[str, Query()] = "",
@@ -250,6 +253,14 @@ async def dashboard(
     # values containing &, =, +, % don't break the links).
     filter_qs = urlencode({k: v for k, v in filters.items() if v})
 
+    # Paginate the "By opponent" table client-side.  The analytics
+    # endpoint returns the full list (already sorted by match count
+    # descending) so we slice here rather than adding server-side
+    # limit/offset — the list is typically small (<200 opponents).
+    opp_per_page = _OPPONENT_DEFAULT_PER_PAGE
+    opp_offset = (opp_page - 1) * opp_per_page
+    opponent_page = opponent_stats[opp_offset : opp_offset + opp_per_page]
+
     return templates.TemplateResponse(
         request,
         "dashboard.html",
@@ -258,6 +269,9 @@ async def dashboard(
             "stats_summary": stats_summary,
             "format_stats": format_stats,
             "opponent_stats": opponent_stats,
+            "opponent_page": opponent_page,
+            "opp_page": opp_page,
+            "opp_per_page": opp_per_page,
             "match_list": match_list,
             "stats_error": stats_error,
             "page": page,

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -125,6 +125,32 @@ def _clear_session_cookie(response: Response) -> None:
     )
 
 
+@app.get("/", response_class=HTMLResponse)
+async def landing(
+    request: Request,
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    """Public landing page.
+
+    Logged-in users are redirected straight to /dashboard (or the admin
+    panel for admins). Everyone else sees the marketing landing page.
+    """
+    try:
+        user = await get_current_browser_user(request, settings)
+    except BrowserAuthRedirect:
+        # No valid session — render the public landing page.
+        mode = await auth_client.public_get_registration_mode(settings.auth_service_url)
+        return templates.TemplateResponse(
+            request,
+            "landing.html",
+            {"user": None, "registration_open": mode != "closed"},
+        )
+    # Logged in — bounce to the appropriate home.
+    if user.role == "admin":
+        return RedirectResponse(url=_ADMIN_LANDING_PATH, status_code=status.HTTP_302_FOUND)
+    return RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+
+
 @app.get("/login", response_class=HTMLResponse)
 async def login_form(request: Request, next: str | None = None) -> HTMLResponse:
     return templates.TemplateResponse(

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -1261,6 +1261,7 @@ async def admin_agents_list(
 async def admin_agent_reingest(
     agent_id: uuid.UUID,
     request: Request,
+    user_id: Annotated[int, Query(ge=1)],
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
     page: Annotated[int, Query(ge=1)] = 1,
@@ -1268,7 +1269,6 @@ async def admin_agent_reingest(
         int,
         Query(ge=1, le=_ADMIN_AGENTS_MAX_PER_PAGE),
     ] = _ADMIN_AGENTS_DEFAULT_PER_PAGE,
-    user_id: Annotated[int, Query(ge=1)] = 0,
 ) -> Response:
     """Admin: force reingest for a specific agent."""
     blocked = _require_admin_or_403(request, user)

--- a/services/web/web_service/parser_client.py
+++ b/services/web/web_service/parser_client.py
@@ -27,16 +27,23 @@ class DeletedCountResult:
 async def delete_my_matches(
     base_url: str,
     token: str,
+    *,
+    agent_id: str | None = None,
 ) -> DeletedCountResult:
-    """Delete all parsed matches for the authenticated user.
+    """Delete parsed matches for the authenticated user.
 
-    Returns the count of deleted matches.
+    When *agent_id* is provided, only matches uploaded by that agent
+    are deleted.  Returns the count of deleted matches.
     """
+    params: dict[str, str] = {}
+    if agent_id is not None:
+        params["agent_id"] = agent_id
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.delete(
                 f"{base_url}/parser/matches",
                 headers={"Authorization": f"Bearer {token}"},
+                params=params,
             )
     except httpx.HTTPError as exc:
         raise ParserClientError(f"parser DELETE /parser/matches transport error: {exc}") from exc
@@ -54,13 +61,23 @@ async def admin_delete_user_matches(
     base_url: str,
     token: str,
     user_id: int,
+    *,
+    agent_id: str | None = None,
 ) -> DeletedCountResult:
-    """Admin: delete all parsed matches for a specific user."""
+    """Admin: delete parsed matches for a specific user.
+
+    When *agent_id* is provided, only matches uploaded by that agent
+    are deleted.
+    """
+    params: dict[str, str] = {}
+    if agent_id is not None:
+        params["agent_id"] = agent_id
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.delete(
                 f"{base_url}/parser/admin/matches/{user_id}",
                 headers={"Authorization": f"Bearer {token}"},
+                params=params,
             )
     except httpx.HTTPError as exc:
         raise ParserClientError(

--- a/services/web/web_service/templates/admin_agents.html
+++ b/services/web/web_service/templates/admin_agents.html
@@ -78,7 +78,7 @@
                             <button type="submit" class="btn btn-danger">Revoke</button>
                         </form>
                         <form method="post"
-                              action="/admin/agents/{{ a.user_id }}/reingest?page={{ page }}&per_page={{ per_page }}"
+                              action="/admin/agents/{{ a.agent_id }}/reingest?page={{ page }}&per_page={{ per_page }}&user_id={{ a.user_id }}"
                               class="inline-form reingest-form"
                               data-user-email="{{ a.user_email }}">
                             <button type="submit" class="btn">Reingest</button>
@@ -136,7 +136,7 @@
         form.addEventListener('submit', function (e) {
             var ue = form.dataset.userEmail || '';
             var msg = 'Force reingest for ' + ue +
-                '? This deletes all parsed matches for this user. ' +
+                '? This deletes parsed matches uploaded by this agent. ' +
                 'The backfill scanner will re-parse them.';
             if (!window.confirm(msg)) {
                 e.preventDefault();

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -105,7 +105,7 @@
                         {{ match.played_at.strftime("%Y-%m-%d") if match.played_at else match.match_id[:8] }}
                     </a>
                 </td>
-                <td>{{ match.opponent or "—" }}</td>
+                <td>{% if match.opponent %}<a href="/dashboard?opponent={{ match.opponent|urlencode }}">{{ match.opponent }}</a>{% else %}&mdash;{% endif %}</td>
                 <td>{{ match.format_ or "—" }}</td>
                 <td>
                     {% if match.result == "W" %}
@@ -200,7 +200,7 @@
         <tbody>
             {% for row in opponent_stats[:5] %}
             <tr>
-                <td>{{ row.opponent }}</td>
+                <td><a href="/dashboard?opponent={{ row.opponent|urlencode }}">{{ row.opponent }}</a></td>
                 <td>{{ row.matches }}</td>
                 <td>{{ row.wins }}W / {{ row.losses }}L / {{ row.draws }}D</td>
                 <td>{{ "%.1f"|format(row.win_rate) }}%</td>
@@ -224,9 +224,9 @@
             </tr>
         </thead>
         <tbody>
-            {% for row in opponent_stats %}
+            {% for row in opponent_page %}
             <tr>
-                <td>{{ row.opponent }}</td>
+                <td><a href="/dashboard?opponent={{ row.opponent|urlencode }}">{{ row.opponent }}</a></td>
                 <td>{{ row.matches }}</td>
                 <td>{{ row.wins }}</td>
                 <td>{{ row.losses }}</td>
@@ -236,6 +236,35 @@
             {% endfor %}
         </tbody>
     </table>
+
+    {% set opp_total = opponent_stats|length %}
+    {% set opp_first = (opp_page - 1) * opp_per_page + 1 %}
+    {% set opp_last = opp_first + opponent_page|length - 1 %}
+    {% set opp_has_prev = opp_page > 1 %}
+    {% set opp_has_next = opp_last < opp_total %}
+    {% if opponent_page %}
+    <nav class="pagination" aria-label="Opponent list pagination">
+        <p class="muted">
+            Showing {{ opp_first }}&ndash;{{ opp_last }} of
+            {{ opp_total }} opponent{{ "" if opp_total == 1 else "s" }}.
+        </p>
+        {% if opp_has_prev or opp_has_next %}
+        <p>
+            {% if opp_has_prev %}
+            <a class="btn"
+               href="/dashboard?opp_page={{ opp_page - 1 }}{% if filter_qs %}&{{ filter_qs }}{% endif %}"
+               rel="prev">&larr; Previous</a>
+            {% endif %}
+            <span class="muted">Page {{ opp_page }}</span>
+            {% if opp_has_next %}
+            <a class="btn"
+               href="/dashboard?opp_page={{ opp_page + 1 }}{% if filter_qs %}&{{ filter_qs }}{% endif %}"
+               rel="next">Next &rarr;</a>
+            {% endif %}
+        </p>
+        {% endif %}
+    </nav>
+    {% endif %}
 </section>
 {% endif %}
 {% endif %}

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -105,8 +105,8 @@
                         {{ match.played_at.strftime("%Y-%m-%d") if match.played_at else match.match_id[:8] }}
                     </a>
                 </td>
-                <td>{{ match.opponent or "&mdash;" }}</td>
-                <td>{{ match.format_ or "&mdash;" }}</td>
+                <td>{{ match.opponent or "—" }}</td>
+                <td>{{ match.format_ or "—" }}</td>
                 <td>
                     {% if match.result == "W" %}
                         <span class="result-badge result-win">W</span>

--- a/services/web/web_service/templates/landing.html
+++ b/services/web/web_service/templates/landing.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Deep Analysis{% endblock %}
+
+{% block content %}
+<section class="auth-card">
+    <h1>Deep Analysis</h1>
+    <p class="muted">
+        MTGO match analytics &mdash; track your performance, identify
+        patterns, improve your game.
+    </p>
+    <div class="form-actions">
+        <a href="/login" class="btn btn-primary">Sign in</a>
+        {% if registration_open %}
+            <a href="/register" class="btn">Register</a>
+        {% endif %}
+    </div>
+</section>
+{% endblock %}

--- a/services/web/web_service/templates/profile_agents.html
+++ b/services/web/web_service/templates/profile_agents.html
@@ -109,7 +109,7 @@
                             <button type="submit" class="btn btn-danger">Revoke</button>
                         </form>
                         <form method="post"
-                              action="/profile/agents/reingest"
+                              action="/profile/agents/{{ a.agent_id }}/reingest"
                               class="inline-form reingest-form">
                             <button type="submit" class="btn">Reingest</button>
                         </form>
@@ -156,7 +156,7 @@
     });
     document.querySelectorAll('.reingest-form').forEach(function (form) {
         form.addEventListener('submit', function (e) {
-            if (!window.confirm('Force reingest? This deletes all your parsed matches. The backfill scanner will re-parse them.')) {
+            if (!window.confirm('Force reingest? This deletes parsed matches uploaded by this agent. The backfill scanner will re-parse them.')) {
                 e.preventDefault();
             }
         });

--- a/tests/test_route_prefix_convention.py
+++ b/tests/test_route_prefix_convention.py
@@ -51,6 +51,7 @@ _INFRA_PATHS = frozenset({"/healthz", "/metrics"})
 # human types or lands on, not service API paths.
 _WEB_BROWSER_PATHS = frozenset(
     {
+        "/",
         "/login",
         "/logout",
         "/dashboard",

--- a/tests/test_route_prefix_convention.py
+++ b/tests/test_route_prefix_convention.py
@@ -59,7 +59,7 @@ _WEB_BROWSER_PATHS = frozenset(
         "/profile/edit",
         "/profile/agents",
         "/profile/agents/registration-code",
-        "/profile/agents/reingest",
+        "/profile/agents/{agent_id}/reingest",
         "/profile/agents/{agent_id}/revoke",
         "/profile/username-suggestions",
         "/admin/users",


### PR DESCRIPTION
## Summary
- **Agent-scoped reingest**: per-agent reingest + per-agent parsed count (joins through ingest.user_uploads)
- **Em-dash fix**: Unicode `—` in templates instead of escaped `&mdash;`
- **Min agent version**: heartbeat returns `min_agent_version` (code constant, not admin-editable)
- **Opponent drill-down**: clickable opponent names filter the dashboard
- **Opponent paging**: "By opponent" section paginated (20/page)
- **Scryfall re-sync**: `should_sync` triggers when legalities are all NULL (covers pre-migration-009 syncs)

## Test plan
- [x] 204 web tests pass, 7 analytics tests pass
- [x] Ruff lint + format clean
- [ ] CI integration tests
- [ ] Verify format detection populates after Scryfall re-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)