### PR TITLE
feat: v0.9.0 — game state reconstruction, analytics, turn viewer

### DIFF
--- a/alembic/versions/011_game_metadata_columns.py
+++ b/alembic/versions/011_game_metadata_columns.py
@@ -1,0 +1,48 @@
+"""parser.games: add play/draw and opening hand metadata columns.
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-05-13
+
+Adds ``on_play``, ``play_first``, and ``opening_hand_sizes`` to
+``parser.games`` for game state reconstruction (v0.9.0).
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "011"
+down_revision = "010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "games",
+        sa.Column("on_play", sa.Boolean(), nullable=True),
+        schema="parser",
+    )
+    op.add_column(
+        "games",
+        sa.Column("play_first", sa.String(255), nullable=True),
+        schema="parser",
+    )
+    op.add_column(
+        "games",
+        sa.Column(
+            "opening_hand_sizes",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default="{}",
+        ),
+        schema="parser",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("games", "opening_hand_sizes", schema="parser")
+    op.drop_column("games", "play_first", schema="parser")
+    op.drop_column("games", "on_play", schema="parser")

--- a/alembic/versions/012_performance_indexes.py
+++ b/alembic/versions/012_performance_indexes.py
@@ -1,0 +1,55 @@
+"""Add performance indexes for common query patterns.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-05-13
+
+Adds composite indexes that cover the most common dashboard and
+background-worker query patterns:
+
+- matches(user_id, played_at) — dashboard date-range filtering
+- matches(user_id, format) — dashboard format filter
+- matches(parsed_with_version) — backfill scanner stale-match query
+- game_states(game_id, turn_number) — turn viewer load order
+"""
+
+from alembic import op
+
+revision = "012"
+down_revision = "011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_matches_user_id_played_at",
+        "matches",
+        ["user_id", "played_at"],
+        schema="parser",
+    )
+    op.create_index(
+        "ix_matches_user_id_format",
+        "matches",
+        ["user_id", "format"],
+        schema="parser",
+    )
+    op.create_index(
+        "ix_matches_parsed_with_version",
+        "matches",
+        ["parsed_with_version"],
+        schema="parser",
+    )
+    op.create_index(
+        "ix_game_states_game_id_turn",
+        "game_states",
+        ["game_id", "turn_number"],
+        schema="parser",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_game_states_game_id_turn", table_name="game_states", schema="parser")
+    op.drop_index("ix_matches_parsed_with_version", table_name="matches", schema="parser")
+    op.drop_index("ix_matches_user_id_format", table_name="matches", schema="parser")
+    op.drop_index("ix_matches_user_id_played_at", table_name="matches", schema="parser")

--- a/alembic/versions/013_invite_max_uses.py
+++ b/alembic/versions/013_invite_max_uses.py
@@ -1,0 +1,36 @@
+"""Add max_uses and use_count to invite_tokens.
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-05-13
+
+Supports multi-use invite tokens. max_uses NULL means unlimited;
+use_count tracks how many registrations have consumed the token.
+"""
+
+from sqlalchemy import Column, Integer, text
+
+from alembic import op
+
+revision = "013"
+down_revision = "012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "invite_tokens",
+        Column("max_uses", Integer(), nullable=True),
+        schema="auth",
+    )
+    op.add_column(
+        "invite_tokens",
+        Column("use_count", Integer(), nullable=False, server_default=text("0")),
+        schema="auth",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("invite_tokens", "use_count", schema="auth")
+    op.drop_column("invite_tokens", "max_uses", schema="auth")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ ignore = []
 "services/analytics/analytics_service/main.py" = ["B008"]
 "services/analytics/analytics_service/cards.py" = ["B008"]
 "services/analytics/analytics_service/matches.py" = ["B008"]
+"services/analytics/analytics_service/game_stats.py" = ["B008"]
+"services/analytics/analytics_service/card_stats.py" = ["B008"]
 "services/parser/parser_service/reingest.py" = ["B008"]
 "services/parser/parser_service/deps.py" = ["B008"]
 

--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -1,0 +1,418 @@
+"""Per-card performance analytics endpoints.
+
+Queries ``parser.game_states.player_states`` JSONB to find cards that
+appeared on the hero's battlefield, then aggregates win rate and cast-turn
+data per card. Joins ``catalog.cards`` for metadata (type line, mana cost,
+colors).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from analytics_service.db import get_session
+from analytics_service.deps import AuthenticatedUser, require_user
+
+router = APIRouter(prefix="/analytics/stats", tags=["card-stats"])
+
+
+_DEFAULT_PER_PAGE = 20
+_MAX_PER_PAGE = 100
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class CardStatItem(BaseModel):
+    name: str
+    cast_count: int = 0
+    win_rate: float = 0.0
+    avg_cast_turn: float | None = None
+    type_line: str | None = None
+    mana_cost: str | None = None
+
+
+class CardStatsResponse(BaseModel):
+    cards: list[CardStatItem] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    per_page: int = _DEFAULT_PER_PAGE
+
+
+class FormatBreakdown(BaseModel):
+    format: str
+    total_games: int = 0
+    wins: int = 0
+    win_rate: float = 0.0
+
+
+class CardDetailResponse(BaseModel):
+    name: str
+    total_games: int = 0
+    wins: int = 0
+    win_rate: float = 0.0
+    avg_cast_turn: float | None = None
+    by_format: list[FormatBreakdown] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+async def _load_mtgo_usernames(db: AsyncSession, user_id: int) -> list[str] | None:
+    """Load MTGO usernames for the given user from auth schema."""
+    try:
+        row = (
+            await db.execute(
+                text("SELECT mtgo_usernames FROM auth.users WHERE id = :uid"),
+                {"uid": user_id},
+            )
+        ).scalar_one_or_none()
+    except Exception:  # noqa: BLE001
+        return None
+    if row and isinstance(row, list):
+        return row
+    return None
+
+
+def _identify_hero(
+    players: list[Any] | None,
+    mtgo_usernames: list[str] | None,
+) -> str | None:
+    """Return the hero player name from the player list."""
+    if not players:
+        return None
+    if mtgo_usernames:
+        names_lower = {n.lower() for n in mtgo_usernames}
+        for p in players:
+            if str(p).lower() in names_lower:
+                return str(p)
+    return str(players[0])
+
+
+def _wr(wins: int, total: int) -> float:
+    return (wins / total) * 100.0 if total else 0.0
+
+
+async def _load_card_appearances(
+    db: AsyncSession,
+    user_id: int,
+    mtgo_usernames: list[str] | None,
+    card_name: str | None = None,
+) -> list[dict[str, Any]]:
+    """Load per-game card appearance data from game_states.
+
+    For each game, find all cards that appeared on the hero's battlefield
+    in any turn snapshot. Returns a list of dicts with keys: game_id,
+    winner, players, format, card_name, first_turn.
+    """
+    rows = (
+        await db.execute(
+            text(
+                """
+                SELECT g.id AS game_id, g.winner, m.players, m.format,
+                       gs.turn_number, gs.player_states
+                FROM parser.game_states gs
+                JOIN parser.games g ON g.id = gs.game_id
+                JOIN parser.matches m ON m.id = g.match_id
+                WHERE m.user_id = :user_id
+                ORDER BY g.id, gs.turn_number
+                """
+            ),
+            {"user_id": user_id},
+        )
+    ).all()
+
+    # Per-game, per-card: track first appearance turn
+    # game_id -> { card_name -> first_turn }
+    game_cards: dict[Any, dict[str, int]] = {}
+    game_meta: dict[Any, dict[str, Any]] = {}
+
+    for game_id, winner, players, fmt, turn_number, player_states in rows:
+        if game_id not in game_meta:
+            game_meta[game_id] = {
+                "winner": winner,
+                "players": list(players) if players else [],
+                "format": fmt,
+            }
+
+        # Find the hero's battlefield cards in this turn
+        player_list = list(players) if players else []
+        hero = _identify_hero(player_list, mtgo_usernames)
+        if hero is None:
+            continue
+
+        states = player_states or {}
+        # Try exact match then case-insensitive for the hero key
+        hero_state = states.get(hero)
+        if hero_state is None:
+            for k, v in states.items():
+                if k.lower() == hero.lower():
+                    hero_state = v
+                    break
+        if hero_state is None:
+            continue
+
+        zones = hero_state.get("zones", {})
+        battlefield = zones.get("battlefield", [])
+
+        if game_id not in game_cards:
+            game_cards[game_id] = {}
+
+        for card in battlefield:
+            cname = str(card) if not isinstance(card, dict) else card.get("name", str(card))
+            if card_name and cname.lower() != card_name.lower():
+                continue
+            if cname not in game_cards[game_id]:
+                game_cards[game_id][cname] = int(turn_number)
+
+    # Flatten into per-game-per-card records
+    results: list[dict[str, Any]] = []
+    for gid, cards in game_cards.items():
+        meta = game_meta[gid]
+        for cname, first_turn in cards.items():
+            results.append(
+                {
+                    "game_id": gid,
+                    "winner": meta["winner"],
+                    "players": meta["players"],
+                    "format": meta["format"],
+                    "card_name": cname,
+                    "first_turn": first_turn,
+                }
+            )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/cards", response_model=CardStatsResponse)
+async def get_card_stats(
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+    page: Annotated[int, Query(ge=1)] = 1,
+    per_page: Annotated[int, Query(ge=1, le=_MAX_PER_PAGE)] = _DEFAULT_PER_PAGE,
+    sort: Annotated[str, Query()] = "cast_count",
+) -> CardStatsResponse:
+    """Per-card performance across all matches."""
+    names = await _load_mtgo_usernames(db, user.user_id)
+    appearances = await _load_card_appearances(db, user.user_id, names)
+
+    # Aggregate per card
+    agg: dict[str, dict[str, Any]] = {}
+    for a in appearances:
+        cname = a["card_name"]
+        hero = _identify_hero(a["players"], names)
+        won = a["winner"] is not None and hero is not None and a["winner"].lower() == hero.lower()
+        if cname not in agg:
+            agg[cname] = {"count": 0, "wins": 0, "turn_sum": 0}
+        agg[cname]["count"] += 1
+        if won:
+            agg[cname]["wins"] += 1
+        agg[cname]["turn_sum"] += a["first_turn"]
+
+    # Fetch card metadata for all card names
+    card_meta: dict[str, dict[str, str | None]] = {}
+    if agg:
+        card_names = list(agg.keys())
+        meta_rows = (
+            await db.execute(
+                text(
+                    """
+                    SELECT name, type_line, mana_cost
+                    FROM catalog.cards
+                    WHERE name = ANY(:names)
+                    """
+                ),
+                {"names": card_names},
+            )
+        ).all()
+        for mname, type_line, mana_cost in meta_rows:
+            card_meta[str(mname)] = {"type_line": type_line, "mana_cost": mana_cost}
+
+    # Build items
+    items: list[CardStatItem] = []
+    for cname, data in agg.items():
+        meta = card_meta.get(cname, {})
+        avg_turn = data["turn_sum"] / data["count"] if data["count"] else None
+        items.append(
+            CardStatItem(
+                name=cname,
+                cast_count=data["count"],
+                win_rate=_wr(data["wins"], data["count"]),
+                avg_cast_turn=round(avg_turn, 2) if avg_turn is not None else None,
+                type_line=meta.get("type_line"),
+                mana_cost=meta.get("mana_cost"),
+            )
+        )
+
+    # Sort
+    if sort == "win_rate":
+        items.sort(key=lambda x: (-x.win_rate, -x.cast_count))
+    else:
+        items.sort(key=lambda x: (-x.cast_count, x.name))
+
+    total = len(items)
+    offset = (page - 1) * per_page
+    page_items = items[offset : offset + per_page]
+
+    return CardStatsResponse(cards=page_items, total=total, page=page, per_page=per_page)
+
+
+@router.get("/cards/{card_name}", response_model=CardDetailResponse)
+async def get_card_detail(
+    card_name: str,
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> CardDetailResponse:
+    """Single card detail across all matches."""
+    names = await _load_mtgo_usernames(db, user.user_id)
+    appearances = await _load_card_appearances(db, user.user_id, names, card_name=card_name)
+
+    if not appearances:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "card_not_found"},
+        )
+
+    total = 0
+    wins = 0
+    turn_sum = 0
+    by_format: dict[str, dict[str, int]] = {}
+
+    for a in appearances:
+        hero = _identify_hero(a["players"], names)
+        won = a["winner"] is not None and hero is not None and a["winner"].lower() == hero.lower()
+        total += 1
+        if won:
+            wins += 1
+        turn_sum += a["first_turn"]
+
+        fmt = a["format"] or "Unknown"
+        fb = by_format.setdefault(fmt, {"total": 0, "wins": 0})
+        fb["total"] += 1
+        if won:
+            fb["wins"] += 1
+
+    avg_turn = turn_sum / total if total else None
+    format_list = [
+        FormatBreakdown(
+            format=fmt,
+            total_games=fb["total"],
+            wins=fb["wins"],
+            win_rate=_wr(fb["wins"], fb["total"]),
+        )
+        for fmt, fb in sorted(by_format.items(), key=lambda kv: -kv[1]["total"])
+    ]
+
+    return CardDetailResponse(
+        name=card_name,
+        total_games=total,
+        wins=wins,
+        win_rate=_wr(wins, total),
+        avg_cast_turn=round(avg_turn, 2) if avg_turn is not None else None,
+        by_format=format_list,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Turn data endpoint
+# ---------------------------------------------------------------------------
+
+
+class TurnState(BaseModel):
+    turn_number: int
+    active_player: str | None = None
+    players: dict[str, Any] = Field(default_factory=dict)
+    stack: list[Any] = Field(default_factory=list)
+
+
+@router.get(
+    "/matches/{match_id}/games/{game_number}/turns",
+    response_model=list[TurnState],
+    tags=["turns"],
+)
+async def get_game_turns(
+    match_id: uuid.UUID,
+    game_number: int,
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+) -> list[TurnState]:
+    """Full game_states data for a single game within a match.
+
+    Scoped to authenticated user (the match must belong to them).
+    """
+    # Verify match ownership
+    match_row = (
+        await db.execute(
+            text(
+                """
+                SELECT id FROM parser.matches
+                WHERE id = :match_id AND user_id = :user_id
+                """
+            ),
+            {"match_id": match_id, "user_id": user.user_id},
+        )
+    ).one_or_none()
+    if match_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "match_not_found"},
+        )
+
+    # Find the game
+    game_row = (
+        await db.execute(
+            text(
+                """
+                SELECT g.id FROM parser.games g
+                WHERE g.match_id = :match_id AND g.game_number = :game_number
+                """
+            ),
+            {"match_id": match_id, "game_number": game_number},
+        )
+    ).one_or_none()
+    if game_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "game_not_found"},
+        )
+
+    game_id = game_row[0]
+
+    # Load all game states for this game
+    state_rows = (
+        await db.execute(
+            text(
+                """
+                SELECT gs.turn_number, gs.active_player, gs.player_states, gs.stack
+                FROM parser.game_states gs
+                WHERE gs.game_id = :game_id
+                ORDER BY gs.turn_number
+                """
+            ),
+            {"game_id": game_id},
+        )
+    ).all()
+
+    return [
+        TurnState(
+            turn_number=int(turn_number),
+            active_player=active_player,
+            players=player_states or {},
+            stack=list(stack) if stack else [],
+        )
+        for turn_number, active_player, player_states, stack in state_rows
+    ]

--- a/services/analytics/analytics_service/game_stats.py
+++ b/services/analytics/analytics_service/game_stats.py
@@ -1,0 +1,351 @@
+"""Game-level analytics endpoints.
+
+Provides play/draw win-rate splits, pre-board vs post-board performance,
+mulligan frequency by opening hand size, and game-length distribution.
+All endpoints filter by ``user_id`` from the verified JWT and identify
+the "hero" player via ``auth.users.mtgo_usernames``, falling back to
+``players[0]`` when no MTGO username matches.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from analytics_service.db import get_session
+from analytics_service.deps import AuthenticatedUser, require_user
+
+router = APIRouter(prefix="/analytics/stats", tags=["game-stats"])
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class WinRateBucket(BaseModel):
+    total: int = 0
+    wins: int = 0
+    win_rate: float = 0.0
+
+
+class PlayDrawResponse(BaseModel):
+    on_play: WinRateBucket = Field(default_factory=WinRateBucket)
+    on_draw: WinRateBucket = Field(default_factory=WinRateBucket)
+
+
+class PrePostBoardResponse(BaseModel):
+    preboard: WinRateBucket = Field(default_factory=WinRateBucket)
+    postboard: WinRateBucket = Field(default_factory=WinRateBucket)
+
+
+class MulliganBucket(BaseModel):
+    hand_size: int
+    total: int = 0
+    wins: int = 0
+    win_rate: float = 0.0
+
+
+class GameLengthBucket(BaseModel):
+    bucket: str
+    total: int = 0
+    wins: int = 0
+    losses: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+async def _load_mtgo_usernames(db: AsyncSession, user_id: int) -> list[str] | None:
+    """Load MTGO usernames for the given user from auth schema."""
+    try:
+        row = (
+            await db.execute(
+                text("SELECT mtgo_usernames FROM auth.users WHERE id = :uid"),
+                {"uid": user_id},
+            )
+        ).scalar_one_or_none()
+    except Exception:  # noqa: BLE001
+        return None
+    if row and isinstance(row, list):
+        return row
+    return None
+
+
+def _identify_hero(
+    players: list[Any] | None,
+    mtgo_usernames: list[str] | None,
+) -> str | None:
+    """Return the hero player name from the player list."""
+    if not players:
+        return None
+    if mtgo_usernames:
+        names_lower = {n.lower() for n in mtgo_usernames}
+        for p in players:
+            if str(p).lower() in names_lower:
+                return str(p)
+    return str(players[0])
+
+
+def _is_hero_winner(winner: str | None, hero: str | None) -> bool | None:
+    """Return True if hero won, False if hero lost, None if indeterminate."""
+    if winner is None or hero is None:
+        return None
+    return winner.lower() == hero.lower()
+
+
+def _wr(wins: int, total: int) -> float:
+    return (wins / total) * 100.0 if total else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+async def _load_games_with_context(
+    db: AsyncSession,
+    user_id: int,
+    format_filter: str | None = None,
+) -> list[dict[str, Any]]:
+    """Load all games with match context for a user.
+
+    Returns a list of dicts with keys: game_number, winner, on_play,
+    play_first, opening_hand_sizes, players, format.
+    """
+    where = "WHERE m.user_id = :user_id"
+    params: dict[str, Any] = {"user_id": user_id}
+    if format_filter:
+        where += " AND LOWER(m.format) = LOWER(:format)"
+        params["format"] = format_filter
+
+    rows = (
+        await db.execute(
+            text(
+                f"""
+                SELECT g.game_number, g.winner, g.on_play, g.play_first,
+                       g.opening_hand_sizes, m.players, m.format, g.id
+                FROM parser.games g
+                JOIN parser.matches m ON m.id = g.match_id
+                {where}
+                ORDER BY m.parsed_at DESC, g.game_number
+                """
+            ),
+            params,
+        )
+    ).all()
+    return [
+        {
+            "game_number": int(r[0]),
+            "winner": r[1],
+            "on_play": r[2],
+            "play_first": r[3],
+            "opening_hand_sizes": r[4] if r[4] else {},
+            "players": list(r[5]) if r[5] else [],
+            "format": r[6],
+            "game_id": r[7],
+        }
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/play-draw", response_model=PlayDrawResponse)
+async def get_play_draw(
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+    format: Annotated[str | None, Query()] = None,
+) -> PlayDrawResponse:
+    """Win rate on the play vs on the draw."""
+    games = await _load_games_with_context(db, user.user_id, format)
+    names = await _load_mtgo_usernames(db, user.user_id)
+
+    play_wins = play_total = 0
+    draw_wins = draw_total = 0
+
+    for g in games:
+        if g["on_play"] is None:
+            continue
+        hero = _identify_hero(g["players"], names)
+        won = _is_hero_winner(g["winner"], hero)
+        if won is None:
+            continue
+        if g["on_play"]:
+            play_total += 1
+            if won:
+                play_wins += 1
+        else:
+            draw_total += 1
+            if won:
+                draw_wins += 1
+
+    return PlayDrawResponse(
+        on_play=WinRateBucket(
+            total=play_total, wins=play_wins, win_rate=_wr(play_wins, play_total)
+        ),
+        on_draw=WinRateBucket(
+            total=draw_total, wins=draw_wins, win_rate=_wr(draw_wins, draw_total)
+        ),
+    )
+
+
+@router.get("/preboard-postboard", response_model=PrePostBoardResponse)
+async def get_preboard_postboard(
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+    format: Annotated[str | None, Query()] = None,
+) -> PrePostBoardResponse:
+    """Win rate in game 1 (pre-board) vs games 2-3 (post-board)."""
+    games = await _load_games_with_context(db, user.user_id, format)
+    names = await _load_mtgo_usernames(db, user.user_id)
+
+    pre_wins = pre_total = 0
+    post_wins = post_total = 0
+
+    for g in games:
+        hero = _identify_hero(g["players"], names)
+        won = _is_hero_winner(g["winner"], hero)
+        if won is None:
+            continue
+        if g["game_number"] == 1:
+            pre_total += 1
+            if won:
+                pre_wins += 1
+        else:
+            post_total += 1
+            if won:
+                post_wins += 1
+
+    return PrePostBoardResponse(
+        preboard=WinRateBucket(total=pre_total, wins=pre_wins, win_rate=_wr(pre_wins, pre_total)),
+        postboard=WinRateBucket(
+            total=post_total, wins=post_wins, win_rate=_wr(post_wins, post_total)
+        ),
+    )
+
+
+@router.get("/mulligans", response_model=list[MulliganBucket])
+async def get_mulligans(
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+    format: Annotated[str | None, Query()] = None,
+) -> list[MulliganBucket]:
+    """Frequency and win rate by opening hand size."""
+    games = await _load_games_with_context(db, user.user_id, format)
+    names = await _load_mtgo_usernames(db, user.user_id)
+
+    buckets: dict[int, dict[str, int]] = {}
+
+    for g in games:
+        hero = _identify_hero(g["players"], names)
+        if hero is None:
+            continue
+        hand_sizes = g.get("opening_hand_sizes") or {}
+        # Try exact match, then case-insensitive
+        hand_size: int | None = None
+        if hero in hand_sizes:
+            hand_size = int(hand_sizes[hero])
+        else:
+            for k, v in hand_sizes.items():
+                if k.lower() == hero.lower():
+                    hand_size = int(v)
+                    break
+        if hand_size is None:
+            continue
+
+        b = buckets.setdefault(hand_size, {"total": 0, "wins": 0})
+        b["total"] += 1
+        won = _is_hero_winner(g["winner"], hero)
+        if won:
+            b["wins"] += 1
+
+    result = []
+    for hs in sorted(buckets, reverse=True):
+        b = buckets[hs]
+        result.append(
+            MulliganBucket(
+                hand_size=hs,
+                total=b["total"],
+                wins=b["wins"],
+                win_rate=_wr(b["wins"], b["total"]),
+            )
+        )
+    return result
+
+
+@router.get("/game-length", response_model=list[GameLengthBucket])
+async def get_game_length(
+    user: AuthenticatedUser = Depends(require_user),
+    db: AsyncSession = Depends(get_session),
+    format: Annotated[str | None, Query()] = None,
+) -> list[GameLengthBucket]:
+    """Turns distribution bucketed into ranges."""
+    names = await _load_mtgo_usernames(db, user.user_id)
+
+    where = "WHERE m.user_id = :user_id"
+    params: dict[str, Any] = {"user_id": user.user_id}
+    if format:
+        where += " AND LOWER(m.format) = LOWER(:format)"
+        params["format"] = format
+
+    rows = (
+        await db.execute(
+            text(
+                f"""
+                SELECT g.id, g.winner, m.players,
+                       MAX(gs.turn_number) AS max_turn
+                FROM parser.games g
+                JOIN parser.matches m ON m.id = g.match_id
+                LEFT JOIN parser.game_states gs ON gs.game_id = g.id
+                {where}
+                GROUP BY g.id, g.winner, m.players
+                HAVING MAX(gs.turn_number) IS NOT NULL
+                """
+            ),
+            params,
+        )
+    ).all()
+
+    _BUCKETS = [
+        ("1-3", 1, 3),
+        ("4-6", 4, 6),
+        ("7-9", 7, 9),
+        ("10-12", 10, 12),
+        ("13+", 13, 999),
+    ]
+    counts: dict[str, dict[str, int]] = {
+        label: {"total": 0, "wins": 0, "losses": 0} for label, _, _ in _BUCKETS
+    }
+
+    for _game_id, winner, players, max_turn in rows:
+        turn = int(max_turn)
+        hero = _identify_hero(list(players) if players else [], names)
+        won = _is_hero_winner(winner, hero)
+        for label, lo, hi in _BUCKETS:
+            if lo <= turn <= hi:
+                counts[label]["total"] += 1
+                if won is True:
+                    counts[label]["wins"] += 1
+                elif won is False:
+                    counts[label]["losses"] += 1
+                break
+
+    return [
+        GameLengthBucket(
+            bucket=label,
+            total=counts[label]["total"],
+            wins=counts[label]["wins"],
+            losses=counts[label]["losses"],
+        )
+        for label, _, _ in _BUCKETS
+    ]

--- a/services/analytics/analytics_service/main.py
+++ b/services/analytics/analytics_service/main.py
@@ -11,9 +11,11 @@ from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI
 from sqlalchemy import text
 
 from analytics_service.archetypes import router as archetypes_router
+from analytics_service.card_stats import router as card_stats_router
 from analytics_service.cards import router as cards_router
 from analytics_service.db import get_sessionmaker
 from analytics_service.deps import AuthenticatedUser, require_admin
+from analytics_service.game_stats import router as game_stats_router
 from analytics_service.matches import router as matches_router
 from analytics_service.mtgo_scraper import SCRAPER_NAME as MTGO_SCRAPER_NAME
 from analytics_service.mtgo_scraper import get_health as get_mtgo_health
@@ -164,6 +166,8 @@ app = FastAPI(title=f"deep-analysis-{SERVICE_NAME}", lifespan=lifespan)
 mount_metrics(app, SERVICE_NAME)
 app.include_router(archetypes_router)
 app.include_router(stats_router)
+app.include_router(game_stats_router)
+app.include_router(card_stats_router)
 app.include_router(cards_router)
 app.include_router(matches_router)
 

--- a/services/analytics/tests/test_card_stats.py
+++ b/services/analytics/tests/test_card_stats.py
@@ -1,0 +1,481 @@
+"""Card stats and turn-data endpoint tests.
+
+Overrides ``get_session`` with a fake session that returns prefab rows,
+and ``require_user`` with a fake user dep. Tests exercise the handler
+aggregation logic without a live Postgres.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _analytics_test_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    out = tmp_path_factory.mktemp("analytics-jwt-keys-cardstats")
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pub_path = out / "jwt_public.pem"
+    pub_path.write_bytes(pub_pem)
+    os.environ["DA_JWT_PUBLIC_KEY_PATH"] = str(pub_path)
+    os.environ.setdefault("DA_DATABASE_URL", "postgresql+asyncpg://x:x@localhost:5432/x")
+    os.environ.setdefault("DA_REDIS_URL", "redis://localhost:6379/0")
+    yield pub_path
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from analytics_service import main as _main
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 7) -> Any:
+    from analytics_service import deps as _deps
+
+    fake = _deps.AuthenticatedUser(user_id=user_id, role="user")
+
+    async def _dep() -> _deps.AuthenticatedUser:
+        return fake
+
+    return _dep
+
+
+# ---------------------------------------------------------------------------
+# Fake DB layer
+# ---------------------------------------------------------------------------
+
+
+class _RowProxy:
+    """Mimics SQLAlchemy Row for tuple-unpacking and indexing."""
+
+    def __init__(self, row: tuple[Any, ...]) -> None:
+        self._row = row
+
+    def __iter__(self) -> Any:
+        return iter(self._row)
+
+    def __len__(self) -> int:
+        return len(self._row)
+
+    def __getitem__(self, idx: int) -> Any:
+        return self._row[idx]
+
+
+class _FakeResult:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[_RowProxy]:
+        return [_RowProxy(r) for r in self._rows]
+
+    def one_or_none(self) -> _RowProxy | None:
+        if not self._rows:
+            return None
+        return _RowProxy(self._rows[0])
+
+    def scalar_one_or_none(self) -> Any:
+        if not self._rows:
+            return None
+        return self._rows[0][0] if isinstance(self._rows[0], tuple) else self._rows[0]
+
+
+class _FakeSession:
+    """Returns canned row sets in queue order."""
+
+    def __init__(self, *, queue: list[list[tuple[Any, ...]]]) -> None:
+        self._queue = list(queue)
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(self, _stmt: Any, params: dict[str, Any] | None = None) -> _FakeResult:
+        self.calls.append(dict(params or {}))
+        rows = self._queue.pop(0) if self._queue else []
+        return _FakeResult(rows)
+
+
+def _override_session(session: _FakeSession) -> Any:
+    async def _dep() -> AsyncIterator[Any]:
+        yield session
+
+    return _dep
+
+
+# ---------------------------------------------------------------------------
+# GET /analytics/stats/cards
+# ---------------------------------------------------------------------------
+
+# game_states query returns: (game_id, winner, players, format, turn_number, player_states)
+
+
+@pytest.mark.asyncio
+async def test_card_stats_empty(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    session = _FakeSession(
+        queue=[
+            # mtgo_usernames
+            [(["alice"],)],
+            # game_states query
+            [],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/cards")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["cards"] == []
+    assert body["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_card_stats_aggregates(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    g1 = uuid.uuid4()
+    g2 = uuid.uuid4()
+
+    session = _FakeSession(
+        queue=[
+            # mtgo_usernames
+            [(["alice"],)],
+            # game_states rows: (game_id, winner, players, format, turn_number, player_states)
+            [
+                (
+                    g1,
+                    "alice",
+                    ["alice", "bob"],
+                    "Modern",
+                    3,
+                    {
+                        "alice": {
+                            "life": 18,
+                            "zones": {"battlefield": ["Lightning Bolt", "Mountain"]},
+                        },
+                        "bob": {"life": 20, "zones": {"battlefield": []}},
+                    },
+                ),
+                (
+                    g2,
+                    "bob",
+                    ["alice", "bob"],
+                    "Modern",
+                    5,
+                    {
+                        "alice": {
+                            "life": 15,
+                            "zones": {"battlefield": ["Lightning Bolt"]},
+                        },
+                        "bob": {"life": 10, "zones": {"battlefield": []}},
+                    },
+                ),
+            ],
+            # catalog.cards metadata query
+            [
+                ("Lightning Bolt", "Instant", "{R}"),
+                ("Mountain", "Basic Land — Mountain", None),
+            ],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/cards")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 2
+    by_name = {c["name"]: c for c in body["cards"]}
+    bolt = by_name["Lightning Bolt"]
+    assert bolt["cast_count"] == 2
+    assert bolt["win_rate"] == 50.0
+    assert bolt["avg_cast_turn"] == 4.0  # (3 + 5) / 2
+    assert bolt["type_line"] == "Instant"
+    assert bolt["mana_cost"] == "{R}"
+    mountain = by_name["Mountain"]
+    assert mountain["cast_count"] == 1
+    assert mountain["win_rate"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_card_stats_pagination(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    g1 = uuid.uuid4()
+
+    session = _FakeSession(
+        queue=[
+            # mtgo_usernames
+            [(["alice"],)],
+            # game_states: 3 different cards
+            [
+                (
+                    g1,
+                    "alice",
+                    ["alice", "bob"],
+                    "Modern",
+                    2,
+                    {
+                        "alice": {
+                            "life": 20,
+                            "zones": {"battlefield": ["Card A", "Card B", "Card C"]},
+                        },
+                    },
+                ),
+            ],
+            # catalog.cards — none found
+            [],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/cards", params={"per_page": 2, "page": 1})
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 3
+    assert len(body["cards"]) == 2
+    assert body["per_page"] == 2
+    assert body["page"] == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /analytics/stats/cards/{card_name}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_card_detail(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    g1 = uuid.uuid4()
+    g2 = uuid.uuid4()
+
+    session = _FakeSession(
+        queue=[
+            # mtgo_usernames
+            [(["alice"],)],
+            # game_states
+            [
+                (
+                    g1,
+                    "alice",
+                    ["alice", "bob"],
+                    "Modern",
+                    3,
+                    {
+                        "alice": {
+                            "life": 18,
+                            "zones": {"battlefield": ["Lightning Bolt"]},
+                        },
+                    },
+                ),
+                (
+                    g2,
+                    "bob",
+                    ["alice", "bob"],
+                    "Pioneer",
+                    5,
+                    {
+                        "alice": {
+                            "life": 15,
+                            "zones": {"battlefield": ["Lightning Bolt"]},
+                        },
+                    },
+                ),
+            ],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/cards/Lightning Bolt")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["name"] == "Lightning Bolt"
+    assert body["total_games"] == 2
+    assert body["wins"] == 1
+    assert body["win_rate"] == 50.0
+    assert body["avg_cast_turn"] == 4.0
+    assert len(body["by_format"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_card_detail_not_found(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    session = _FakeSession(
+        queue=[
+            # mtgo_usernames
+            [(["alice"],)],
+            # game_states — empty
+            [],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/cards/Nonexistent Card")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 404
+    assert r.json()["detail"]["error"] == "card_not_found"
+
+
+# ---------------------------------------------------------------------------
+# GET /analytics/stats/matches/{match_id}/games/{game_number}/turns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_game_turns(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    match_id = uuid.uuid4()
+    game_id = uuid.uuid4()
+
+    session = _FakeSession(
+        queue=[
+            # match ownership check
+            [(match_id,)],
+            # game lookup
+            [(game_id,)],
+            # game_states rows: (turn_number, active_player, player_states, stack)
+            [
+                (
+                    1,
+                    "alice",
+                    {
+                        "alice": {"life": 20, "zones": {"hand": ["Mountain"]}, "mana_pool": {}},
+                        "bob": {"life": 20, "zones": {"hand": []}, "mana_pool": {}},
+                    },
+                    [],
+                ),
+                (
+                    2,
+                    "bob",
+                    {
+                        "alice": {"life": 20, "zones": {"hand": []}, "mana_pool": {}},
+                        "bob": {"life": 18, "zones": {"hand": ["Island"]}, "mana_pool": {}},
+                    },
+                    ["Counterspell"],
+                ),
+            ],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get(f"/analytics/stats/matches/{match_id}/games/1/turns")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 2
+    assert body[0]["turn_number"] == 1
+    assert body[0]["active_player"] == "alice"
+    assert body[0]["players"]["alice"]["life"] == 20
+    assert body[0]["stack"] == []
+    assert body[1]["turn_number"] == 2
+    assert body[1]["stack"] == ["Counterspell"]
+
+
+@pytest.mark.asyncio
+async def test_game_turns_match_not_found(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    match_id = uuid.uuid4()
+    session = _FakeSession(queue=[[]])  # match not found
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get(f"/analytics/stats/matches/{match_id}/games/1/turns")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 404
+    assert r.json()["detail"]["error"] == "match_not_found"
+
+
+@pytest.mark.asyncio
+async def test_game_turns_game_not_found(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    match_id = uuid.uuid4()
+    session = _FakeSession(
+        queue=[
+            [(match_id,)],  # match found
+            [],  # game not found
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get(f"/analytics/stats/matches/{match_id}/games/1/turns")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 404
+    assert r.json()["detail"]["error"] == "game_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Auth tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_card_stats_unauth_returns_401(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get("/analytics/stats/cards")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_game_turns_unauth_returns_401(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get(f"/analytics/stats/matches/{uuid.uuid4()}/games/1/turns")
+    assert r.status_code == 401

--- a/services/analytics/tests/test_game_stats.py
+++ b/services/analytics/tests/test_game_stats.py
@@ -1,0 +1,340 @@
+"""Game-level stats endpoint tests.
+
+Overrides ``get_session`` with a fake session that returns prefab rows,
+and ``require_user`` with a fake user dep. Tests exercise the handler
+aggregation logic without a live Postgres.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _analytics_test_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    out = tmp_path_factory.mktemp("analytics-jwt-keys-gamestats")
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pub_path = out / "jwt_public.pem"
+    pub_path.write_bytes(pub_pem)
+    os.environ["DA_JWT_PUBLIC_KEY_PATH"] = str(pub_path)
+    os.environ.setdefault("DA_DATABASE_URL", "postgresql+asyncpg://x:x@localhost:5432/x")
+    os.environ.setdefault("DA_REDIS_URL", "redis://localhost:6379/0")
+    yield pub_path
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from analytics_service import main as _main
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 7) -> Any:
+    from analytics_service import deps as _deps
+
+    fake = _deps.AuthenticatedUser(user_id=user_id, role="user")
+
+    async def _dep() -> _deps.AuthenticatedUser:
+        return fake
+
+    return _dep
+
+
+# ---------------------------------------------------------------------------
+# Fake DB layer
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[tuple[Any, ...]]:
+        return list(self._rows)
+
+    def scalar_one_or_none(self) -> Any:
+        if not self._rows:
+            return None
+        return self._rows[0][0] if isinstance(self._rows[0], tuple) else self._rows[0]
+
+
+class _FakeSession:
+    """Returns canned row sets in queue order."""
+
+    def __init__(self, *, queue: list[list[tuple[Any, ...]]]) -> None:
+        self._queue = list(queue)
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(self, _stmt: Any, params: dict[str, Any] | None = None) -> _FakeResult:
+        self.calls.append(dict(params or {}))
+        rows = self._queue.pop(0) if self._queue else []
+        return _FakeResult(rows)
+
+
+def _override_session(session: _FakeSession) -> Any:
+    async def _dep() -> AsyncIterator[Any]:
+        yield session
+
+    return _dep
+
+
+# ---------------------------------------------------------------------------
+# Play/draw tests
+# ---------------------------------------------------------------------------
+
+# Helper: make a game row tuple matching the _load_games_with_context query:
+# (game_number, winner, on_play, play_first, opening_hand_sizes, players, format, game_id)
+
+
+def _game_row(
+    game_number: int,
+    winner: str | None,
+    on_play: bool | None,
+    play_first: str | None = None,
+    opening_hand_sizes: dict | None = None,
+    players: list | None = None,
+    fmt: str = "Modern",
+    game_id: Any | None = None,
+) -> tuple:
+    return (
+        game_number,
+        winner,
+        on_play,
+        play_first,
+        opening_hand_sizes or {},
+        players or ["alice", "bob"],
+        fmt,
+        game_id or uuid.uuid4(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_play_draw_empty(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    session = _FakeSession(
+        queue=[
+            [],  # games query
+            [],  # mtgo_usernames query
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/play-draw")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["on_play"]["total"] == 0
+    assert body["on_draw"]["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_play_draw_splits(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    session = _FakeSession(
+        queue=[
+            # games: alice on play wins, alice on draw loses, alice on play loses
+            [
+                _game_row(1, "alice", True),
+                _game_row(2, "bob", False),
+                _game_row(1, "bob", True),
+            ],
+            # mtgo_usernames
+            [(["alice"],)],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/play-draw")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["on_play"]["total"] == 2
+    assert body["on_play"]["wins"] == 1
+    assert body["on_play"]["win_rate"] == 50.0
+    assert body["on_draw"]["total"] == 1
+    assert body["on_draw"]["wins"] == 0
+    assert body["on_draw"]["win_rate"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Preboard / postboard tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preboard_postboard(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    session = _FakeSession(
+        queue=[
+            # games: game 1 win, game 2 loss, game 3 win
+            [
+                _game_row(1, "alice", True),
+                _game_row(2, "bob", False),
+                _game_row(3, "alice", True),
+            ],
+            # mtgo_usernames
+            [(["alice"],)],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/preboard-postboard")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["preboard"]["total"] == 1
+    assert body["preboard"]["wins"] == 1
+    assert body["preboard"]["win_rate"] == 100.0
+    assert body["postboard"]["total"] == 2
+    assert body["postboard"]["wins"] == 1
+    assert body["postboard"]["win_rate"] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# Mulligan tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mulligans(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    session = _FakeSession(
+        queue=[
+            [
+                _game_row(1, "alice", True, opening_hand_sizes={"alice": 7, "bob": 7}),
+                _game_row(2, "bob", False, opening_hand_sizes={"alice": 6, "bob": 7}),
+                _game_row(1, "alice", True, opening_hand_sizes={"alice": 7, "bob": 6}),
+            ],
+            # mtgo_usernames
+            [(["alice"],)],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/mulligans")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    # Sorted descending by hand size: 7, 6
+    assert len(body) == 2
+    assert body[0]["hand_size"] == 7
+    assert body[0]["total"] == 2
+    assert body[0]["wins"] == 2
+    assert body[0]["win_rate"] == 100.0
+    assert body[1]["hand_size"] == 6
+    assert body[1]["total"] == 1
+    assert body[1]["wins"] == 0
+    assert body[1]["win_rate"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Game-length tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_game_length_buckets(app_client: httpx.AsyncClient) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    g1 = uuid.uuid4()
+    g2 = uuid.uuid4()
+    g3 = uuid.uuid4()
+
+    session = _FakeSession(
+        queue=[
+            # mtgo_usernames
+            [(["alice"],)],
+            # game-length query: (game_id, winner, players, max_turn)
+            [
+                (g1, "alice", ["alice", "bob"], 5),
+                (g2, "bob", ["alice", "bob"], 11),
+                (g3, "alice", ["alice", "bob"], 14),
+            ],
+        ]
+    )
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/game-length")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    by_bucket = {b["bucket"]: b for b in body}
+    assert by_bucket["4-6"]["total"] == 1
+    assert by_bucket["4-6"]["wins"] == 1
+    assert by_bucket["4-6"]["losses"] == 0
+    assert by_bucket["10-12"]["total"] == 1
+    assert by_bucket["10-12"]["wins"] == 0
+    assert by_bucket["10-12"]["losses"] == 1
+    assert by_bucket["13+"]["total"] == 1
+    assert by_bucket["13+"]["wins"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Auth tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_play_draw_unauth_returns_401(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get("/analytics/stats/play-draw")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_mulligans_unauth_returns_401(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get("/analytics/stats/mulligans")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_game_length_unauth_returns_401(app_client: httpx.AsyncClient) -> None:
+    r = await app_client.get("/analytics/stats/game-length")
+    assert r.status_code == 401

--- a/services/auth/alembic/versions/008_invite_max_uses.py
+++ b/services/auth/alembic/versions/008_invite_max_uses.py
@@ -1,7 +1,7 @@
 """Add max_uses and use_count to invite_tokens.
 
-Revision ID: 013
-Revises: 012
+Revision ID: 008
+Revises: 007
 Create Date: 2026-05-13
 
 Supports multi-use invite tokens. max_uses NULL means unlimited;
@@ -12,8 +12,8 @@ from sqlalchemy import Column, Integer, text
 
 from alembic import op
 
-revision = "013"
-down_revision = "012"
+revision = "008"
+down_revision = "007"
 branch_labels = None
 depends_on = None
 

--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -379,8 +379,8 @@ def _invite_view(row: InviteToken, creator_email: str | None) -> InviteView:
         created_by_email=creator_email,
         created_at=row.created_at,
         expires_at=row.expires_at,
-        max_uses=row.max_uses,
-        use_count=row.use_count,
+        max_uses=row.max_uses if row.max_uses is not None else 1,
+        use_count=row.use_count or 0,
     )
 
 

--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -404,12 +404,15 @@ async def create_invite(
     plaintext = generate_invite_token()
     now = datetime.now(UTC)
     expires_at = now + timedelta(hours=body.expires_in_hours)
+    # 0 means unlimited; None (should not happen with the updated schema
+    # but guard defensively) also maps to 0.
+    stored_max_uses = body.max_uses if body.max_uses is not None else 0
     invite = InviteToken(
         token_hash=hash_invite_token(plaintext),
         created_by_user_id=admin.user_id,
         created_at=now,
         expires_at=expires_at,
-        max_uses=body.max_uses,
+        max_uses=stored_max_uses,
     )
     db.add(invite)
     await db.commit()
@@ -433,13 +436,15 @@ async def list_invites(
     """List pending invites (not exhausted, not expired)."""
     now = datetime.now(UTC)
     # An invite is pending when it hasn't expired and still has uses
-    # remaining: either max_uses is NULL (unlimited) or use_count < max_uses.
+    # remaining: max_uses=0 means unlimited, NULL is legacy unlimited,
+    # positive max_uses requires use_count < max_uses.
     from sqlalchemy import or_
 
     pending = (
         InviteToken.expires_at > now,
         or_(
             InviteToken.max_uses.is_(None),
+            InviteToken.max_uses == 0,
             InviteToken.use_count < InviteToken.max_uses,
         ),
     )
@@ -484,8 +489,9 @@ async def revoke_invite(
         raise _error(status.HTTP_404_NOT_FOUND, "invite_not_found")
     now = datetime.now(UTC)
     # Revoke if not expired and still has remaining uses.
+    # max_uses 0 or NULL = unlimited (always active until expired).
     still_active = invite.expires_at > now and (
-        invite.max_uses is None or invite.use_count < invite.max_uses
+        invite.max_uses is None or invite.max_uses == 0 or invite.use_count < invite.max_uses
     )
     if still_active:
         invite.expires_at = now

--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -379,6 +379,8 @@ def _invite_view(row: InviteToken, creator_email: str | None) -> InviteView:
         created_by_email=creator_email,
         created_at=row.created_at,
         expires_at=row.expires_at,
+        max_uses=row.max_uses,
+        use_count=row.use_count,
     )
 
 
@@ -407,6 +409,7 @@ async def create_invite(
         created_by_user_id=admin.user_id,
         created_at=now,
         expires_at=expires_at,
+        max_uses=body.max_uses,
     )
     db.add(invite)
     await db.commit()
@@ -416,6 +419,7 @@ async def create_invite(
         token=plaintext,
         expires_at=invite.expires_at,
         created_at=invite.created_at,
+        max_uses=invite.max_uses,
     )
 
 
@@ -426,11 +430,18 @@ async def list_invites(
     _admin: AuthenticatedUser = Depends(require_admin),
     db: AsyncSession = Depends(get_session),
 ) -> InviteListView:
-    """List pending invites (not used, not expired)."""
+    """List pending invites (not exhausted, not expired)."""
     now = datetime.now(UTC)
+    # An invite is pending when it hasn't expired and still has uses
+    # remaining: either max_uses is NULL (unlimited) or use_count < max_uses.
+    from sqlalchemy import or_
+
     pending = (
-        InviteToken.used_at.is_(None),
         InviteToken.expires_at > now,
+        or_(
+            InviteToken.max_uses.is_(None),
+            InviteToken.use_count < InviteToken.max_uses,
+        ),
     )
 
     total = int(
@@ -472,7 +483,11 @@ async def revoke_invite(
     if invite is None:
         raise _error(status.HTTP_404_NOT_FOUND, "invite_not_found")
     now = datetime.now(UTC)
-    if invite.used_at is None and invite.expires_at > now:
+    # Revoke if not expired and still has remaining uses.
+    still_active = invite.expires_at > now and (
+        invite.max_uses is None or invite.use_count < invite.max_uses
+    )
+    if still_active:
         invite.expires_at = now
         await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -34,6 +34,8 @@ from auth_service.schemas import (
     RevokeSessionsResponse,
     SetRegistrationModeRequest,
     StaleCleanupResponse,
+    TunablesView,
+    UpdateTunablesRequest,
     UpdateUserRequest,
     UserListView,
     UserView,
@@ -501,3 +503,99 @@ async def cleanup_stale_agents(
         r.revoked_at = now
     await db.commit()
     return StaleCleanupResponse(revoked_count=len(rows), cutoff_date=cutoff.isoformat())
+
+
+# ---------------------------------------------------------------------------
+# Tunables — admin-configurable runtime parameters
+# ---------------------------------------------------------------------------
+
+# Mutable tunables stored as individual keys in server_settings.
+# The key prefix groups them together and the default value is used
+# both when no DB row exists and for initial display.
+_TUNABLE_DEFAULTS: dict[str, int] = {
+    "backfill_batch_size": 100,
+    "backfill_interval_seconds": 300,
+    "scryfall_sync_interval_days": 7,
+    "mtgo_scraper_interval_hours": 24,
+}
+
+# Read-only constants surfaced in the tunables view for admin visibility
+# but not persisted to server_settings — they live in code.
+_PARSER_VERSION = "0.9.0"
+_REPARSE_MIN_VERSION = "0.9.0"
+_MIN_AGENT_VERSION = "0.4.14"
+
+
+async def _read_tunable(db: AsyncSession, key: str) -> int:
+    """Read a single tunable from server_settings, falling back to the
+    compiled default."""
+    row = (
+        await db.execute(select(ServerSetting).where(ServerSetting.key == f"tunable:{key}"))
+    ).scalar_one_or_none()
+    if row is None:
+        return _TUNABLE_DEFAULTS[key]
+    try:
+        return int(row.value)
+    except (TypeError, ValueError):
+        return _TUNABLE_DEFAULTS[key]
+
+
+async def _read_all_tunables(db: AsyncSession) -> TunablesView:
+    return TunablesView(
+        backfill_batch_size=await _read_tunable(db, "backfill_batch_size"),
+        backfill_interval_seconds=await _read_tunable(db, "backfill_interval_seconds"),
+        scryfall_sync_interval_days=await _read_tunable(db, "scryfall_sync_interval_days"),
+        mtgo_scraper_interval_hours=await _read_tunable(db, "mtgo_scraper_interval_hours"),
+        reparse_min_version=_REPARSE_MIN_VERSION,
+        min_agent_version=_MIN_AGENT_VERSION,
+        parser_version=_PARSER_VERSION,
+    )
+
+
+@router.get("/settings/tunables", response_model=TunablesView)
+async def get_tunables(
+    _admin: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> TunablesView:
+    """Read the current values of all tunables. Any admin may read."""
+    return await _read_all_tunables(db)
+
+
+@router.patch("/settings/tunables", response_model=TunablesView)
+async def update_tunables(
+    body: UpdateTunablesRequest,
+    admin: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> TunablesView:
+    """Update one or more mutable tunables. Any admin may write."""
+    now = datetime.now(UTC)
+    updates: dict[str, int] = {}
+    if body.backfill_batch_size is not None:
+        updates["backfill_batch_size"] = body.backfill_batch_size
+    if body.backfill_interval_seconds is not None:
+        updates["backfill_interval_seconds"] = body.backfill_interval_seconds
+    if body.scryfall_sync_interval_days is not None:
+        updates["scryfall_sync_interval_days"] = body.scryfall_sync_interval_days
+    if body.mtgo_scraper_interval_hours is not None:
+        updates["mtgo_scraper_interval_hours"] = body.mtgo_scraper_interval_hours
+
+    for key, value in updates.items():
+        db_key = f"tunable:{key}"
+        row = (
+            await db.execute(select(ServerSetting).where(ServerSetting.key == db_key))
+        ).scalar_one_or_none()
+        if row is None:
+            row = ServerSetting(
+                key=db_key,
+                value=value,
+                updated_at=now,
+                updated_by_user_id=admin.user_id,
+            )
+            db.add(row)
+        else:
+            row.value = value
+            row.updated_at = now
+            row.updated_by_user_id = admin.user_id
+
+    await db.commit()
+    return await _read_all_tunables(db)

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -771,7 +771,10 @@ async def register(
                 detail={"error": "invalid_invite_token"},
             )
         # Check whether the invite has remaining uses.
-        if invite.max_uses is not None and invite.use_count >= invite.max_uses:
+        # Pre-migration rows have max_uses=NULL — treat those as
+        # single-use (max_uses=1) for backward compatibility.
+        effective_max = invite.max_uses if invite.max_uses is not None else 1
+        if invite.use_count >= effective_max:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={"error": "invite_exhausted"},

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -755,8 +755,8 @@ async def register(
     if raw_token:
         # Lock the row for the duration of the transaction so two
         # concurrent /auth/register calls racing the same token can't
-        # both observe used_at IS NULL — the second waits, then sees
-        # the stamped row and is rejected.
+        # both see remaining capacity — the second waits, then sees
+        # the incremented use_count and is rejected if exhausted.
         invite = (
             await db.execute(
                 select(InviteToken)
@@ -765,11 +765,16 @@ async def register(
             )
         ).scalar_one_or_none()
         now = datetime.now(UTC)
-        if invite is None or invite.used_at is not None or invite.expires_at <= now:
-            code = "invalid_invite_token"
+        if invite is None or invite.expires_at <= now:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail={"error": code},
+                detail={"error": "invalid_invite_token"},
+            )
+        # Check whether the invite has remaining uses.
+        if invite.max_uses is not None and invite.use_count >= invite.max_uses:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": "invite_exhausted"},
             )
 
     # Email uniqueness check (case-insensitive). Done after token
@@ -799,6 +804,7 @@ async def register(
         await db.flush()
 
         if invite is not None:
+            invite.use_count += 1
             invite.used_at = datetime.now(UTC)
             invite.used_by_user_id = user.id
 

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -771,10 +771,11 @@ async def register(
                 detail={"error": "invalid_invite_token"},
             )
         # Check whether the invite has remaining uses.
-        # Pre-migration rows have max_uses=NULL — treat those as
-        # single-use (max_uses=1) for backward compatibility.
+        # max_uses=0 → unlimited (always allow, just check expiry above).
+        # max_uses IS NULL → legacy single-use, treat as max_uses=1.
+        # max_uses > 0 → normal multi-use, check use_count < max_uses.
         effective_max = invite.max_uses if invite.max_uses is not None else 1
-        if invite.use_count >= effective_max:
+        if effective_max > 0 and invite.use_count >= effective_max:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={"error": "invite_exhausted"},

--- a/services/auth/auth_service/models.py
+++ b/services/auth/auth_service/models.py
@@ -170,13 +170,15 @@ class InviteToken(Base):
     cascade-wipe the invite history.
 
     ``max_uses`` controls how many registrations can consume this token:
-    - ``None`` (NULL) means unlimited uses.
+    - ``0`` means unlimited uses.
     - A positive integer caps the token at that many uses.
+    - ``None`` (NULL) is treated as single-use (``max_uses = 1``) for
+      backward compatibility with pre-migration rows.
     ``use_count`` tracks how many registrations have consumed it so far.
 
-    A row is "pending" when ``use_count < max_uses`` (or ``max_uses``
-    is NULL) and ``expires_at > now()``. Legacy single-use tokens set
-    ``max_uses = 1``. Revocation is implemented by stamping
+    A row is "pending" when ``max_uses = 0`` (unlimited) or
+    ``use_count < max_uses``, and ``expires_at > now()``. Revocation
+    is implemented by stamping
     ``expires_at = now()`` rather than deleting the row, so the audit
     trail of who-minted-what survives. The ``ix_invite_tokens_pending``
     composite index covers the pending-list query.

--- a/services/auth/auth_service/models.py
+++ b/services/auth/auth_service/models.py
@@ -158,7 +158,7 @@ class ServerSetting(Base):
 
 
 class InviteToken(Base):
-    """Single-use, hashed-at-rest user-invite token.
+    """Hashed-at-rest user-invite token with optional use limit.
 
     Pattern mirrors :class:`AgentRegistration`'s api token: the issuing
     endpoint returns plaintext once and persists only a SHA-256 hex
@@ -169,11 +169,17 @@ class InviteToken(Base):
     NULL`` so deleting an admin (issuer) or a user (consumer) doesn't
     cascade-wipe the invite history.
 
-    A row is "pending" when ``used_at IS NULL AND expires_at > now()``;
-    revocation is implemented by stamping ``expires_at = now()`` rather
-    than deleting the row, so the audit trail of who-minted-what
-    survives. The ``ix_invite_tokens_pending`` composite index covers
-    the pending-list query.
+    ``max_uses`` controls how many registrations can consume this token:
+    - ``None`` (NULL) means unlimited uses.
+    - A positive integer caps the token at that many uses.
+    ``use_count`` tracks how many registrations have consumed it so far.
+
+    A row is "pending" when ``use_count < max_uses`` (or ``max_uses``
+    is NULL) and ``expires_at > now()``. Legacy single-use tokens set
+    ``max_uses = 1``. Revocation is implemented by stamping
+    ``expires_at = now()`` rather than deleting the row, so the audit
+    trail of who-minted-what survives. The ``ix_invite_tokens_pending``
+    composite index covers the pending-list query.
     """
 
     __tablename__ = "invite_tokens"
@@ -199,6 +205,8 @@ class InviteToken(Base):
         ForeignKey("auth.users.id", ondelete="SET NULL"),
         nullable=True,
     )
+    max_uses: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    use_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
 
     __table_args__ = (
         UniqueConstraint("token_hash", name="uq_invite_tokens_token_hash"),

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -181,6 +181,7 @@ class CreateInviteRequest(BaseModel):
         ge=1,
         le=INVITE_TOKEN_MAX_HOURS,
     )
+    max_uses: int | None = Field(default=1, ge=1, le=10000)
 
 
 class CreateInviteResponse(BaseModel):
@@ -190,6 +191,7 @@ class CreateInviteResponse(BaseModel):
     token: str
     expires_at: datetime
     created_at: datetime
+    max_uses: int | None
 
 
 class InviteView(BaseModel):
@@ -198,6 +200,8 @@ class InviteView(BaseModel):
     created_by_email: str | None
     created_at: datetime
     expires_at: datetime
+    max_uses: int | None
+    use_count: int
 
 
 class InviteListView(BaseModel):

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -181,7 +181,7 @@ class CreateInviteRequest(BaseModel):
         ge=1,
         le=INVITE_TOKEN_MAX_HOURS,
     )
-    max_uses: int | None = Field(default=1, ge=1, le=10000)
+    max_uses: int = Field(default=1, ge=0, le=10000)
 
 
 class CreateInviteResponse(BaseModel):
@@ -191,7 +191,7 @@ class CreateInviteResponse(BaseModel):
     token: str
     expires_at: datetime
     created_at: datetime
-    max_uses: int | None
+    max_uses: int
 
 
 class InviteView(BaseModel):
@@ -200,7 +200,7 @@ class InviteView(BaseModel):
     created_by_email: str | None
     created_at: datetime
     expires_at: datetime
-    max_uses: int | None
+    max_uses: int
     use_count: int
 
 

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -221,3 +221,44 @@ class AgentRegisterWithCredentialsRequest(BaseModel):
     password: str = Field(min_length=1, json_schema_extra={"writeOnly": True})
     agent_name: str = Field(min_length=1, max_length=255)
     client_version: str = Field(min_length=1, max_length=64)
+
+
+# ---------------------------------------------------------------------------
+# Admin tunables — configurable server settings
+# ---------------------------------------------------------------------------
+
+
+class TunablesView(BaseModel):
+    """Current values of all tunables — both mutable (DB-stored) and
+    read-only code constants."""
+
+    backfill_batch_size: int
+    backfill_interval_seconds: int
+    scryfall_sync_interval_days: int
+    mtgo_scraper_interval_hours: int
+    reparse_min_version: str
+    min_agent_version: str
+    parser_version: str
+
+
+class UpdateTunablesRequest(BaseModel):
+    """Only the mutable tunables may be patched."""
+
+    backfill_batch_size: int | None = Field(default=None, ge=10, le=1000)
+    backfill_interval_seconds: int | None = Field(default=None, ge=60, le=3600)
+    scryfall_sync_interval_days: int | None = Field(default=None, ge=1, le=30)
+    mtgo_scraper_interval_hours: int | None = Field(default=None, ge=1, le=168)
+
+    @model_validator(mode="after")
+    def _at_least_one(self) -> UpdateTunablesRequest:
+        if all(
+            v is None
+            for v in (
+                self.backfill_batch_size,
+                self.backfill_interval_seconds,
+                self.scryfall_sync_interval_days,
+                self.mtgo_scraper_interval_hours,
+            )
+        ):
+            raise ValueError("at_least_one_field_required")
+        return self

--- a/services/auth/tests/test_invites.py
+++ b/services/auth/tests/test_invites.py
@@ -746,13 +746,13 @@ async def test_create_invite_with_max_uses(client: Any, db_session: AsyncSession
 
 @pytest.mark.asyncio
 async def test_create_invite_unlimited(client: Any, db_session: AsyncSession) -> None:
-    """max_uses=null means unlimited uses."""
+    """max_uses=0 means unlimited uses."""
     await _seed_user(db_session, email="root@example.com", role="admin")
     token = await _login(client, "root@example.com", "pw")
 
-    r = await client.post("/admin/invites", json={"max_uses": None}, headers=_h(token))
+    r = await client.post("/admin/invites", json={"max_uses": 0}, headers=_h(token))
     assert r.status_code == 201, r.text
-    assert r.json()["max_uses"] is None
+    assert r.json()["max_uses"] == 0
 
 
 @pytest.mark.asyncio
@@ -816,7 +816,7 @@ async def test_unlimited_invite_allows_many_registrations(
         created_by_user_id=admin_id,
         created_at=datetime.now(UTC),
         expires_at=datetime.now(UTC) + timedelta(hours=168),
-        max_uses=None,
+        max_uses=0,  # 0 = unlimited
     )
     db_session.add(invite)
     await db_session.commit()

--- a/services/auth/tests/test_invites.py
+++ b/services/auth/tests/test_invites.py
@@ -77,6 +77,7 @@ async def test_create_invite_returns_plaintext_and_hashes_at_rest(
     body = r.json()
     assert "token" in body
     assert "id" in body
+    assert body["max_uses"] == 1  # default single-use
     plaintext = body["token"]
     assert len(plaintext) >= 20  # opaque, URL-safe, 32 bytes of entropy
 
@@ -87,7 +88,8 @@ async def test_create_invite_returns_plaintext_and_hashes_at_rest(
     assert row.token_hash == hash_invite_token(plaintext)
     assert row.token_hash != plaintext
     assert row.created_by_user_id == 1
-    assert row.used_at is None
+    assert row.use_count == 0
+    assert row.max_uses == 1
     # Default 168h ≈ 7 days from now (allow 5 min slack for test runtime).
     delta = row.expires_at - datetime.now(UTC)
     assert timedelta(hours=167, minutes=55) < delta < timedelta(hours=168, minutes=5)
@@ -169,22 +171,27 @@ async def test_list_invites_returns_pending_only(client: Any, db_session: AsyncS
         created_by_user_id=admin_id,
         created_at=now,
         expires_at=now + timedelta(hours=168),
+        max_uses=5,
+        use_count=2,
     )
     expired = InviteToken(
         token_hash=hash_invite_token("expired-tok"),
         created_by_user_id=admin_id,
         created_at=now - timedelta(hours=200),
         expires_at=now - timedelta(hours=1),
+        max_uses=1,
     )
-    used = InviteToken(
+    exhausted = InviteToken(
         token_hash=hash_invite_token("used-tok"),
         created_by_user_id=admin_id,
         created_at=now,
         expires_at=now + timedelta(hours=168),
+        max_uses=1,
+        use_count=1,
         used_at=now,
         used_by_user_id=admin_id,
     )
-    db_session.add_all([pending, expired, used])
+    db_session.add_all([pending, expired, exhausted])
     await db_session.commit()
 
     r = await client.get("/admin/invites", headers=_h(token))
@@ -193,6 +200,8 @@ async def test_list_invites_returns_pending_only(client: Any, db_session: AsyncS
     assert body["total"] == 1
     assert len(body["invites"]) == 1
     assert body["invites"][0]["created_by_email"] == "root@example.com"
+    assert body["invites"][0]["max_uses"] == 5
+    assert body["invites"][0]["use_count"] == 2
 
 
 @pytest.mark.asyncio
@@ -405,6 +414,7 @@ async def test_register_invite_only_happy_path_consumes_token(
     ).scalar_one()
     assert refreshed.used_at is not None
     assert refreshed.used_by_user_id == new_user_id
+    assert refreshed.use_count == 1
 
 
 @pytest.mark.asyncio
@@ -416,6 +426,7 @@ async def test_register_token_single_use_enforcement(client: Any, db_session: As
         created_by_user_id=admin_id,
         created_at=datetime.now(UTC),
         expires_at=datetime.now(UTC) + timedelta(hours=168),
+        max_uses=1,
     )
     db_session.add(invite)
     await db_session.commit()
@@ -431,7 +442,7 @@ async def test_register_token_single_use_enforcement(client: Any, db_session: As
     )
     assert r1.status_code == 201
 
-    # Second use fails — token already consumed.
+    # Second use fails — token exhausted.
     r2 = await client.post(
         "/auth/register",
         json={
@@ -441,7 +452,7 @@ async def test_register_token_single_use_enforcement(client: Any, db_session: As
         },
     )
     assert r2.status_code == 403
-    assert r2.json() == {"detail": {"error": "invalid_invite_token"}}
+    assert r2.json() == {"detail": {"error": "invite_exhausted"}}
 
 
 @pytest.mark.asyncio
@@ -449,8 +460,8 @@ async def test_register_concurrent_consumption_only_one_wins(
     client: Any, db_session: AsyncSession
 ) -> None:
     """Two parallel POST /auth/register calls racing the same token: one
-    wins (201), one loses (403 invalid_invite_token). Guards against the
-    SELECT-then-UPDATE race that lets both observe the row as unused.
+    wins (201), one loses (403 invite_exhausted). Guards against the
+    SELECT-then-UPDATE race that lets both observe remaining capacity.
     """
     import asyncio
 
@@ -461,6 +472,7 @@ async def test_register_concurrent_consumption_only_one_wins(
         created_by_user_id=admin_id,
         created_at=datetime.now(UTC),
         expires_at=datetime.now(UTC) + timedelta(hours=168),
+        max_uses=1,
     )
     db_session.add(invite)
     await db_session.commit()
@@ -483,7 +495,7 @@ async def test_register_concurrent_consumption_only_one_wins(
     assert statuses == [201, 403], (r1.status_code, r1.text, r2.status_code, r2.text)
 
     loser = r1 if r1.status_code == 403 else r2
-    assert loser.json() == {"detail": {"error": "invalid_invite_token"}}
+    assert loser.json() == {"detail": {"error": "invite_exhausted"}}
 
     # Exactly one user was created.
     users = (
@@ -557,6 +569,7 @@ async def test_register_open_mode_consumes_token_if_provided(
         created_by_user_id=admin_id,
         created_at=datetime.now(UTC),
         expires_at=datetime.now(UTC) + timedelta(hours=168),
+        max_uses=1,
     )
     db_session.add(invite)
     await db_session.commit()
@@ -578,6 +591,7 @@ async def test_register_open_mode_consumes_token_if_provided(
         await db_session.execute(select(InviteToken).where(InviteToken.id == invite_id))
     ).scalar_one()
     assert refreshed.used_at is not None
+    assert refreshed.use_count == 1
 
 
 @pytest.mark.asyncio
@@ -706,6 +720,117 @@ async def test_register_invite_only_password_complexity_still_enforced(
     )
     assert r.status_code == 400
     assert r.json() == {"detail": {"error": "weak_password"}}
+
+
+# ---------------------------------------------------------------------------
+# Multi-use invites
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_invite_with_max_uses(client: Any, db_session: AsyncSession) -> None:
+    await _seed_user(db_session, email="root@example.com", role="admin")
+    token = await _login(client, "root@example.com", "pw")
+
+    r = await client.post("/admin/invites", json={"max_uses": 20}, headers=_h(token))
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["max_uses"] == 20
+
+    row = (
+        await db_session.execute(select(InviteToken).where(InviteToken.id == uuid.UUID(body["id"])))
+    ).scalar_one()
+    assert row.max_uses == 20
+    assert row.use_count == 0
+
+
+@pytest.mark.asyncio
+async def test_create_invite_unlimited(client: Any, db_session: AsyncSession) -> None:
+    """max_uses=null means unlimited uses."""
+    await _seed_user(db_session, email="root@example.com", role="admin")
+    token = await _login(client, "root@example.com", "pw")
+
+    r = await client.post("/admin/invites", json={"max_uses": None}, headers=_h(token))
+    assert r.status_code == 201, r.text
+    assert r.json()["max_uses"] is None
+
+
+@pytest.mark.asyncio
+async def test_multi_use_invite_allows_multiple_registrations(
+    client: Any, db_session: AsyncSession
+) -> None:
+    admin_id = await _seed_user(db_session, email="root@example.com", role="admin")
+    plaintext = "multi-use-tok-abc"
+    invite = InviteToken(
+        token_hash=hash_invite_token(plaintext),
+        created_by_user_id=admin_id,
+        created_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC) + timedelta(hours=168),
+        max_uses=3,
+    )
+    db_session.add(invite)
+    await db_session.commit()
+    await db_session.refresh(invite)
+    invite_id = invite.id
+
+    # Three registrations should all succeed.
+    for i in range(3):
+        r = await client.post(
+            "/auth/register",
+            json={
+                "email": f"user{i}@example.com",
+                "password": "longenoughpw!!",
+                "token": plaintext,
+            },
+        )
+        assert r.status_code == 201, f"Registration {i} failed: {r.text}"
+
+    # Fourth should fail — exhausted.
+    r = await client.post(
+        "/auth/register",
+        json={
+            "email": "user3@example.com",
+            "password": "longenoughpw!!",
+            "token": plaintext,
+        },
+    )
+    assert r.status_code == 403
+    assert r.json() == {"detail": {"error": "invite_exhausted"}}
+
+    # Verify use_count.
+    db_session.expunge_all()
+    refreshed = (
+        await db_session.execute(select(InviteToken).where(InviteToken.id == invite_id))
+    ).scalar_one()
+    assert refreshed.use_count == 3
+
+
+@pytest.mark.asyncio
+async def test_unlimited_invite_allows_many_registrations(
+    client: Any, db_session: AsyncSession
+) -> None:
+    admin_id = await _seed_user(db_session, email="root@example.com", role="admin")
+    plaintext = "unlimited-tok-abc"
+    invite = InviteToken(
+        token_hash=hash_invite_token(plaintext),
+        created_by_user_id=admin_id,
+        created_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC) + timedelta(hours=168),
+        max_uses=None,
+    )
+    db_session.add(invite)
+    await db_session.commit()
+
+    for i in range(5):
+        r = await client.post(
+            "/auth/register",
+            json={
+                "email": f"unlim{i}@example.com",
+                "password": "longenoughpw!!",
+                "token": plaintext,
+            },
+        )
+        assert r.status_code == 201, f"Registration {i} failed: {r.text}"
 
 
 # ---------------------------------------------------------------------------

--- a/services/parser/parser_service/backfill.py
+++ b/services/parser/parser_service/backfill.py
@@ -24,7 +24,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from parser_service.consumer import ParserConsumer
-from parser_service.settings import REPARSE_MIN_VERSION
+from parser_service.settings import REPARSE_MIN_VERSION, get_settings
 
 _log = logging.getLogger("parser.backfill")
 
@@ -49,8 +49,10 @@ _UNPARSED_SQL = text(
 async def scan_unparsed(
     sm: async_sessionmaker[AsyncSession],
     consumer: ParserConsumer,
-    batch_size: int = 100,
+    batch_size: int | None = None,
 ) -> int:
+    if batch_size is None:
+        batch_size = get_settings().backfill_batch_size
     async with sm() as session:
         rows = (
             await session.execute(

--- a/services/parser/parser_service/models.py
+++ b/services/parser/parser_service/models.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     DateTime,
     ForeignKey,
     Index,
@@ -92,6 +93,9 @@ class Game(Base):
     game_number: Mapped[int] = mapped_column(Integer, nullable=False)
     winner: Mapped[str | None] = mapped_column(String(255), nullable=True)
     result: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    on_play: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    play_first: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    opening_hand_sizes: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
 
     __table_args__ = (
         UniqueConstraint("match_id", "game_number", name="uq_games_match_game_number"),

--- a/services/parser/parser_service/parsing/models.py
+++ b/services/parser/parser_service/parsing/models.py
@@ -68,6 +68,9 @@ class ParsedGame(BaseModel):
     game_number: int
     winner: str | None = None
     result: str | None = None  # "win", "loss", "draw", "concede"
+    on_play: bool | None = None  # True if hero chose to play first
+    play_first: str | None = None  # player name who chose to play first
+    opening_hand_sizes: dict[str, int] = Field(default_factory=dict)
     turns: list[TurnSnapshot] = Field(default_factory=list)
 
 

--- a/services/parser/parser_service/parsing/parser.py
+++ b/services/parser/parser_service/parsing/parser.py
@@ -184,6 +184,18 @@ class MTGODatStrategy(LogFormatStrategy):
 
     _CARD_RE = re.compile(r"@\[([^@\[\]]+?)@:\d+,\d+:@\]")
 
+    # --- word-to-int mapping for MTGO hand-size text ----------------------
+    _WORD_TO_INT: dict[str, int] = {
+        "zero": 0,
+        "one": 1,
+        "two": 2,
+        "three": 3,
+        "four": 4,
+        "five": 5,
+        "six": 6,
+        "seven": 7,
+    }
+
     def can_parse(self, content: bytes, filename: str | None = None) -> bool:
         if not content:
             return False
@@ -352,6 +364,46 @@ class MTGODatStrategy(LogFormatStrategy):
             game.winner = opp
             game.result = "concede"
 
+        # --- play/draw detection ------------------------------------------
+        play_first_re = re.compile(rf"@P({alt}) chooses to play first\.")
+        draw_first_re = re.compile(rf"@P({alt}) chooses to draw first\.")
+        if (m := play_first_re.search(block)) is not None:
+            game.play_first = m.group(1)
+        elif (m := draw_first_re.search(block)) is not None:
+            # The player who chose to draw first means the opponent plays first.
+            chooser = m.group(1)
+            opp = next((p for p in players if p != chooser), None)
+            game.play_first = opp
+
+        # --- opening hand sizes -------------------------------------------
+        # Two forms in the .dat log:
+        #   "@P<player> begins the game with <word> cards in hand."
+        #   "@P<player> puts ... and begins the game with <word> cards in hand."
+        # Both indicate the final hand size (post-mulligan). We use two
+        # separate patterns so the non-greedy quantifier can't skip across
+        # @P boundaries.
+        word_alt = "|".join(self._WORD_TO_INT.keys())
+        hand_direct_re = re.compile(rf"@P({alt}) begins the game with ({word_alt}) cards in hand\.")
+        hand_bottom_re = re.compile(
+            rf"@P({alt}) puts [^@]+ and begins the game with ({word_alt}) cards in hand\."
+        )
+        for m in hand_direct_re.finditer(block):
+            player = m.group(1)
+            count = self._WORD_TO_INT.get(m.group(2).lower(), 7)
+            game.opening_hand_sizes[player] = count
+        for m in hand_bottom_re.finditer(block):
+            player = m.group(1)
+            count = self._WORD_TO_INT.get(m.group(2).lower(), 7)
+            # The "puts ... and begins" form is the post-mulligan size;
+            # it overrides any earlier "begins the game" match.
+            game.opening_hand_sizes[player] = count
+
+        # on_play is relative to the first player in the match's player
+        # list (the "hero"): True if hero plays first, False if hero draws.
+        # We leave it None if we couldn't determine play_first.
+        if game.play_first is not None and players:
+            game.on_play = game.play_first == players[0]
+
         game.turns = self._parse_turns(block, players)
         return game
 
@@ -363,20 +415,83 @@ class MTGODatStrategy(LogFormatStrategy):
             return []
 
         carry: dict[str, PlayerSnapshot] = {p: PlayerSnapshot(name=p) for p in players}
-        play_re = re.compile(rf"@P({alt}) plays {self._CARD_RE.pattern}")
-        cast_re = re.compile(rf"@P({alt}) casts {self._CARD_RE.pattern}")
+        card_pat = self._CARD_RE.pattern
+
+        play_re = re.compile(rf"@P({alt}) plays {card_pat}")
+        cast_re = re.compile(rf"@P({alt}) casts {card_pat}")
+
+        # Draw patterns:
+        #   "@P<player> draws a card."  (anonymous draw)
+        #   "@P<player> draws a card with @[Card@:id:@]."  (draw triggered by source)
+        #   "@P<player> draws <word> cards with @[Card@:id:@]."  (multi-draw)
+        draw_anon_re = re.compile(rf"@P({alt}) draws a card\.")
+        draw_with_re = re.compile(rf"@P({alt}) draws a card with {card_pat}")
+        draw_multi_re = re.compile(
+            rf"@P({alt}) draws ({'|'.join(self._WORD_TO_INT.keys())})"
+            rf" cards with {card_pat}"
+        )
+
+        # Graveyard: "@P<player> puts @[Card@:id:@] into their graveyard."
+        graveyard_re = re.compile(rf"@P({alt}) puts {card_pat} into their graveyard\.")
+
+        # Exile: "@P<player> exiles @[Card@:id:@]"
+        exile_re = re.compile(rf"@P({alt}) exiles {card_pat}")
+
+        # Life payment: "by paying <N> life" within a cast line.
+        # The player is captured from the cast-line prefix.
+        life_pay_re = re.compile(rf"@P({alt}) casts {card_pat} by paying (\d+) life")
 
         turns: list[TurnSnapshot] = []
         for idx, (start, num, active) in enumerate(marks):
             end = marks[idx + 1][0] if idx + 1 < len(marks) else len(block)
             window = block[start:end]
 
+            # Lands / spells → battlefield
             for pm in play_re.finditer(window):
                 snap = carry.setdefault(pm.group(1), PlayerSnapshot(name=pm.group(1)))
                 snap.zones.battlefield.append(pm.group(2).strip())
             for cm in cast_re.finditer(window):
                 snap = carry.setdefault(cm.group(1), PlayerSnapshot(name=cm.group(1)))
                 snap.zones.battlefield.append(cm.group(2).strip())
+
+            # Draws → hand zone (card name "unknown" for anonymous draws)
+            for dm in draw_anon_re.finditer(window):
+                snap = carry.setdefault(dm.group(1), PlayerSnapshot(name=dm.group(1)))
+                snap.zones.hand.append("unknown")
+            for dm in draw_with_re.finditer(window):
+                snap = carry.setdefault(dm.group(1), PlayerSnapshot(name=dm.group(1)))
+                snap.zones.hand.append("unknown")
+            for dm in draw_multi_re.finditer(window):
+                snap = carry.setdefault(dm.group(1), PlayerSnapshot(name=dm.group(1)))
+                count = self._WORD_TO_INT.get(dm.group(2).lower(), 1)
+                for _ in range(count):
+                    snap.zones.hand.append("unknown")
+
+            # Graveyard moves
+            for gm in graveyard_re.finditer(window):
+                snap = carry.setdefault(gm.group(1), PlayerSnapshot(name=gm.group(1)))
+                card = gm.group(2).strip()
+                snap.zones.graveyard.append(card)
+                # Remove from battlefield if present (best-effort)
+                if card in snap.zones.battlefield:
+                    snap.zones.battlefield.remove(card)
+
+            # Exile moves
+            for em in exile_re.finditer(window):
+                snap = carry.setdefault(em.group(1), PlayerSnapshot(name=em.group(1)))
+                card = em.group(2).strip()
+                snap.zones.exile.append(card)
+                # Remove from battlefield/graveyard if present (best-effort)
+                if card in snap.zones.battlefield:
+                    snap.zones.battlefield.remove(card)
+                elif card in snap.zones.graveyard:
+                    snap.zones.graveyard.remove(card)
+
+            # Life payments (best-effort — only explicit "paying N life",
+            # NOT combat damage which isn't logged in .dat format)
+            for lm in life_pay_re.finditer(window):
+                snap = carry.setdefault(lm.group(1), PlayerSnapshot(name=lm.group(1)))
+                snap.life -= int(lm.group(3))
 
             snapshot_players = {
                 name: PlayerSnapshot(

--- a/services/parser/parser_service/persistence.py
+++ b/services/parser/parser_service/persistence.py
@@ -76,6 +76,9 @@ async def persist_match(
             game_number=parsed_game.game_number,
             winner=parsed_game.winner,
             result=parsed_game.result,
+            on_play=parsed_game.on_play,
+            play_first=parsed_game.play_first,
+            opening_hand_sizes=parsed_game.opening_hand_sizes,
         )
         session.add(game)
         await session.flush()  # populate game.id

--- a/services/parser/parser_service/settings.py
+++ b/services/parser/parser_service/settings.py
@@ -10,12 +10,12 @@ from common.settings import BaseServiceSettings
 
 # Stamped on every match row at parse time so we can detect matches
 # parsed by an older version and queue them for reparse.
-PARSER_VERSION = "0.8.8"
+PARSER_VERSION = "0.9.0"
 
 # Backfill scanner picks up matches where ``parsed_with_version`` is
 # NULL or less than this threshold, ensuring they get re-parsed with
 # the current parser logic.
-REPARSE_MIN_VERSION = "0.8.8"
+REPARSE_MIN_VERSION = "0.9.0"
 
 
 class ParserSettings(BaseServiceSettings):

--- a/services/parser/parser_service/settings.py
+++ b/services/parser/parser_service/settings.py
@@ -34,6 +34,8 @@ class ParserSettings(BaseServiceSettings):
     parser_max_log_bytes: int = 50 * 1024 * 1024
     # Interval (seconds) between backfill scans for ingested-but-not-parsed files.
     backfill_interval_seconds: int = 300
+    # Maximum number of unparsed files to process per backfill scan.
+    backfill_batch_size: int = 100
 
 
 _settings: ParserSettings | None = None

--- a/services/parser/tests/test_game_state.py
+++ b/services/parser/tests/test_game_state.py
@@ -1,0 +1,348 @@
+"""Tests for v0.9.0 game state reconstruction — play/draw, mulligans,
+draw/zone tracking, and life payment extraction from .dat fixtures.
+
+Life tracking caveat: only explicit "paying N life" is tracked.
+Combat damage is NOT logged in the .dat format and is not tracked.
+Assertions use <= / >= bounds, not exact values, because the parser
+is best-effort for life totals.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from parser_service.parsing import LogParser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# Fixture shorthand — same as test_parser_logic.py.
+DAT_01EA1246 = "Match_GameLog_01ea1246-6306-483b-b03d-d0f7bf203e28.dat"
+DAT_2B464924 = "Match_GameLog_2b464924-54fb-4b05-8e3f-d4cfbd9a0310.dat"
+DAT_40087184 = "Match_GameLog_40087184-b709-4109-8ee8-7112e894b834.dat"
+DAT_4873FBEE = "Match_GameLog_4873fbee-48a8-4830-8864-d5631db75f0b.dat"
+
+
+def _parse(name: str):
+    return LogParser().parse((FIXTURES / name).read_bytes())
+
+
+# ── play/draw detection ─────────────────────────────────────────────────
+
+
+class TestPlayDraw:
+    """Verify play_first and on_play across all .dat fixtures."""
+
+    def test_01ea1246_game1_wangsu_plays_first(self) -> None:
+        parsed = _parse(DAT_01EA1246)
+        g1 = parsed.games[0]
+        assert g1.play_first == "WANGSU"
+        # WANGSU is players[0], so on_play is True
+        assert g1.on_play is True
+
+    def test_01ea1246_game3_sentania_plays_first(self) -> None:
+        parsed = _parse(DAT_01EA1246)
+        g3 = parsed.games[2]
+        assert g3.play_first == "sentania"
+        # sentania is players[1], so on_play is False
+        assert g3.on_play is False
+
+    def test_2b464924_game1_sentania_plays_first(self) -> None:
+        parsed = _parse(DAT_2B464924)
+        g1 = parsed.games[0]
+        assert g1.play_first == "sentania"
+
+    def test_2b464924_game3_214_plays_first(self) -> None:
+        parsed = _parse(DAT_2B464924)
+        g3 = parsed.games[2]
+        assert g3.play_first == "214"
+        assert g3.on_play is True  # 214 is players[0]
+
+    def test_40087184_game1_sentania_plays_first(self) -> None:
+        parsed = _parse(DAT_40087184)
+        g1 = parsed.games[0]
+        assert g1.play_first == "sentania"
+
+    def test_40087184_game2_youngjustin_plays_first(self) -> None:
+        parsed = _parse(DAT_40087184)
+        g2 = parsed.games[1]
+        assert g2.play_first == "YoungJustin"
+        assert g2.on_play is True  # YoungJustin is players[0]
+
+    def test_4873fbee_game1_diamondcommando_plays_first(self) -> None:
+        parsed = _parse(DAT_4873FBEE)
+        g1 = parsed.games[0]
+        assert g1.play_first == "DiamondCommando"
+
+    def test_4873fbee_game2_sentania_plays_first(self) -> None:
+        parsed = _parse(DAT_4873FBEE)
+        g2 = parsed.games[1]
+        assert g2.play_first == "sentania"
+
+    def test_every_game_has_play_first(self) -> None:
+        """All games across all fixtures should detect play/draw."""
+        for name in (DAT_01EA1246, DAT_2B464924, DAT_40087184, DAT_4873FBEE):
+            parsed = _parse(name)
+            for g in parsed.games:
+                assert g.play_first is not None, f"{name} game {g.game_number}: play_first is None"
+                assert g.on_play is not None, f"{name} game {g.game_number}: on_play is None"
+
+
+# ── mulligan / opening hand size detection ──────────────────────────────
+
+
+class TestOpeningHandSizes:
+    """Verify opening_hand_sizes extraction."""
+
+    def test_01ea1246_game1_both_keep_seven(self) -> None:
+        parsed = _parse(DAT_01EA1246)
+        g1 = parsed.games[0]
+        assert g1.opening_hand_sizes == {"WANGSU": 7, "sentania": 7}
+
+    def test_01ea1246_game3_wangsu_mulligans_to_six(self) -> None:
+        parsed = _parse(DAT_01EA1246)
+        g3 = parsed.games[2]
+        assert g3.opening_hand_sizes["WANGSU"] == 6
+        assert g3.opening_hand_sizes["sentania"] == 7
+
+    def test_40087184_game1_sentania_mulligans_to_five(self) -> None:
+        """sentania mulligans twice (7 → 6 → 5) in game 1."""
+        parsed = _parse(DAT_40087184)
+        g1 = parsed.games[0]
+        assert g1.opening_hand_sizes["sentania"] == 5
+        assert g1.opening_hand_sizes["YoungJustin"] == 7
+
+    def test_40087184_game2_both_keep_seven(self) -> None:
+        parsed = _parse(DAT_40087184)
+        g2 = parsed.games[1]
+        assert g2.opening_hand_sizes == {"YoungJustin": 7, "sentania": 7}
+
+    def test_4873fbee_game1_diamondcommando_mulligans_to_four(self) -> None:
+        """DiamondCommando mulligans three times (7 → 6 → 5 → 4)."""
+        parsed = _parse(DAT_4873FBEE)
+        g1 = parsed.games[0]
+        assert g1.opening_hand_sizes["DiamondCommando"] == 4
+        assert g1.opening_hand_sizes["sentania"] == 7
+
+    def test_4873fbee_game2_diamondcommando_mulligans_to_four_again(self) -> None:
+        parsed = _parse(DAT_4873FBEE)
+        g2 = parsed.games[1]
+        assert g2.opening_hand_sizes["DiamondCommando"] == 4
+
+    def test_2b464924_game1_214_mulligans_to_six(self) -> None:
+        parsed = _parse(DAT_2B464924)
+        g1 = parsed.games[0]
+        assert g1.opening_hand_sizes["214"] == 6
+        assert g1.opening_hand_sizes["sentania"] == 7
+
+    def test_every_game_has_hand_sizes(self) -> None:
+        """All games should have at least one player's hand size."""
+        for name in (DAT_01EA1246, DAT_2B464924, DAT_40087184, DAT_4873FBEE):
+            parsed = _parse(name)
+            for g in parsed.games:
+                assert g.opening_hand_sizes, (
+                    f"{name} game {g.game_number}: opening_hand_sizes is empty"
+                )
+
+
+# ── draw tracking ───────────────────────────────────────────────────────
+
+
+class TestDrawTracking:
+    """Verify that card draws populate the hand zone."""
+
+    def test_hand_zone_grows_with_draws(self) -> None:
+        """After multiple turns, hand zone should have entries from draws."""
+        parsed = _parse(DAT_01EA1246)
+        g1 = parsed.games[0]
+        assert g1.turns, "expected turns"
+        last_turn = g1.turns[-1]
+        # Both players should have drawn cards by the last turn.
+        for player in ("WANGSU", "sentania"):
+            hand = last_turn.players[player].zones.hand
+            assert len(hand) > 0, f"{player} hand zone is empty at end of game"
+
+    def test_anonymous_draws_tracked_as_unknown(self) -> None:
+        """'draws a card.' lines should add 'unknown' to hand."""
+        parsed = _parse(DAT_01EA1246)
+        g1 = parsed.games[0]
+        # After a few turns, at least one "unknown" should appear.
+        all_hand_cards: list[str] = []
+        for turn in g1.turns:
+            for snap in turn.players.values():
+                all_hand_cards.extend(snap.zones.hand)
+        assert "unknown" in all_hand_cards
+
+    def test_multi_draw_adds_multiple_entries(self) -> None:
+        """'draws three cards with Brainstorm' → 3 entries in hand."""
+        parsed = _parse(DAT_01EA1246)
+        # Game 1 has Brainstorm draws. Check that a turn with Brainstorm
+        # adds 3 hand entries in a single turn window.
+        g1 = parsed.games[0]
+        prev_hand_count: dict[str, int] = {}
+        brainstorm_turn_found = False
+        for turn in g1.turns:
+            for name, snap in turn.players.items():
+                cur = len(snap.zones.hand)
+                prev = prev_hand_count.get(name, 0)
+                # A turn with Brainstorm should add at least 3 to hand.
+                if cur - prev >= 3:
+                    brainstorm_turn_found = True
+                prev_hand_count[name] = cur
+        assert brainstorm_turn_found, "expected a turn with 3+ new hand entries (Brainstorm)"
+
+
+# ── graveyard tracking ──────────────────────────────────────────────────
+
+
+class TestGraveyardTracking:
+    """Verify 'puts ... into their graveyard' populates graveyard zone."""
+
+    def test_01ea1246_flusterstorm_in_graveyard(self) -> None:
+        """WANGSU puts Flusterstorm into their graveyard in game 1."""
+        parsed = _parse(DAT_01EA1246)
+        g1 = parsed.games[0]
+        last_turn = g1.turns[-1]
+        gy = last_turn.players["WANGSU"].zones.graveyard
+        assert "Flusterstorm" in gy
+
+    def test_40087184_thoughtseize_in_graveyard(self) -> None:
+        """YoungJustin puts Thoughtseize into their graveyard in game 1."""
+        parsed = _parse(DAT_40087184)
+        g1 = parsed.games[0]
+        last_turn = g1.turns[-1]
+        gy = last_turn.players["YoungJustin"].zones.graveyard
+        assert "Thoughtseize" in gy
+
+    def test_graveyard_cards_are_clean(self) -> None:
+        """Graveyard entries should be clean card names, no @-artifacts."""
+        for name in (DAT_01EA1246, DAT_2B464924, DAT_40087184, DAT_4873FBEE):
+            parsed = _parse(name)
+            for g in parsed.games:
+                for turn in g.turns:
+                    for snap in turn.players.values():
+                        for card in snap.zones.graveyard:
+                            assert "@" not in card, f"dirty graveyard entry: {card}"
+
+
+# ── exile tracking ──────────────────────────────────────────────────────
+
+
+class TestExileTracking:
+    """Verify 'exiles ...' populates exile zone."""
+
+    def test_01ea1246_atraxa_exiled_by_force(self) -> None:
+        """sentania exiles Atraxa, Grand Unifier with Force of Will's ability."""
+        parsed = _parse(DAT_01EA1246)
+        g1 = parsed.games[0]
+        last_turn = g1.turns[-1]
+        exile = last_turn.players["sentania"].zones.exile
+        assert "Atraxa, Grand Unifier" in exile
+
+    def test_4873fbee_exile_zone_populated(self) -> None:
+        """DiamondCommando exiles cards across games 1 and 2."""
+        parsed = _parse(DAT_4873FBEE)
+        for g in parsed.games:
+            last_turn = g.turns[-1]
+            all_exile = sum(len(snap.zones.exile) for snap in last_turn.players.values())
+            assert all_exile > 0, f"game {g.game_number}: no cards exiled"
+
+    def test_exile_cards_are_clean(self) -> None:
+        """Exile entries should be clean card names."""
+        for name in (DAT_01EA1246, DAT_2B464924, DAT_40087184, DAT_4873FBEE):
+            parsed = _parse(name)
+            for g in parsed.games:
+                for turn in g.turns:
+                    for snap in turn.players.values():
+                        for card in snap.zones.exile:
+                            assert "@" not in card, f"dirty exile entry: {card}"
+
+
+# ── life payment tracking ───────────────────────────────────────────────
+
+
+class TestLifePaymentTracking:
+    """Verify best-effort life tracking from 'paying N life' patterns.
+
+    Only life PAYMENTS (Force of Will, Snuff Out, fetch lands, etc.) are
+    tracked. Combat damage is NOT logged in the .dat format.
+    """
+
+    def test_force_of_will_costs_1_life(self) -> None:
+        """Games with Force of Will casts should show life < 20."""
+        parsed = _parse(DAT_01EA1246)
+        g1 = parsed.games[0]
+        last_turn = g1.turns[-1]
+        # WANGSU casts FoW paying 1 life at least twice in game 1
+        assert last_turn.players["WANGSU"].life < 20
+
+    def test_snuff_out_costs_4_life(self) -> None:
+        """YoungJustin casts Snuff Out paying 4 life in game 1 of 40087184."""
+        parsed = _parse(DAT_40087184)
+        g1 = parsed.games[0]
+        last_turn = g1.turns[-1]
+        assert last_turn.players["YoungJustin"].life <= 16
+
+    def test_life_decrements_are_cumulative(self) -> None:
+        """Multiple FoW casts by the same player accumulate life loss."""
+        parsed = _parse(DAT_01EA1246)
+        # Game 2: WANGSU casts FoW paying 1 life multiple times
+        g2 = parsed.games[1]
+        last_turn = g2.turns[-1]
+        # At least 2 FoW casts → life should be <= 18
+        assert last_turn.players["WANGSU"].life <= 18
+
+    def test_all_fixtures_have_life_payments(self) -> None:
+        """Every fixture has at least one FoW, so some player should be < 20."""
+        for name in (DAT_01EA1246, DAT_2B464924, DAT_40087184, DAT_4873FBEE):
+            parsed = _parse(name)
+            any_below_20 = False
+            for g in parsed.games:
+                if not g.turns:
+                    continue
+                last_turn = g.turns[-1]
+                for snap in last_turn.players.values():
+                    if snap.life < 20:
+                        any_below_20 = True
+            assert any_below_20, f"{name}: no player life < 20 across all games"
+
+    def test_life_never_negative_in_fixtures(self) -> None:
+        """Sanity check: life should not go below 0 from payment tracking."""
+        for name in (DAT_01EA1246, DAT_2B464924, DAT_40087184, DAT_4873FBEE):
+            parsed = _parse(name)
+            for g in parsed.games:
+                for turn in g.turns:
+                    for snap in turn.players.values():
+                        assert snap.life >= 0, (
+                            f"{name} game {g.game_number} turn {turn.turn_number}: "
+                            f"{snap.name} life={snap.life} (negative)"
+                        )
+
+
+# ── ParsedGame model fields ─────────────────────────────────────────────
+
+
+class TestParsedGameModelFields:
+    """Ensure the new fields have correct defaults."""
+
+    def test_default_values(self) -> None:
+        from parser_service.parsing.models import ParsedGame
+
+        g = ParsedGame(game_number=1)
+        assert g.on_play is None
+        assert g.play_first is None
+        assert g.opening_hand_sizes == {}
+
+    def test_fields_serialise_roundtrip(self) -> None:
+        from parser_service.parsing.models import ParsedGame
+
+        g = ParsedGame(
+            game_number=1,
+            on_play=True,
+            play_first="Alice",
+            opening_hand_sizes={"Alice": 7, "Bob": 6},
+        )
+        data = g.model_dump()
+        restored = ParsedGame(**data)
+        assert restored.on_play is True
+        assert restored.play_first == "Alice"
+        assert restored.opening_hand_sizes == {"Alice": 7, "Bob": 6}

--- a/services/web/tests/test_admin_invites_routes.py
+++ b/services/web/tests/test_admin_invites_routes.py
@@ -212,7 +212,9 @@ async def test_post_create_invite_renders_plaintext_and_invite_url(
     plaintext = "test-plaintext-tok-abc"
     invite_id = str(uuid.uuid4())
 
-    async def fake_create(_url: str, _token: str, _hours: int) -> auth_client.CreatedInvite:
+    async def fake_create(
+        _url: str, _token: str, _hours: int, **_kw: Any
+    ) -> auth_client.CreatedInvite:
         return auth_client.CreatedInvite(
             id=invite_id,
             token=plaintext,

--- a/services/web/tests/test_admin_invites_routes.py
+++ b/services/web/tests/test_admin_invites_routes.py
@@ -77,6 +77,8 @@ def _sample_invite_item() -> Any:
         created_by_email="admin@local",
         created_at=datetime.now(UTC) - timedelta(hours=2),
         expires_at=datetime.now(UTC) + timedelta(hours=166),
+        max_uses=1,
+        use_count=0,
     )
 
 

--- a/services/web/tests/test_admin_invites_routes.py
+++ b/services/web/tests/test_admin_invites_routes.py
@@ -213,7 +213,7 @@ async def test_post_create_invite_renders_plaintext_and_invite_url(
     invite_id = str(uuid.uuid4())
 
     async def fake_create(
-        _url: str, _token: str, _hours: int, **_kw: Any
+        _url: str, _token: str, _hours: int, _max_uses: int = 1, **_kw: Any
     ) -> auth_client.CreatedInvite:
         return auth_client.CreatedInvite(
             id=invite_id,

--- a/services/web/tests/test_dashboard_stats.py
+++ b/services/web/tests/test_dashboard_stats.py
@@ -150,10 +150,58 @@ async def test_dashboard_renders_with_stats(
             per_page=20,
         )
 
+    async def fake_play_draw(_url: str, _token: str) -> Any:
+        return analytics_client.PlayDrawStats(
+            on_play_matches=10,
+            on_play_wins=6,
+            on_play_win_rate=60.0,
+            on_draw_matches=8,
+            on_draw_wins=3,
+            on_draw_win_rate=37.5,
+        )
+
+    async def fake_preboard(_url: str, _token: str) -> Any:
+        return analytics_client.PreboardPostboardStats(
+            game1_matches=10,
+            game1_wins=5,
+            game1_win_rate=50.0,
+            games23_matches=8,
+            games23_wins=4,
+            games23_win_rate=50.0,
+        )
+
+    async def fake_mulligan(_url: str, _token: str) -> Any:
+        return analytics_client.MulliganStats(
+            buckets=[
+                analytics_client.MulliganBucket(hand_size=7, games=12, wins=8, win_rate=66.7),
+                analytics_client.MulliganBucket(hand_size=6, games=4, wins=2, win_rate=50.0),
+            ]
+        )
+
+    async def fake_card_stats(_url: str, _token: str, **_kw: Any) -> Any:
+        return analytics_client.CardStatsResponse(
+            cards=[
+                analytics_client.CardStatItem(
+                    card_name="Lightning Bolt",
+                    games=10,
+                    wins=7,
+                    win_rate=70.0,
+                    avg_cast_turn=2.3,
+                ),
+            ],
+            total=1,
+            page=1,
+            per_page=20,
+        )
+
     monkeypatch.setattr(analytics_client, "get_stats_summary", fake_summary)
     monkeypatch.setattr(analytics_client, "get_stats_by_format", fake_format)
     monkeypatch.setattr(analytics_client, "get_stats_by_opponent", fake_opponent)
     monkeypatch.setattr(analytics_client, "get_match_list", fake_match_list)
+    monkeypatch.setattr(analytics_client, "get_play_draw_stats", fake_play_draw)
+    monkeypatch.setattr(analytics_client, "get_preboard_postboard_stats", fake_preboard)
+    monkeypatch.setattr(analytics_client, "get_mulligan_stats", fake_mulligan)
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_card_stats)
 
     _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
     try:
@@ -174,6 +222,13 @@ async def test_dashboard_renders_with_stats(
     assert "By opponent" in text
     # No error banner
     assert "Stats unavailable" not in text
+    # v0.9.0 analytics widgets
+    assert "Play/Draw Split" in text
+    assert "On Play" in text
+    assert "Pre-board vs Post-board" in text
+    assert "Mulligan Analysis" in text
+    assert "Card Performance" in text
+    assert "Lightning Bolt" in text
 
 
 @pytest.mark.asyncio
@@ -197,10 +252,17 @@ async def test_dashboard_empty_state_no_matches(
     async def fake_match_list(_url: str, _token: str, **_kw: Any) -> Any:
         return analytics_client.MatchListResponse(matches=[], total=0, page=1, per_page=20)
 
+    async def fake_none(*_a: Any, **_kw: Any) -> None:
+        raise analytics_client.AnalyticsClientError("no data")
+
     monkeypatch.setattr(analytics_client, "get_stats_summary", fake_summary)
     monkeypatch.setattr(analytics_client, "get_stats_by_format", fake_format)
     monkeypatch.setattr(analytics_client, "get_stats_by_opponent", fake_opponent)
     monkeypatch.setattr(analytics_client, "get_match_list", fake_match_list)
+    monkeypatch.setattr(analytics_client, "get_play_draw_stats", fake_none)
+    monkeypatch.setattr(analytics_client, "get_preboard_postboard_stats", fake_none)
+    monkeypatch.setattr(analytics_client, "get_mulligan_stats", fake_none)
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_none)
 
     _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
     try:
@@ -213,6 +275,8 @@ async def test_dashboard_empty_state_no_matches(
     # No breakdown sections
     assert "By format" not in r.text
     assert "By opponent" not in r.text
+    # v0.9.0 widgets also not shown when analytics unavailable
+    assert "Play/Draw Split" not in r.text
 
 
 @pytest.mark.asyncio
@@ -231,6 +295,10 @@ async def test_dashboard_renders_error_banner_on_analytics_failure(
     monkeypatch.setattr(analytics_client, "get_stats_by_format", boom)
     monkeypatch.setattr(analytics_client, "get_stats_by_opponent", boom)
     monkeypatch.setattr(analytics_client, "get_match_list", boom)
+    monkeypatch.setattr(analytics_client, "get_play_draw_stats", boom)
+    monkeypatch.setattr(analytics_client, "get_preboard_postboard_stats", boom)
+    monkeypatch.setattr(analytics_client, "get_mulligan_stats", boom)
+    monkeypatch.setattr(analytics_client, "get_card_stats", boom)
 
     _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
     try:

--- a/services/web/tests/test_match_detail_route.py
+++ b/services/web/tests/test_match_detail_route.py
@@ -205,3 +205,149 @@ async def test_match_detail_unauth_redirects_to_login(app_client: httpx.AsyncCli
     r = await app_client.get(f"/matches/{uuid.uuid4()}")
     assert r.status_code == 302
     assert r.headers["location"].startswith("/login")
+
+
+# ---------------------------------------------------------------------------
+# Turn viewer HTMX partial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_turn_viewer_renders_turns(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    match_id = str(uuid.uuid4())
+
+    async def fake_turns(_url: str, _token: str, _mid: str, _gn: int) -> Any:
+        return analytics_client.GameTurnsResponse(
+            match_id=match_id,
+            game_number=1,
+            turns=[
+                analytics_client.TurnData(
+                    turn_number=1,
+                    active_player="alice",
+                    player_states=[
+                        analytics_client.PlayerTurnState(
+                            player="alice",
+                            life=20,
+                            zones=analytics_client.ZoneState(
+                                battlefield=["Mountain"],
+                                hand=["Lightning Bolt"],
+                            ),
+                        ),
+                        analytics_client.PlayerTurnState(
+                            player="bob",
+                            life=20,
+                        ),
+                    ],
+                ),
+                analytics_client.TurnData(
+                    turn_number=2,
+                    active_player="bob",
+                    player_states=[
+                        analytics_client.PlayerTurnState(player="alice", life=20),
+                        analytics_client.PlayerTurnState(player="bob", life=17),
+                    ],
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(analytics_client, "get_game_turns", fake_turns)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(f"/matches/{match_id}/games/1/turns")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    text = r.text
+    # Partial — no full HTML doc
+    assert "<!DOCTYPE" not in text
+    # Contains turn data
+    assert "alice" in text
+    assert "bob" in text
+    assert "Mountain" in text
+    assert "Lightning Bolt" in text
+
+
+@pytest.mark.asyncio
+async def test_turn_viewer_empty_turns(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    match_id = str(uuid.uuid4())
+
+    async def fake_turns(_url: str, _token: str, _mid: str, _gn: int) -> Any:
+        return analytics_client.GameTurnsResponse(
+            match_id=match_id,
+            game_number=1,
+            turns=[],
+        )
+
+    monkeypatch.setattr(analytics_client, "get_game_turns", fake_turns)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(f"/matches/{match_id}/games/1/turns")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "No turn data available" in r.text
+
+
+@pytest.mark.asyncio
+async def test_turn_viewer_503_when_analytics_unavailable(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def boom(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("simulated outage")
+
+    monkeypatch.setattr(analytics_client, "get_game_turns", boom)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(f"/matches/{uuid.uuid4()}/games/1/turns")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 503
+    assert "Turn data unavailable" in r.text
+
+
+@pytest.mark.asyncio
+async def test_turn_viewer_unauth_returns_401(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def forbidden(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsForbidden("expired")
+
+    monkeypatch.setattr(analytics_client, "get_game_turns", forbidden)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(f"/matches/{uuid.uuid4()}/games/1/turns")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 401

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -790,15 +790,19 @@ async def get_mulligan_stats(base_url: str, token: str) -> MulliganStats:
         raise AnalyticsClientError(
             f"analytics GET /stats/mulligans returned {resp.status_code}: {resp.text}"
         )
-    d = resp.json()
+    # The analytics endpoint returns a bare JSON array of MulliganBucket
+    # objects (not wrapped in {"buckets": [...]}). Each bucket uses
+    # "total" for the game count, which we map to our client's "games".
+    raw = resp.json()
+    items: list[dict] = raw if isinstance(raw, list) else raw.get("buckets", [])
     buckets = [
         MulliganBucket(
             hand_size=int(b.get("hand_size") or 0),
-            games=int(b.get("games") or 0),
+            games=int(b.get("total") or b.get("games") or 0),
             wins=int(b.get("wins") or 0),
             win_rate=float(b.get("win_rate") or 0.0),
         )
-        for b in d.get("buckets", [])
+        for b in items
     ]
     return MulliganStats(buckets=buckets)
 
@@ -965,7 +969,7 @@ async def get_game_turns(
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(
-                f"{base_url}/analytics/matches/{match_id}/games/{game_number}/turns",
+                f"{base_url}/analytics/stats/matches/{match_id}/games/{game_number}/turns",
                 headers={"Authorization": f"Bearer {token}"},
             )
     except httpx.HTTPError as exc:

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -467,6 +467,9 @@ class GameItem:
     game_number: int
     winner: str | None
     turns: int | None
+    on_play: bool | None = None
+    play_first: str | None = None
+    opening_hand_sizes: dict[str, int] | None = None
 
 
 @dataclass
@@ -480,10 +483,14 @@ class MatchDetail:
 
 def _to_game(payload: dict[str, Any]) -> GameItem:
     raw_turns = payload.get("turns")
+    raw_hand_sizes = payload.get("opening_hand_sizes")
     return GameItem(
         game_number=int(payload.get("game_number") or 0),
         winner=payload.get("winner"),
         turns=int(raw_turns) if raw_turns is not None else None,
+        on_play=payload.get("on_play"),
+        play_first=payload.get("play_first"),
+        opening_hand_sizes=dict(raw_hand_sizes) if raw_hand_sizes else None,
     )
 
 
@@ -668,3 +675,315 @@ async def get_stats_by_opponent(base_url: str, token: str) -> list[OpponentStatI
             f"analytics GET /stats/by-opponent returned {resp.status_code}: {resp.text}"
         )
     return [_to_opponent_stat(row) for row in resp.json()]
+
+
+# ---------------------------------------------------------------------------
+# v0.9.0 — game-level analytics
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PlayDrawStats:
+    on_play_matches: int
+    on_play_wins: int
+    on_play_win_rate: float
+    on_draw_matches: int
+    on_draw_wins: int
+    on_draw_win_rate: float
+
+
+async def get_play_draw_stats(base_url: str, token: str) -> PlayDrawStats:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/stats/play-draw",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/play-draw transport error: {exc}"
+        ) from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /stats/play-draw returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/play-draw returned {resp.status_code}: {resp.text}"
+        )
+    d = resp.json()
+    return PlayDrawStats(
+        on_play_matches=int(d.get("on_play_matches") or 0),
+        on_play_wins=int(d.get("on_play_wins") or 0),
+        on_play_win_rate=float(d.get("on_play_win_rate") or 0.0),
+        on_draw_matches=int(d.get("on_draw_matches") or 0),
+        on_draw_wins=int(d.get("on_draw_wins") or 0),
+        on_draw_win_rate=float(d.get("on_draw_win_rate") or 0.0),
+    )
+
+
+@dataclass
+class PreboardPostboardStats:
+    game1_matches: int
+    game1_wins: int
+    game1_win_rate: float
+    games23_matches: int
+    games23_wins: int
+    games23_win_rate: float
+
+
+async def get_preboard_postboard_stats(base_url: str, token: str) -> PreboardPostboardStats:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/stats/preboard-postboard",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/preboard-postboard transport error: {exc}"
+        ) from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(
+            f"analytics GET /stats/preboard-postboard returned {resp.status_code}"
+        )
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/preboard-postboard returned {resp.status_code}: {resp.text}"
+        )
+    d = resp.json()
+    return PreboardPostboardStats(
+        game1_matches=int(d.get("game1_matches") or 0),
+        game1_wins=int(d.get("game1_wins") or 0),
+        game1_win_rate=float(d.get("game1_win_rate") or 0.0),
+        games23_matches=int(d.get("games23_matches") or 0),
+        games23_wins=int(d.get("games23_wins") or 0),
+        games23_win_rate=float(d.get("games23_win_rate") or 0.0),
+    )
+
+
+@dataclass
+class MulliganBucket:
+    hand_size: int
+    games: int
+    wins: int
+    win_rate: float
+
+
+@dataclass
+class MulliganStats:
+    buckets: list[MulliganBucket]
+
+
+async def get_mulligan_stats(base_url: str, token: str) -> MulliganStats:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/stats/mulligans",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/mulligans transport error: {exc}"
+        ) from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /stats/mulligans returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/mulligans returned {resp.status_code}: {resp.text}"
+        )
+    d = resp.json()
+    buckets = [
+        MulliganBucket(
+            hand_size=int(b.get("hand_size") or 0),
+            games=int(b.get("games") or 0),
+            wins=int(b.get("wins") or 0),
+            win_rate=float(b.get("win_rate") or 0.0),
+        )
+        for b in d.get("buckets", [])
+    ]
+    return MulliganStats(buckets=buckets)
+
+
+@dataclass
+class GameLengthStats:
+    buckets: list[dict[str, Any]]
+
+
+async def get_game_length_stats(base_url: str, token: str) -> GameLengthStats:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/stats/game-length",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/game-length transport error: {exc}"
+        ) from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /stats/game-length returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/game-length returned {resp.status_code}: {resp.text}"
+        )
+    d = resp.json()
+    return GameLengthStats(buckets=d.get("buckets", []))
+
+
+@dataclass
+class CardStatItem:
+    card_name: str
+    games: int
+    wins: int
+    win_rate: float
+    avg_cast_turn: float | None
+
+
+@dataclass
+class CardStatsResponse:
+    cards: list[CardStatItem]
+    total: int
+    page: int
+    per_page: int
+
+
+async def get_card_stats(
+    base_url: str,
+    token: str,
+    *,
+    page: int = 1,
+    per_page: int = 20,
+    sort_by: str = "games",
+) -> CardStatsResponse:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/stats/cards",
+                params={"page": page, "per_page": per_page, "sort_by": sort_by},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(f"analytics GET /stats/cards transport error: {exc}") from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /stats/cards returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /stats/cards returned {resp.status_code}: {resp.text}"
+        )
+    d = resp.json()
+    cards = [
+        CardStatItem(
+            card_name=str(c.get("card_name") or ""),
+            games=int(c.get("games") or 0),
+            wins=int(c.get("wins") or 0),
+            win_rate=float(c.get("win_rate") or 0.0),
+            avg_cast_turn=float(c["avg_cast_turn"]) if c.get("avg_cast_turn") is not None else None,
+        )
+        for c in d.get("cards", [])
+    ]
+    return CardStatsResponse(
+        cards=cards,
+        total=int(d.get("total") or 0),
+        page=int(d.get("page") or 1),
+        per_page=int(d.get("per_page") or 20),
+    )
+
+
+# ---------------------------------------------------------------------------
+# v0.9.0 — turn viewer
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ZoneState:
+    battlefield: list[str] = field(default_factory=list)
+    hand: list[str] = field(default_factory=list)
+    graveyard: list[str] = field(default_factory=list)
+    exile: list[str] = field(default_factory=list)
+    library_count: int | None = None
+
+
+@dataclass
+class PlayerTurnState:
+    player: str
+    life: int | None = None
+    zones: ZoneState | None = None
+
+
+@dataclass
+class TurnData:
+    turn_number: int
+    active_player: str | None
+    player_states: list[PlayerTurnState] = field(default_factory=list)
+    stack: list[str] = field(default_factory=list)
+
+
+@dataclass
+class GameTurnsResponse:
+    match_id: str
+    game_number: int
+    turns: list[TurnData] = field(default_factory=list)
+
+
+def _to_zone_state(payload: dict[str, Any] | None) -> ZoneState | None:
+    if not payload:
+        return None
+    return ZoneState(
+        battlefield=list(payload.get("battlefield") or []),
+        hand=list(payload.get("hand") or []),
+        graveyard=list(payload.get("graveyard") or []),
+        exile=list(payload.get("exile") or []),
+        library_count=(
+            int(payload["library_count"]) if payload.get("library_count") is not None else None
+        ),
+    )
+
+
+def _to_player_turn_state(payload: dict[str, Any]) -> PlayerTurnState:
+    raw_life = payload.get("life")
+    return PlayerTurnState(
+        player=str(payload.get("player") or ""),
+        life=int(raw_life) if raw_life is not None else None,
+        zones=_to_zone_state(payload.get("zones")),
+    )
+
+
+def _to_turn(payload: dict[str, Any]) -> TurnData:
+    return TurnData(
+        turn_number=int(payload.get("turn_number") or 0),
+        active_player=payload.get("active_player"),
+        player_states=[_to_player_turn_state(ps) for ps in payload.get("player_states", [])],
+        stack=list(payload.get("stack") or []),
+    )
+
+
+async def get_game_turns(
+    base_url: str,
+    token: str,
+    match_id: str,
+    game_number: int,
+) -> GameTurnsResponse:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/matches/{match_id}/games/{game_number}/turns",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /matches/{{id}}/games/{{n}}/turns transport error: {exc}"
+        ) from exc
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(
+            f"analytics GET /matches/{{id}}/games/{{n}}/turns returned {resp.status_code}"
+        )
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /matches/{{id}}/games/{{n}}/turns "
+            f"returned {resp.status_code}: {resp.text}"
+        )
+    d = resp.json()
+    return GameTurnsResponse(
+        match_id=str(d.get("match_id") or match_id),
+        game_number=int(d.get("game_number") or game_number),
+        turns=[_to_turn(t) for t in d.get("turns", [])],
+    )

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -832,3 +832,88 @@ async def admin_reset_password(
     raise AuthClientError(
         f"auth /admin/users reset-password returned {resp.status_code}: {resp.text}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tunables — admin-configurable runtime parameters
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TunablesResult:
+    backfill_batch_size: int
+    backfill_interval_seconds: int
+    scryfall_sync_interval_days: int
+    mtgo_scraper_interval_hours: int
+    reparse_min_version: str
+    min_agent_version: str
+    parser_version: str
+
+
+async def admin_get_tunables(base_url: str, token: str) -> TunablesResult:
+    """Admin-only: read all tunables (mutable + read-only constants)."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/admin/settings/tunables",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AuthClientError(f"auth GET /admin/settings/tunables transport error: {exc}") from exc
+    if resp.status_code in (401, 403):
+        raise AuthForbidden(f"auth GET /admin/settings/tunables returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AuthClientError(
+            f"auth GET /admin/settings/tunables returned {resp.status_code}: {resp.text}"
+        )
+    data = resp.json()
+    return TunablesResult(
+        backfill_batch_size=int(data["backfill_batch_size"]),
+        backfill_interval_seconds=int(data["backfill_interval_seconds"]),
+        scryfall_sync_interval_days=int(data["scryfall_sync_interval_days"]),
+        mtgo_scraper_interval_hours=int(data["mtgo_scraper_interval_hours"]),
+        reparse_min_version=str(data["reparse_min_version"]),
+        min_agent_version=str(data["min_agent_version"]),
+        parser_version=str(data["parser_version"]),
+    )
+
+
+async def admin_update_tunables(
+    base_url: str,
+    token: str,
+    updates: dict[str, int],
+) -> tuple[TunablesResult | None, str | None]:
+    """Admin-only: patch mutable tunables. Returns (result, error_code).
+
+    - 200 -> (TunablesResult, None)
+    - 422 -> (None, "validation_error")
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.patch(
+                f"{base_url}/admin/settings/tunables",
+                headers={"Authorization": f"Bearer {token}"},
+                json=updates,
+            )
+    except httpx.HTTPError as exc:
+        raise AuthClientError(
+            f"auth PATCH /admin/settings/tunables transport error: {exc}"
+        ) from exc
+    if resp.status_code == 200:
+        data = resp.json()
+        return TunablesResult(
+            backfill_batch_size=int(data["backfill_batch_size"]),
+            backfill_interval_seconds=int(data["backfill_interval_seconds"]),
+            scryfall_sync_interval_days=int(data["scryfall_sync_interval_days"]),
+            mtgo_scraper_interval_hours=int(data["mtgo_scraper_interval_hours"]),
+            reparse_min_version=str(data["reparse_min_version"]),
+            min_agent_version=str(data["min_agent_version"]),
+            parser_version=str(data["parser_version"]),
+        ), None
+    if resp.status_code in (401, 403):
+        raise AuthForbidden(f"auth PATCH /admin/settings/tunables returned {resp.status_code}")
+    if resp.status_code in (400, 422):
+        return None, "validation_error"
+    raise AuthClientError(
+        f"auth PATCH /admin/settings/tunables returned {resp.status_code}: {resp.text}"
+    )

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -638,6 +638,8 @@ class InviteItem:
     created_by_email: str | None
     created_at: datetime | None
     expires_at: datetime | None
+    max_uses: int | None = None
+    use_count: int = 0
 
 
 @dataclass
@@ -646,12 +648,14 @@ class CreatedInvite:
     token: str
     expires_at: datetime | None
     created_at: datetime | None
+    max_uses: int | None = None
 
 
 async def admin_create_invite(
     base_url: str,
     token: str,
     expires_in_hours: int,
+    max_uses: int | None = 1,
 ) -> CreatedInvite:
     """Admin-only: mint a new invite token.
 
@@ -660,12 +664,17 @@ async def admin_create_invite(
     form already constrains the input, so a 422 here is unexpected and
     deserves to bubble up.
     """
+    payload: dict[str, Any] = {"expires_in_hours": expires_in_hours}
+    if max_uses is not None:
+        payload["max_uses"] = max_uses
+    else:
+        payload["max_uses"] = None
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.post(
                 f"{base_url}/admin/invites",
                 headers={"Authorization": f"Bearer {token}"},
-                json={"expires_in_hours": expires_in_hours},
+                json=payload,
             )
     except httpx.HTTPError as exc:
         raise AuthClientError(f"auth POST /admin/invites transport error: {exc}") from exc
@@ -679,6 +688,7 @@ async def admin_create_invite(
         token=str(data["token"]),
         expires_at=_parse_dt(data.get("expires_at")),
         created_at=_parse_dt(data.get("created_at")),
+        max_uses=data.get("max_uses"),
     )
 
 
@@ -712,6 +722,8 @@ async def admin_list_invites(
             created_by_email=i.get("created_by_email"),
             created_at=_parse_dt(i.get("created_at")),
             expires_at=_parse_dt(i.get("expires_at")),
+            max_uses=i.get("max_uses"),
+            use_count=int(i.get("use_count", 0)),
         )
         for i in data.get("invites", [])
     ]

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -655,7 +655,7 @@ async def admin_create_invite(
     base_url: str,
     token: str,
     expires_in_hours: int,
-    max_uses: int | None = 1,
+    max_uses: int = 1,
 ) -> CreatedInvite:
     """Admin-only: mint a new invite token.
 
@@ -664,11 +664,7 @@ async def admin_create_invite(
     form already constrains the input, so a 422 here is unexpected and
     deserves to bubble up.
     """
-    payload: dict[str, Any] = {"expires_in_hours": expires_in_hours}
-    if max_uses is not None:
-        payload["max_uses"] = max_uses
-    else:
-        payload["max_uses"] = None
+    payload: dict[str, Any] = {"expires_in_hours": expires_in_hours, "max_uses": max_uses}
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.post(

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -1846,6 +1846,7 @@ async def admin_invites_list(
 async def admin_invites_create(
     request: Request,
     expires_in_hours: Annotated[int, Form(ge=1, le=_INVITE_MAX_EXPIRES_HOURS)],
+    max_uses: Annotated[int | None, Form()] = 1,
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
     page: Annotated[int, Query(ge=1)] = 1,
@@ -1858,9 +1859,12 @@ async def admin_invites_create(
     if blocked is not None:
         return blocked
 
+    # Treat 0 or empty as unlimited (NULL).
+    effective_max_uses = max_uses if max_uses and max_uses > 0 else None
+
     try:
         created = await auth_client.admin_create_invite(
-            settings.auth_service_url, user.token, expires_in_hours
+            settings.auth_service_url, user.token, expires_in_hours, effective_max_uses
         )
     except auth_client.AuthForbidden:
         _log.info("admin.invites.create.forbidden", extra={"user_id": user.user_id})

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -8,6 +8,7 @@ independent and coexist in the compose stack.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import uuid
@@ -1546,9 +1547,7 @@ async def admin_settings(
             error = "Authentication service unavailable. Please try again."
 
     code = (
-        status.HTTP_503_SERVICE_UNAVAILABLE
-        if error and mode is None and tunables is None
-        else 200
+        status.HTTP_503_SERVICE_UNAVAILABLE if error and mode is None and tunables is None else 200
     )
     return _render_admin_settings(
         request,
@@ -1626,6 +1625,68 @@ async def admin_settings_registration_mode(
         error=message,
         saved=False,
         status_code=code,
+    )
+
+
+@app.post("/admin/settings/tunables")
+async def admin_settings_tunables(
+    request: Request,
+    backfill_batch_size: Annotated[int, Form()],
+    backfill_interval_seconds: Annotated[int, Form()],
+    scryfall_sync_interval_days: Annotated[int, Form()],
+    mtgo_scraper_interval_hours: Annotated[int, Form()],
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    updates = {
+        "backfill_batch_size": backfill_batch_size,
+        "backfill_interval_seconds": backfill_interval_seconds,
+        "scryfall_sync_interval_days": scryfall_sync_interval_days,
+        "mtgo_scraper_interval_hours": mtgo_scraper_interval_hours,
+    }
+
+    try:
+        result, err = await auth_client.admin_update_tunables(
+            settings.auth_service_url, user.token, updates
+        )
+    except auth_client.AuthForbidden:
+        _log.info("admin.settings.tunables.put.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except auth_client.AuthClientError:
+        _log.exception("auth PATCH /admin/settings/tunables call failed")
+        return Response(
+            content="Authentication service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if result is not None:
+        return RedirectResponse(
+            url="/admin/settings?tunables_saved=1", status_code=status.HTTP_303_SEE_OTHER
+        )
+
+    # Inline error — re-fetch state for the page.  Best-effort:
+    # swallowing here is correct because the original mutation error is
+    # what we want to surface; list context underneath is nice-to-have.
+    mode: auth_client.RegistrationMode | None = None
+    tunables: auth_client.TunablesResult | None = None
+    with contextlib.suppress(auth_client.AuthForbidden, auth_client.AuthClientError):
+        mode = await auth_client.admin_get_registration_mode(settings.auth_service_url, user.token)
+    with contextlib.suppress(auth_client.AuthForbidden, auth_client.AuthClientError):
+        tunables = await auth_client.admin_get_tunables(settings.auth_service_url, user.token)
+
+    return _render_admin_settings(
+        request,
+        user,
+        mode=mode,
+        tunables=tunables,
+        error=None,
+        saved=False,
+        tunables_error="Invalid tunable values. Check ranges and try again.",
+        status_code=status.HTTP_400_BAD_REQUEST,
     )
 
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -1859,8 +1859,8 @@ async def admin_invites_create(
     if blocked is not None:
         return blocked
 
-    # Treat 0 or empty as unlimited (NULL).
-    effective_max_uses = max_uses if max_uses and max_uses > 0 else None
+    # Treat 0 or empty as unlimited (0 in the API).
+    effective_max_uses = max_uses if max_uses and max_uses > 0 else 0
 
     try:
         created = await auth_client.admin_create_invite(

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -239,6 +239,10 @@ async def dashboard(
     opponent_stats: list[Any] = []
     match_list: Any = None
     stats_error = False
+    play_draw_stats: Any = None
+    preboard_postboard_stats: Any = None
+    mulligan_stats: Any = None
+    card_stats: Any = None
     try:
         stats_summary = await analytics_client.get_stats_summary(
             settings.analytics_service_url, user.token
@@ -266,6 +270,36 @@ async def dashboard(
     except analytics_client.AnalyticsClientError:
         _log.exception("analytics stats call failed; rendering dashboard with error banner")
         stats_error = True
+
+    # v0.9.0 analytics widgets — each is independent so a failure in
+    # one doesn't block the others or the main dashboard.
+    try:
+        play_draw_stats = await analytics_client.get_play_draw_stats(
+            settings.analytics_service_url, user.token
+        )
+    except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
+        _log.debug("play/draw stats unavailable")
+
+    try:
+        preboard_postboard_stats = await analytics_client.get_preboard_postboard_stats(
+            settings.analytics_service_url, user.token
+        )
+    except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
+        _log.debug("preboard/postboard stats unavailable")
+
+    try:
+        mulligan_stats = await analytics_client.get_mulligan_stats(
+            settings.analytics_service_url, user.token
+        )
+    except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
+        _log.debug("mulligan stats unavailable")
+
+    try:
+        card_stats = await analytics_client.get_card_stats(
+            settings.analytics_service_url, user.token, per_page=20, sort_by="games"
+        )
+    except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
+        _log.debug("card stats unavailable")
 
     # Filters dict to persist across pagination
     filters = {
@@ -304,6 +338,10 @@ async def dashboard(
             "per_page": per_page,
             "filters": filters,
             "filter_qs": filter_qs,
+            "play_draw_stats": play_draw_stats,
+            "preboard_postboard_stats": preboard_postboard_stats,
+            "mulligan_stats": mulligan_stats,
+            "card_stats": card_stats,
         },
     )
 
@@ -831,6 +869,39 @@ async def match_detail_page(
                 "Cube",
             ],
         },
+    )
+
+
+@app.get("/matches/{match_id}/games/{game_number}/turns", response_class=HTMLResponse)
+async def match_game_turns(
+    match_id: uuid.UUID,
+    game_number: int,
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    """HTMX partial: per-game turn-by-turn state viewer."""
+    try:
+        turns_data = await analytics_client.get_game_turns(
+            settings.analytics_service_url,
+            user.token,
+            str(match_id),
+            game_number,
+        )
+    except analytics_client.AnalyticsForbidden:
+        return HTMLResponse("<p>Session expired. Please reload the page.</p>", status_code=401)
+    except analytics_client.AnalyticsClientError:
+        _log.exception(
+            "analytics GET /matches/%s/games/%s/turns call failed", match_id, game_number
+        )
+        return HTMLResponse(
+            "<p>Turn data unavailable — analytics service could not be reached.</p>",
+            status_code=503,
+        )
+    return templates.TemplateResponse(
+        request,
+        "_turn_viewer.html",
+        {"turns_data": turns_data},
     )
 
 
@@ -1414,8 +1485,11 @@ def _render_admin_settings(
     user: BrowserUser,
     *,
     mode: auth_client.RegistrationMode | None,
+    tunables: auth_client.TunablesResult | None = None,
     error: str | None,
     saved: bool,
+    tunables_saved: bool = False,
+    tunables_error: str | None = None,
     status_code: int,
 ) -> Response:
     return templates.TemplateResponse(
@@ -1424,10 +1498,13 @@ def _render_admin_settings(
         {
             "user": user,
             "mode": mode,
+            "tunables": tunables,
             "is_root_admin": user.user_id == _ROOT_ADMIN_USER_ID,
             "lock_tooltip": _REGISTRATION_MODE_LOCK_TOOLTIP,
             "error": error,
             "saved": saved,
+            "tunables_saved": tunables_saved,
+            "tunables_error": tunables_error,
         },
         status_code=status_code,
     )
@@ -1439,10 +1516,15 @@ async def admin_settings(
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
     saved: Annotated[int, Query(ge=0, le=1)] = 0,
+    tunables_saved: Annotated[int, Query(ge=0, le=1)] = 0,
 ) -> Response:
     blocked = _require_admin_or_403(request, user)
     if blocked is not None:
         return blocked
+
+    mode: auth_client.RegistrationMode | None = None
+    tunables: auth_client.TunablesResult | None = None
+    error: str | None = None
 
     try:
         mode = await auth_client.admin_get_registration_mode(settings.auth_service_url, user.token)
@@ -1451,21 +1533,32 @@ async def admin_settings(
         return _admin_forbidden(request, user)
     except auth_client.AuthClientError:
         _log.exception("auth /admin/settings/registration-mode call failed")
-        return _render_admin_settings(
-            request,
-            user,
-            mode=None,
-            error="Authentication service unavailable. Please try again.",
-            saved=False,
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-        )
+        error = "Authentication service unavailable. Please try again."
+
+    try:
+        tunables = await auth_client.admin_get_tunables(settings.auth_service_url, user.token)
+    except auth_client.AuthForbidden:
+        _log.info("admin.settings.tunables.get.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except auth_client.AuthClientError:
+        _log.exception("auth /admin/settings/tunables call failed")
+        if error is None:
+            error = "Authentication service unavailable. Please try again."
+
+    code = (
+        status.HTTP_503_SERVICE_UNAVAILABLE
+        if error and mode is None and tunables is None
+        else 200
+    )
     return _render_admin_settings(
         request,
         user,
         mode=mode,
-        error=None,
+        tunables=tunables,
+        error=error,
         saved=saved == 1,
-        status_code=200,
+        tunables_saved=tunables_saved == 1,
+        status_code=code,
     )
 
 

--- a/services/web/web_service/templates/_turn_viewer.html
+++ b/services/web/web_service/templates/_turn_viewer.html
@@ -1,0 +1,95 @@
+{# HTMX partial — no {% extends %} #}
+{% if not turns_data or not turns_data.turns %}
+<p class="muted" style="padding: 8px 0;">No turn data available for this game.</p>
+{% else %}
+<div class="turn-viewer">
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>Turn</th>
+                <th>Active Player</th>
+                {% for ps in turns_data.turns[0].player_states %}
+                <th>{{ ps.player }} Life</th>
+                {% endfor %}
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for turn in turns_data.turns %}
+            {% set turn_idx = loop.index0 %}
+            <tr>
+                <td>{{ turn.turn_number }}</td>
+                <td>{{ turn.active_player or "—" }}</td>
+                {% for ps in turn.player_states %}
+                <td>
+                    {% if ps.life is not none %}
+                        {% if turn_idx > 0 and loop.index0 < turns_data.turns[turn_idx - 1].player_states|length %}
+                            {% set prev_life = turns_data.turns[turn_idx - 1].player_states[loop.index0].life %}
+                            {% if prev_life is not none and ps.life < prev_life %}
+                                <span style="color: #a4252b; font-weight: 500;">{{ ps.life }}</span>
+                            {% elif prev_life is not none and ps.life > prev_life %}
+                                <span style="color: #155724; font-weight: 500;">{{ ps.life }}</span>
+                            {% else %}
+                                {{ ps.life }}
+                            {% endif %}
+                        {% else %}
+                            {{ ps.life }}
+                        {% endif %}
+                    {% else %}
+                        —
+                    {% endif %}
+                </td>
+                {% endfor %}
+                <td>
+                    <button class="btn btn-secondary btn-sm turn-detail-toggle"
+                            onclick="var el=document.getElementById('turn-detail-{{ turns_data.game_number }}-{{ turn.turn_number }}'); el.style.display = el.style.display === 'none' ? 'table-row' : 'none';">
+                        Details
+                    </button>
+                </td>
+            </tr>
+            <tr id="turn-detail-{{ turns_data.game_number }}-{{ turn.turn_number }}" style="display: none;">
+                <td colspan="{{ 3 + turn.player_states|length }}" style="background: #f9fafb; padding: 12px;">
+                    {% for ps in turn.player_states %}
+                    <div style="margin-bottom: 8px;">
+                        <strong>{{ ps.player }}</strong>
+                        {% if ps.zones %}
+                        <ul style="list-style: none; padding-left: 12px; margin: 4px 0;">
+                            {% if ps.zones.hand %}
+                            <li><strong>Hand:</strong> {{ ps.zones.hand|join(", ") }}</li>
+                            {% endif %}
+                            {% if ps.zones.battlefield %}
+                            <li><strong>Battlefield:</strong> {{ ps.zones.battlefield|join(", ") }}</li>
+                            {% endif %}
+                            {% if ps.zones.graveyard %}
+                            <li><strong>Graveyard:</strong> {{ ps.zones.graveyard|join(", ") }}</li>
+                            {% endif %}
+                            {% if ps.zones.exile %}
+                            <li><strong>Exile:</strong> {{ ps.zones.exile|join(", ") }}</li>
+                            {% endif %}
+                        </ul>
+                        {% else %}
+                        <span class="muted"> — no zone data</span>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
+                    {% if turn.stack %}
+                    <div>
+                        <strong>Stack:</strong> {{ turn.stack|join(", ") }}
+                    </div>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <p class="muted" style="font-size: 11px; margin-top: 4px;">
+        Life totals are best-effort for .dat files (tracks payments only, not combat damage).
+    </p>
+</div>
+{% endif %}
+
+<style>
+.turn-viewer { padding: 8px 0; }
+.turn-detail-toggle { cursor: pointer; }
+.btn-sm { padding: 4px 8px; font-size: 12px; }
+</style>

--- a/services/web/web_service/templates/admin_invites.html
+++ b/services/web/web_service/templates/admin_invites.html
@@ -43,6 +43,11 @@
             <input type="number" name="expires_in_hours"
                    value="{{ default_hours }}" min="1" max="{{ max_hours }}" required>
         </label>
+        <label class="field">
+            <span>Max uses (0 = unlimited)</span>
+            <input type="number" name="max_uses"
+                   value="1" min="0" max="10000">
+        </label>
         <button type="submit" class="btn btn-primary">Create invite</button>
     </form>
 
@@ -57,6 +62,7 @@
                     <th>Created by</th>
                     <th>Created</th>
                     <th>Age</th>
+                    <th>Uses</th>
                     <th>Expires</th>
                     <th>Actions</th>
                 </tr>
@@ -68,6 +74,7 @@
                     <td>{{ i.created_by_email or "—" }}</td>
                     <td>{{ i.created_at.strftime("%Y-%m-%d %H:%M") if i.created_at else "—" }}</td>
                     <td>{{ i.age or "—" }}</td>
+                    <td>{{ i.use_count }} / {{ i.max_uses if i.max_uses is not none else "&#8734;" }}</td>
                     <td>{{ i.expires_at.strftime("%Y-%m-%d %H:%M") if i.expires_at else "—" }}</td>
                     <td>
                         <form method="post"

--- a/services/web/web_service/templates/admin_invites.html
+++ b/services/web/web_service/templates/admin_invites.html
@@ -74,7 +74,7 @@
                     <td>{{ i.created_by_email or "—" }}</td>
                     <td>{{ i.created_at.strftime("%Y-%m-%d %H:%M") if i.created_at else "—" }}</td>
                     <td>{{ i.age or "—" }}</td>
-                    <td>{{ i.use_count }} / {{ i.max_uses if i.max_uses is not none else "&#8734;" }}</td>
+                    <td>{{ i.use_count }} / {{ "&#8734;" if i.max_uses is none or i.max_uses == 0 else i.max_uses }}</td>
                     <td>{{ i.expires_at.strftime("%Y-%m-%d %H:%M") if i.expires_at else "—" }}</td>
                     <td>
                         <form method="post"

--- a/services/web/web_service/templates/admin_settings.html
+++ b/services/web/web_service/templates/admin_settings.html
@@ -64,5 +64,85 @@
             {% endif %}
         </form>
     {% endif %}
+
+    {# ------------------------------------------------------------------ #}
+    {# System tunables                                                     #}
+    {# ------------------------------------------------------------------ #}
+
+    <hr>
+
+    {% if tunables_saved %}
+    <div class="alert alert-info" role="status">System tunables updated.</div>
+    {% endif %}
+
+    {% if tunables_error %}
+    <div class="alert alert-error" role="alert">{{ tunables_error }}</div>
+    {% endif %}
+
+    <h2>System tunables</h2>
+    <p class="muted">
+        Configurable runtime parameters for parser and analytics services.
+        Changes take effect on the next service read cycle.
+    </p>
+
+    {% if tunables is none %}
+        <p class="muted">Tunables unavailable.</p>
+    {% else %}
+        <form method="post" action="/admin/settings/tunables" class="tunables-form">
+            <fieldset>
+                <legend>Parser</legend>
+                <label class="field">
+                    <span>Backfill batch size</span>
+                    <input type="number" name="backfill_batch_size"
+                           value="{{ tunables.backfill_batch_size }}"
+                           min="10" max="1000" required>
+                    <small class="muted">Files per scan (10–1000)</small>
+                </label>
+                <label class="field">
+                    <span>Backfill interval (seconds)</span>
+                    <input type="number" name="backfill_interval_seconds"
+                           value="{{ tunables.backfill_interval_seconds }}"
+                           min="60" max="3600" required>
+                    <small class="muted">Seconds between scans (60–3600)</small>
+                </label>
+            </fieldset>
+
+            <fieldset>
+                <legend>Analytics</legend>
+                <label class="field">
+                    <span>Scryfall sync interval (days)</span>
+                    <input type="number" name="scryfall_sync_interval_days"
+                           value="{{ tunables.scryfall_sync_interval_days }}"
+                           min="1" max="30" required>
+                    <small class="muted">Days between Scryfall card syncs (1–30)</small>
+                </label>
+                <label class="field">
+                    <span>MTGO scraper interval (hours)</span>
+                    <input type="number" name="mtgo_scraper_interval_hours"
+                           value="{{ tunables.mtgo_scraper_interval_hours }}"
+                           min="1" max="168" required>
+                    <small class="muted">Hours between MTGO scraper runs (1–168)</small>
+                </label>
+            </fieldset>
+
+            <fieldset>
+                <legend>Version constants (read-only)</legend>
+                <label class="field">
+                    <span>Parser version</span>
+                    <input type="text" value="{{ tunables.parser_version }}" disabled>
+                </label>
+                <label class="field">
+                    <span>Reparse min version</span>
+                    <input type="text" value="{{ tunables.reparse_min_version }}" disabled>
+                </label>
+                <label class="field">
+                    <span>Minimum agent version</span>
+                    <input type="text" value="{{ tunables.min_agent_version }}" disabled>
+                </label>
+            </fieldset>
+
+            <button type="submit" class="btn btn-primary">Save tunables</button>
+        </form>
+    {% endif %}
 </section>
 {% endblock %}

--- a/services/web/web_service/templates/base.html
+++ b/services/web/web_service/templates/base.html
@@ -6,6 +6,7 @@
     <title>{% block title %}Deep Analysis{% endblock %}</title>
     <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/static/style.css">
+    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
 </head>
 <body>
     <header class="site-header">

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -155,6 +155,120 @@
 </section>
 {% endif %}
 
+{% if play_draw_stats %}
+<section class="panel">
+    <h2>Play/Draw Split</h2>
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Games</th>
+                <th>Wins</th>
+                <th>Win Rate</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>On Play</strong></td>
+                <td>{{ play_draw_stats.on_play_matches }}</td>
+                <td>{{ play_draw_stats.on_play_wins }}</td>
+                <td>{{ "%.1f"|format(play_draw_stats.on_play_win_rate) }}%</td>
+            </tr>
+            <tr>
+                <td><strong>On Draw</strong></td>
+                <td>{{ play_draw_stats.on_draw_matches }}</td>
+                <td>{{ play_draw_stats.on_draw_wins }}</td>
+                <td>{{ "%.1f"|format(play_draw_stats.on_draw_win_rate) }}%</td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+{% endif %}
+
+{% if preboard_postboard_stats %}
+<section class="panel">
+    <h2>Pre-board vs Post-board</h2>
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Games</th>
+                <th>Wins</th>
+                <th>Win Rate</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>Game 1 (Pre-board)</strong></td>
+                <td>{{ preboard_postboard_stats.game1_matches }}</td>
+                <td>{{ preboard_postboard_stats.game1_wins }}</td>
+                <td>{{ "%.1f"|format(preboard_postboard_stats.game1_win_rate) }}%</td>
+            </tr>
+            <tr>
+                <td><strong>Games 2-3 (Post-board)</strong></td>
+                <td>{{ preboard_postboard_stats.games23_matches }}</td>
+                <td>{{ preboard_postboard_stats.games23_wins }}</td>
+                <td>{{ "%.1f"|format(preboard_postboard_stats.games23_win_rate) }}%</td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+{% endif %}
+
+{% if mulligan_stats and mulligan_stats.buckets %}
+<section class="panel">
+    <h2>Mulligan Analysis</h2>
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>Hand Size</th>
+                <th>Games</th>
+                <th>Wins</th>
+                <th>Win Rate</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for bucket in mulligan_stats.buckets %}
+            {% if bucket.games > 0 %}
+            <tr>
+                <td>{{ bucket.hand_size }}</td>
+                <td>{{ bucket.games }}</td>
+                <td>{{ bucket.wins }}</td>
+                <td>{{ "%.1f"|format(bucket.win_rate) }}%</td>
+            </tr>
+            {% endif %}
+            {% endfor %}
+        </tbody>
+    </table>
+</section>
+{% endif %}
+
+{% if card_stats and card_stats.cards %}
+<section class="panel">
+    <h2>Card Performance</h2>
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>Card</th>
+                <th>Games</th>
+                <th>Win Rate</th>
+                <th>Avg Cast Turn</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for card in card_stats.cards %}
+            <tr>
+                <td>{{ card.card_name }}</td>
+                <td>{{ card.games }}</td>
+                <td>{{ "%.1f"|format(card.win_rate) }}%</td>
+                <td>{{ "%.1f"|format(card.avg_cast_turn) if card.avg_cast_turn is not none else "—" }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</section>
+{% endif %}
+
 {% if format_stats|default([]) %}
 <section class="panel">
     <h2>By format</h2>

--- a/services/web/web_service/templates/match_detail.html
+++ b/services/web/web_service/templates/match_detail.html
@@ -55,14 +55,43 @@
                     <th>Game #</th>
                     <th>Winner</th>
                     <th>Turns</th>
+                    <th>Opening Hands</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
                 {% for game in match.games %}
                 <tr>
-                    <td>{{ game.game_number }}</td>
+                    <td>
+                        {{ game.game_number }}
+                        {% if game.on_play is true %}
+                            <span class="play-draw-badge play-badge">(On Play)</span>
+                        {% elif game.on_play is false %}
+                            <span class="play-draw-badge draw-badge">(On Draw)</span>
+                        {% endif %}
+                    </td>
                     <td>{{ game.winner or "—" }}</td>
                     <td>{{ game.turns if game.turns is not none else "—" }}</td>
+                    <td>
+                        {% if game.opening_hand_sizes %}
+                            {{ game.opening_hand_sizes.values()|list|join(" vs ") }}
+                        {% else %}
+                            —
+                        {% endif %}
+                    </td>
+                    <td>
+                        <button class="btn btn-secondary btn-sm"
+                            hx-get="/matches/{{ match.match_id }}/games/{{ game.game_number }}/turns"
+                            hx-target="#turns-{{ game.game_number }}"
+                            hx-swap="innerHTML">
+                            Show turns
+                        </button>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="5" style="padding: 0; border: none;">
+                        <div id="turns-{{ game.game_number }}"></div>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -88,5 +117,9 @@
 .result-draw { background: #fff3cd; color: #856404; }
 .inline-form { display: inline; }
 .inline-form select { font-size: inherit; padding: 0.15rem 0.3rem; }
+.play-draw-badge { font-size: 11px; font-weight: 500; margin-left: 4px; }
+.play-badge { color: #155724; }
+.draw-badge { color: #856404; }
+.btn-sm { padding: 4px 8px; font-size: 12px; }
 </style>
 {% endblock %}

--- a/tests/test_route_prefix_convention.py
+++ b/tests/test_route_prefix_convention.py
@@ -76,6 +76,7 @@ _WEB_BROWSER_PATHS = frozenset(
         "/cards",
         "/matches/{match_id}",
         "/matches/{match_id}/format",
+        "/matches/{match_id}/games/{game_number}/turns",
     }
 )
 


### PR DESCRIPTION
## Summary

Game state reconstruction + 17lands-style analytics + turn-by-turn viewer. The foundation for all future analysis features.

### Parser enrichment
- Play/draw detection, mulligan tracking, opening hand sizes
- Draw tracking, graveyard/exile zone movements
- Best-effort life tracking (payments only, not combat damage for .dat)
- `REPARSE_MIN_VERSION = "0.9.0"` — auto-reparses all old matches

### Analytics endpoints
- `GET /analytics/stats/play-draw` — win rate on play vs draw
- `GET /analytics/stats/preboard-postboard` — game 1 vs games 2-3
- `GET /analytics/stats/mulligans` — frequency + WR by hand size
- `GET /analytics/stats/game-length` — turns distribution
- `GET /analytics/stats/cards` — per-card cast count, WR, avg cast turn
- `GET /analytics/stats/cards/{name}` — single card detail
- `GET /analytics/matches/{id}/games/{num}/turns` — turn data for viewer

### Web UI
- Turn-by-turn viewer (HTMX lazy-loaded, expandable per-game)
- Dashboard: play/draw split, pre/post-board, mulligan analysis, card performance
- Play/draw badges and opening hand sizes on match detail

### Infrastructure
- Performance indexes: `(user_id, played_at)`, `(user_id, format)`, `parsed_with_version`, `(game_id, turn_number)`
- Admin tunables UI: backfill batch size, intervals, scraper settings
- Multi-use invite tokens: `max_uses` + `use_count` (post a 20-use invite to Discord)

### Migrations
- 011: Game metadata columns (on_play, play_first, opening_hand_sizes)
- 012: Performance indexes
- 013: Invite max_uses + use_count

## Test plan
- [x] 70 parser tests (33 new game state tests)
- [x] 59 analytics tests (28 new)
- [x] 231+ web tests
- [x] Ruff lint + format clean
- [ ] CI full suite
- [ ] Deploy + reingest to verify dashboard populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)