### PR TITLE
fix: v0.9.0 dashboard bugs

### DIFF
--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -108,6 +108,10 @@ async def _load_card_appearances(
     user_id: int,
     mtgo_usernames: list[str] | None,
     card_name: str | None = None,
+    format_filter: str | None = None,
+    opponent: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
 ) -> list[dict[str, Any]]:
     """Load per-game card appearance data from game_states.
 
@@ -115,20 +119,35 @@ async def _load_card_appearances(
     in any turn snapshot. Returns a list of dicts with keys: game_id,
     winner, players, format, card_name, first_turn.
     """
+    where = "WHERE m.user_id = :user_id"
+    params: dict[str, Any] = {"user_id": user_id}
+    if format_filter:
+        where += " AND LOWER(m.format) = LOWER(:format)"
+        params["format"] = format_filter
+    if opponent:
+        where += " AND m.players @> :opp_json::jsonb"
+        params["opp_json"] = f'["{opponent}"]'
+    if date_from:
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
+        params["date_from"] = date_from
+    if date_to:
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
+        params["date_to"] = date_to
+
     rows = (
         await db.execute(
             text(
-                """
+                f"""
                 SELECT g.id AS game_id, g.winner, m.players, m.format,
                        gs.turn_number, gs.player_states
                 FROM parser.game_states gs
                 JOIN parser.games g ON g.id = gs.game_id
                 JOIN parser.matches m ON m.id = g.match_id
-                WHERE m.user_id = :user_id
+                {where}
                 ORDER BY g.id, gs.turn_number
                 """
             ),
-            {"user_id": user_id},
+            params,
         )
     ).all()
 
@@ -205,10 +224,22 @@ async def get_card_stats(
     page: Annotated[int, Query(ge=1)] = 1,
     per_page: Annotated[int, Query(ge=1, le=_MAX_PER_PAGE)] = _DEFAULT_PER_PAGE,
     sort: Annotated[str, Query()] = "cast_count",
+    format: Annotated[str | None, Query()] = None,
+    opponent: Annotated[str | None, Query()] = None,
+    date_from: Annotated[str | None, Query()] = None,
+    date_to: Annotated[str | None, Query()] = None,
 ) -> CardStatsResponse:
     """Per-card performance across all matches."""
     names = await _load_mtgo_usernames(db, user.user_id)
-    appearances = await _load_card_appearances(db, user.user_id, names)
+    appearances = await _load_card_appearances(
+        db,
+        user.user_id,
+        names,
+        format_filter=format,
+        opponent=opponent,
+        date_from=date_from,
+        date_to=date_to,
+    )
 
     # Aggregate per card
     agg: dict[str, dict[str, Any]] = {}

--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -8,6 +8,7 @@ colors).
 
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Annotated, Any
 
@@ -126,7 +127,7 @@ async def _load_card_appearances(
         params["format"] = format_filter
     if opponent:
         where += " AND m.players @> :opp_json::jsonb"
-        params["opp_json"] = f'["{opponent}"]'
+        params["opp_json"] = json.dumps([opponent])
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from

--- a/services/analytics/analytics_service/game_stats.py
+++ b/services/analytics/analytics_service/game_stats.py
@@ -113,6 +113,9 @@ async def _load_games_with_context(
     db: AsyncSession,
     user_id: int,
     format_filter: str | None = None,
+    opponent: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
 ) -> list[dict[str, Any]]:
     """Load all games with match context for a user.
 
@@ -124,6 +127,15 @@ async def _load_games_with_context(
     if format_filter:
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format_filter
+    if opponent:
+        where += " AND m.players @> :opp_json::jsonb"
+        params["opp_json"] = f'["{opponent}"]'
+    if date_from:
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
+        params["date_from"] = date_from
+    if date_to:
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
+        params["date_to"] = date_to
 
     rows = (
         await db.execute(
@@ -165,9 +177,14 @@ async def get_play_draw(
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
     format: Annotated[str | None, Query()] = None,
+    opponent: Annotated[str | None, Query()] = None,
+    date_from: Annotated[str | None, Query()] = None,
+    date_to: Annotated[str | None, Query()] = None,
 ) -> PlayDrawResponse:
     """Win rate on the play vs on the draw."""
-    games = await _load_games_with_context(db, user.user_id, format)
+    games = await _load_games_with_context(
+        db, user.user_id, format, opponent=opponent, date_from=date_from, date_to=date_to
+    )
     names = await _load_mtgo_usernames(db, user.user_id)
 
     play_wins = play_total = 0
@@ -204,9 +221,14 @@ async def get_preboard_postboard(
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
     format: Annotated[str | None, Query()] = None,
+    opponent: Annotated[str | None, Query()] = None,
+    date_from: Annotated[str | None, Query()] = None,
+    date_to: Annotated[str | None, Query()] = None,
 ) -> PrePostBoardResponse:
     """Win rate in game 1 (pre-board) vs games 2-3 (post-board)."""
-    games = await _load_games_with_context(db, user.user_id, format)
+    games = await _load_games_with_context(
+        db, user.user_id, format, opponent=opponent, date_from=date_from, date_to=date_to
+    )
     names = await _load_mtgo_usernames(db, user.user_id)
 
     pre_wins = pre_total = 0
@@ -239,9 +261,14 @@ async def get_mulligans(
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
     format: Annotated[str | None, Query()] = None,
+    opponent: Annotated[str | None, Query()] = None,
+    date_from: Annotated[str | None, Query()] = None,
+    date_to: Annotated[str | None, Query()] = None,
 ) -> list[MulliganBucket]:
     """Frequency and win rate by opening hand size."""
-    games = await _load_games_with_context(db, user.user_id, format)
+    games = await _load_games_with_context(
+        db, user.user_id, format, opponent=opponent, date_from=date_from, date_to=date_to
+    )
     names = await _load_mtgo_usernames(db, user.user_id)
 
     buckets: dict[int, dict[str, int]] = {}
@@ -288,6 +315,9 @@ async def get_game_length(
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
     format: Annotated[str | None, Query()] = None,
+    opponent: Annotated[str | None, Query()] = None,
+    date_from: Annotated[str | None, Query()] = None,
+    date_to: Annotated[str | None, Query()] = None,
 ) -> list[GameLengthBucket]:
     """Turns distribution bucketed into ranges."""
     names = await _load_mtgo_usernames(db, user.user_id)
@@ -297,6 +327,15 @@ async def get_game_length(
     if format:
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format
+    if opponent:
+        where += " AND m.players @> :opp_json::jsonb"
+        params["opp_json"] = f'["{opponent}"]'
+    if date_from:
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
+        params["date_from"] = date_from
+    if date_to:
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
+        params["date_to"] = date_to
 
     rows = (
         await db.execute(

--- a/services/analytics/analytics_service/game_stats.py
+++ b/services/analytics/analytics_service/game_stats.py
@@ -9,6 +9,7 @@ the "hero" player via ``auth.users.mtgo_usernames``, falling back to
 
 from __future__ import annotations
 
+import json
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
@@ -129,7 +130,7 @@ async def _load_games_with_context(
         params["format"] = format_filter
     if opponent:
         where += " AND m.players @> :opp_json::jsonb"
-        params["opp_json"] = f'["{opponent}"]'
+        params["opp_json"] = json.dumps([opponent])
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from
@@ -329,7 +330,7 @@ async def get_game_length(
         params["format"] = format
     if opponent:
         where += " AND m.players @> :opp_json::jsonb"
-        params["opp_json"] = f'["{opponent}"]'
+        params["opp_json"] = json.dumps([opponent])
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from

--- a/services/analytics/analytics_service/stats.py
+++ b/services/analytics/analytics_service/stats.py
@@ -328,10 +328,11 @@ async def get_username_suggestion(
         await db.execute(
             text(
                 """
-                SELECT name, COUNT(*) AS n
-                FROM parser.matches, jsonb_array_elements_text(players) AS name
-                WHERE user_id = :user_id
-                GROUP BY name
+                SELECT pname, COUNT(DISTINCT m.id) AS n
+                FROM parser.matches m
+                CROSS JOIN LATERAL jsonb_array_elements_text(m.players) AS pname
+                WHERE m.user_id = :user_id
+                GROUP BY pname
                 ORDER BY n DESC
                 LIMIT 5
                 """

--- a/services/web/tests/test_dashboard_stats.py
+++ b/services/web/tests/test_dashboard_stats.py
@@ -150,7 +150,7 @@ async def test_dashboard_renders_with_stats(
             per_page=20,
         )
 
-    async def fake_play_draw(_url: str, _token: str) -> Any:
+    async def fake_play_draw(_url: str, _token: str, **_kw: Any) -> Any:
         return analytics_client.PlayDrawStats(
             on_play_matches=10,
             on_play_wins=6,
@@ -160,7 +160,7 @@ async def test_dashboard_renders_with_stats(
             on_draw_win_rate=37.5,
         )
 
-    async def fake_preboard(_url: str, _token: str) -> Any:
+    async def fake_preboard(_url: str, _token: str, **_kw: Any) -> Any:
         return analytics_client.PreboardPostboardStats(
             game1_matches=10,
             game1_wins=5,
@@ -170,7 +170,7 @@ async def test_dashboard_renders_with_stats(
             games23_win_rate=50.0,
         )
 
-    async def fake_mulligan(_url: str, _token: str) -> Any:
+    async def fake_mulligan(_url: str, _token: str, **_kw: Any) -> Any:
         return analytics_client.MulliganStats(
             buckets=[
                 analytics_client.MulliganBucket(hand_size=7, games=12, wins=8, win_rate=66.7),

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -692,11 +692,29 @@ class PlayDrawStats:
     on_draw_win_rate: float
 
 
-async def get_play_draw_stats(base_url: str, token: str) -> PlayDrawStats:
+async def get_play_draw_stats(
+    base_url: str,
+    token: str,
+    *,
+    format_filter: str | None = None,
+    opponent: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> PlayDrawStats:
+    params: dict[str, str] = {}
+    if format_filter:
+        params["format"] = format_filter
+    if opponent:
+        params["opponent"] = opponent
+    if date_from:
+        params["date_from"] = date_from
+    if date_to:
+        params["date_to"] = date_to
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(
                 f"{base_url}/analytics/stats/play-draw",
+                params=params,
                 headers={"Authorization": f"Bearer {token}"},
             )
     except httpx.HTTPError as exc:
@@ -710,13 +728,15 @@ async def get_play_draw_stats(base_url: str, token: str) -> PlayDrawStats:
             f"analytics GET /stats/play-draw returned {resp.status_code}: {resp.text}"
         )
     d = resp.json()
+    on_play = d.get("on_play") or {}
+    on_draw = d.get("on_draw") or {}
     return PlayDrawStats(
-        on_play_matches=int(d.get("on_play_matches") or 0),
-        on_play_wins=int(d.get("on_play_wins") or 0),
-        on_play_win_rate=float(d.get("on_play_win_rate") or 0.0),
-        on_draw_matches=int(d.get("on_draw_matches") or 0),
-        on_draw_wins=int(d.get("on_draw_wins") or 0),
-        on_draw_win_rate=float(d.get("on_draw_win_rate") or 0.0),
+        on_play_matches=int(on_play.get("total") or 0),
+        on_play_wins=int(on_play.get("wins") or 0),
+        on_play_win_rate=float(on_play.get("win_rate") or 0.0),
+        on_draw_matches=int(on_draw.get("total") or 0),
+        on_draw_wins=int(on_draw.get("wins") or 0),
+        on_draw_win_rate=float(on_draw.get("win_rate") or 0.0),
     )
 
 
@@ -730,11 +750,29 @@ class PreboardPostboardStats:
     games23_win_rate: float
 
 
-async def get_preboard_postboard_stats(base_url: str, token: str) -> PreboardPostboardStats:
+async def get_preboard_postboard_stats(
+    base_url: str,
+    token: str,
+    *,
+    format_filter: str | None = None,
+    opponent: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> PreboardPostboardStats:
+    params: dict[str, str] = {}
+    if format_filter:
+        params["format"] = format_filter
+    if opponent:
+        params["opponent"] = opponent
+    if date_from:
+        params["date_from"] = date_from
+    if date_to:
+        params["date_to"] = date_to
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(
                 f"{base_url}/analytics/stats/preboard-postboard",
+                params=params,
                 headers={"Authorization": f"Bearer {token}"},
             )
     except httpx.HTTPError as exc:
@@ -750,13 +788,15 @@ async def get_preboard_postboard_stats(base_url: str, token: str) -> PreboardPos
             f"analytics GET /stats/preboard-postboard returned {resp.status_code}: {resp.text}"
         )
     d = resp.json()
+    preboard = d.get("preboard") or {}
+    postboard = d.get("postboard") or {}
     return PreboardPostboardStats(
-        game1_matches=int(d.get("game1_matches") or 0),
-        game1_wins=int(d.get("game1_wins") or 0),
-        game1_win_rate=float(d.get("game1_win_rate") or 0.0),
-        games23_matches=int(d.get("games23_matches") or 0),
-        games23_wins=int(d.get("games23_wins") or 0),
-        games23_win_rate=float(d.get("games23_win_rate") or 0.0),
+        game1_matches=int(preboard.get("total") or 0),
+        game1_wins=int(preboard.get("wins") or 0),
+        game1_win_rate=float(preboard.get("win_rate") or 0.0),
+        games23_matches=int(postboard.get("total") or 0),
+        games23_wins=int(postboard.get("wins") or 0),
+        games23_win_rate=float(postboard.get("win_rate") or 0.0),
     )
 
 
@@ -773,11 +813,29 @@ class MulliganStats:
     buckets: list[MulliganBucket]
 
 
-async def get_mulligan_stats(base_url: str, token: str) -> MulliganStats:
+async def get_mulligan_stats(
+    base_url: str,
+    token: str,
+    *,
+    format_filter: str | None = None,
+    opponent: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> MulliganStats:
+    params: dict[str, str] = {}
+    if format_filter:
+        params["format"] = format_filter
+    if opponent:
+        params["opponent"] = opponent
+    if date_from:
+        params["date_from"] = date_from
+    if date_to:
+        params["date_to"] = date_to
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(
                 f"{base_url}/analytics/stats/mulligans",
+                params=params,
                 headers={"Authorization": f"Bearer {token}"},
             )
     except httpx.HTTPError as exc:
@@ -857,12 +915,25 @@ async def get_card_stats(
     page: int = 1,
     per_page: int = 20,
     sort_by: str = "games",
+    format_filter: str | None = None,
+    opponent: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
 ) -> CardStatsResponse:
+    params: dict[str, Any] = {"page": page, "per_page": per_page, "sort_by": sort_by}
+    if format_filter:
+        params["format"] = format_filter
+    if opponent:
+        params["opponent"] = opponent
+    if date_from:
+        params["date_from"] = date_from
+    if date_to:
+        params["date_to"] = date_to
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(
                 f"{base_url}/analytics/stats/cards",
-                params={"page": page, "per_page": per_page, "sort_by": sort_by},
+                params=params,
                 headers={"Authorization": f"Bearer {token}"},
             )
     except httpx.HTTPError as exc:
@@ -876,8 +947,8 @@ async def get_card_stats(
     d = resp.json()
     cards = [
         CardStatItem(
-            card_name=str(c.get("card_name") or ""),
-            games=int(c.get("games") or 0),
+            card_name=str(c.get("name") or c.get("card_name") or ""),
+            games=int(c.get("cast_count") or c.get("games") or 0),
             wins=int(c.get("wins") or 0),
             win_rate=float(c.get("win_rate") or 0.0),
             avg_cast_turn=float(c["avg_cast_turn"]) if c.get("avg_cast_turn") is not None else None,
@@ -952,10 +1023,21 @@ def _to_player_turn_state(payload: dict[str, Any]) -> PlayerTurnState:
 
 
 def _to_turn(payload: dict[str, Any]) -> TurnData:
+    # The analytics endpoint returns player data as a dict keyed by
+    # player name (``"players": {"name": {...}}``), while the web
+    # client expects a flat list of player state objects.
+    raw_states = payload.get("player_states") or []
+    if not raw_states:
+        players_dict = payload.get("players") or {}
+        if isinstance(players_dict, dict):
+            raw_states = [
+                {"player": name, **(data if isinstance(data, dict) else {})}
+                for name, data in players_dict.items()
+            ]
     return TurnData(
         turn_number=int(payload.get("turn_number") or 0),
         active_player=payload.get("active_player"),
-        player_states=[_to_player_turn_state(ps) for ps in payload.get("player_states", [])],
+        player_states=[_to_player_turn_state(ps) for ps in raw_states],
         stack=list(payload.get("stack") or []),
     )
 
@@ -986,8 +1068,20 @@ async def get_game_turns(
             f"returned {resp.status_code}: {resp.text}"
         )
     d = resp.json()
+    # The analytics endpoint returns either a bare JSON array of turn
+    # objects or a wrapped object with match_id/game_number/turns keys.
+    if isinstance(d, list):
+        turns = [_to_turn(t) for t in d]
+    else:
+        turns = [_to_turn(t) for t in d.get("turns", [])]
+    if isinstance(d, dict):
+        resolved_match_id = str(d.get("match_id") or match_id)
+        resolved_game_number = int(d.get("game_number") or game_number)
+    else:
+        resolved_match_id = str(match_id)
+        resolved_game_number = game_number
     return GameTurnsResponse(
-        match_id=str(d.get("match_id") or match_id),
-        game_number=int(d.get("game_number") or game_number),
-        turns=[_to_turn(t) for t in d.get("turns", [])],
+        match_id=resolved_match_id,
+        game_number=resolved_game_number,
+        turns=turns,
     )

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -274,30 +274,42 @@ async def dashboard(
 
     # v0.9.0 analytics widgets — each is independent so a failure in
     # one doesn't block the others or the main dashboard.
+    # Build filter kwargs for analytics widget calls
+    _widget_filters = {
+        "format_filter": format or None,
+        "opponent": opponent or None,
+        "date_from": date_from or None,
+        "date_to": date_to or None,
+    }
+
     try:
         play_draw_stats = await analytics_client.get_play_draw_stats(
-            settings.analytics_service_url, user.token
+            settings.analytics_service_url, user.token, **_widget_filters
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("play/draw stats unavailable")
 
     try:
         preboard_postboard_stats = await analytics_client.get_preboard_postboard_stats(
-            settings.analytics_service_url, user.token
+            settings.analytics_service_url, user.token, **_widget_filters
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("preboard/postboard stats unavailable")
 
     try:
         mulligan_stats = await analytics_client.get_mulligan_stats(
-            settings.analytics_service_url, user.token
+            settings.analytics_service_url, user.token, **_widget_filters
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("mulligan stats unavailable")
 
     try:
         card_stats = await analytics_client.get_card_stats(
-            settings.analytics_service_url, user.token, per_page=20, sort_by="games"
+            settings.analytics_service_url,
+            user.token,
+            per_page=20,
+            sort_by="games",
+            **_widget_filters,
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("card stats unavailable")


### PR DESCRIPTION
## Summary

- **Play/Draw and Pre/Post-board stats all zeros**: Web analytics client used wrong field names (`on_play_matches` vs `on_play.total`). Fixed the response mapping to match the actual nested API shape.
- **Card names showing as "0"**: Analytics API returns `name` + `cast_count` but the web client read `card_name` + `games`. Fixed the field mapping.
- **Username suggestion returning opponents**: Rewrote the SQL query with explicit `CROSS JOIN LATERAL` and `COUNT(DISTINCT m.id)` to avoid ambiguity with PostgreSQL's `name` type alias.
- **Dashboard filters not applied to widgets**: Play/Draw, Mulligan, Pre/Post-board, and Card Performance widgets now accept and forward all active filter params (opponent, format, date range).
- **"Show turns" button broken**: Analytics returns a bare JSON array but the client called `.get()` on it (expecting a dict). Fixed to handle both response shapes. Also fixed player state dict-to-list mapping.

## Test plan

- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] Parser tests: 70/70 passed
- [x] Web tests: 231/231 passed
- [x] Analytics tests (non-DB): 37/37 passed
- [ ] Compose smoke E2E (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)