### PR TITLE
fix: landing page, nav menus, MTGO username display

### DIFF
--- a/services/auth/auth_service/jwt_issue.py
+++ b/services/auth/auth_service/jwt_issue.py
@@ -34,6 +34,7 @@ class JWTIssuer:
         scope: str | None = None,
         override_ttl_seconds: int | None = None,
         email: str | None = None,
+        mtgo_usernames: list[str] | None = None,
     ) -> str:
         now = datetime.now(UTC)
         ttl = override_ttl_seconds if override_ttl_seconds is not None else self._access_ttl
@@ -50,6 +51,8 @@ class JWTIssuer:
             claims["scope"] = scope
         if email is not None:
             claims["email"] = email
+        if mtgo_usernames:
+            claims["mtgo_usernames"] = mtgo_usernames
         return jwt.encode(claims, self._private_key, algorithm="RS256")
 
 
@@ -76,6 +79,7 @@ def issue_access_token(
     scope: str | None = None,
     override_ttl_seconds: int | None = None,
     email: str | None = None,
+    mtgo_usernames: list[str] | None = None,
 ) -> str:
     return get_issuer().issue_access_token(
         user_id,
@@ -84,6 +88,7 @@ def issue_access_token(
         scope=scope,
         override_ttl_seconds=override_ttl_seconds,
         email=email,
+        mtgo_usernames=mtgo_usernames,
     )
 
 

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -183,7 +183,13 @@ async def login(
             )
             expires_in = settings.password_change_token_ttl_seconds
         else:
-            access = issue_access_token(user.id, user.role, session_row.id, email=user.email)
+            access = issue_access_token(
+                user.id,
+                user.role,
+                session_row.id,
+                email=user.email,
+                mtgo_usernames=user.mtgo_usernames,
+            )
             expires_in = settings.access_token_ttl_seconds
 
         return TokenResponse(
@@ -245,7 +251,13 @@ async def refresh(
     await db.commit()
     await db.refresh(new_session)
 
-    access = issue_access_token(user.id, user.role, new_session.id, email=user.email)
+    access = issue_access_token(
+        user.id,
+        user.role,
+        new_session.id,
+        email=user.email,
+        mtgo_usernames=user.mtgo_usernames,
+    )
     return TokenResponse(
         access_token=access,
         refresh_token=new_refresh,
@@ -347,15 +359,17 @@ async def update_me(
     await db.commit()
     await db.refresh(user)
 
-    # Email is a JWT claim; the caller's existing token is now stale.
-    # Mint a fresh access token bound to the same session_id so the
-    # web layer can rotate the cookie without forcing a re-login.
+    # Email and mtgo_usernames are JWT claims; the caller's existing
+    # token is now stale.  Mint a fresh access token bound to the same
+    # session_id so the web layer can rotate the cookie without forcing
+    # a re-login.
     settings = get_settings()
     fresh_access = issue_access_token(
         user.id,
         user.role,
         caller.session_id,
         email=user.email,
+        mtgo_usernames=user.mtgo_usernames,
     )
 
     _log.info("auth.me.updated", extra={"user_id": user.id})

--- a/services/web/web_service/deps.py
+++ b/services/web/web_service/deps.py
@@ -37,6 +37,14 @@ class BrowserUser:
     # Raw JWT — needed for service-to-service calls (password change,
     # logout) where we forward the user's token as a Bearer header.
     token: str
+    mtgo_usernames: list[str] | None = None
+
+    @property
+    def display_name(self) -> str:
+        """Nav-friendly display: first MTGO username if set, else email."""
+        if self.mtgo_usernames:
+            return self.mtgo_usernames[0]
+        return self.email or f"user #{self.user_id}"
 
 
 class BrowserAuthRedirect(Exception):
@@ -106,6 +114,14 @@ def _resolve_browser_user(request: Request, settings: WebSettings) -> BrowserUse
     email_claim = claims.get("email")
     email = str(email_claim) if email_claim else ""
 
+    # mtgo_usernames is included in the JWT since v0.9.1 so the nav
+    # can display a player name without a network call to auth.  Older
+    # tokens simply lack the claim — fall back to None.
+    raw_names = claims.get("mtgo_usernames")
+    mtgo_usernames: list[str] | None = None
+    if isinstance(raw_names, list) and all(isinstance(n, str) for n in raw_names):
+        mtgo_usernames = raw_names or None
+
     return BrowserUser(
         user_id=user_id,
         email=email,
@@ -113,6 +129,7 @@ def _resolve_browser_user(request: Request, settings: WebSettings) -> BrowserUse
         must_change_password=scope == PASSWORD_CHANGE_SCOPE,
         scope=scope,
         token=token,
+        mtgo_usernames=mtgo_usernames,
     )
 
 

--- a/services/web/web_service/static/style.css
+++ b/services/web/web_service/static/style.css
@@ -252,3 +252,72 @@ input:focus { outline: 2px solid var(--focus); outline-offset: 0; border-color: 
     background: var(--bg);
     text-decoration: none;
 }
+
+/* Admin badge in nav */
+.nav-badge-admin {
+    display: inline-block;
+    background: var(--accent);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 1px 5px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 4px;
+}
+
+/* Landing page */
+.landing {
+    max-width: 560px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.landing-hero {
+    margin-bottom: 32px;
+}
+.landing-hero h1 {
+    font-size: 28px;
+    margin-bottom: 8px;
+}
+.landing-tagline {
+    color: var(--text-muted);
+    font-size: 16px;
+    margin: 0;
+}
+
+.landing-features {
+    text-align: left;
+    margin-bottom: 32px;
+}
+.landing-feature-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+.landing-feature-list li {
+    padding: 12px 16px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 14px;
+    line-height: 1.5;
+}
+.landing-feature-list li strong {
+    color: var(--accent);
+}
+
+.landing-cta {
+    text-align: center;
+}
+.landing-cta .form-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    margin: 0;
+}

--- a/services/web/web_service/templates/base.html
+++ b/services/web/web_service/templates/base.html
@@ -11,22 +11,31 @@
 <body>
     <header class="site-header">
         <div class="site-header-inner">
-            <a class="site-logo" href="/dashboard">Deep Analysis</a>
+            <a class="site-logo" href="{% if user %}/dashboard{% else %}/{% endif %}">Deep Analysis</a>
             <nav class="site-nav">
                 {% if user %}
+                    {% if user.role != "admin" %}
                     <a class="nav-link" href="/cards">Cards</a>
+                    {% endif %}
                     <div class="nav-dropdown" tabindex="0">
                         <button type="button" class="nav-dropdown-trigger" aria-haspopup="true">
-                            {% if user.email %}{{ user.email }}{% else %}user #{{ user.user_id }}{% endif %}
+                            {% if user.role == "admin" %}
+                                <span class="nav-badge-admin">Admin</span>
+                                {{ user.email or "admin" }}
+                            {% else %}
+                                {{ user.display_name }}
+                            {% endif %}
                             <span class="nav-dropdown-arrow" aria-hidden="true">&#9662;</span>
                         </button>
                         <ul class="nav-dropdown-menu" role="menu">
                             {% if user.role != "admin" %}
                             <li role="none"><a role="menuitem" href="/profile">Profile</a></li>
+                            <li role="none"><a role="menuitem" href="/profile/edit">Edit profile</a></li>
                             <li role="none"><a role="menuitem" href="/settings/password">Change password</a></li>
                             <li role="none"><a role="menuitem" href="/profile/agents">My agents</a></li>
                             {% else %}
                             <li role="none"><a role="menuitem" href="/admin/users">Admin panel</a></li>
+                            <li role="none" class="nav-dropdown-divider"></li>
                             <li role="none"><a role="menuitem" href="/settings/password">Change password</a></li>
                             {% endif %}
                             <li role="none" class="nav-dropdown-divider"></li>
@@ -47,7 +56,7 @@
     </main>
 
     <footer class="site-footer">
-        <span>Deep Analysis &middot; self-hosted match analytics</span>
+        <span>Deep Analysis · self-hosted match analytics</span>
         <span class="site-version">v{{ app_version }}</span>
     </footer>
 </body>

--- a/services/web/web_service/templates/landing.html
+++ b/services/web/web_service/templates/landing.html
@@ -1,19 +1,44 @@
 {% extends "base.html" %}
 
-{% block title %}Deep Analysis{% endblock %}
+{% block title %}Deep Analysis — MTGO Match Analytics{% endblock %}
 
 {% block content %}
-<section class="auth-card">
-    <h1>Deep Analysis</h1>
-    <p class="muted">
-        MTGO match analytics &mdash; track your performance, identify
-        patterns, improve your game.
-    </p>
-    <div class="form-actions">
-        <a href="/login" class="btn btn-primary">Sign in</a>
-        {% if registration_open %}
-            <a href="/register" class="btn">Register</a>
-        {% endif %}
-    </div>
-</section>
+<div class="landing">
+    <section class="landing-hero">
+        <h1>Deep Analysis</h1>
+        <p class="landing-tagline">
+            Self-hosted match analytics for Magic: The Gathering Online
+        </p>
+    </section>
+
+    <section class="landing-features">
+        <ul class="landing-feature-list">
+            <li>
+                <strong>Match tracking</strong> — automatically capture every
+                match from your MTGO game logs
+            </li>
+            <li>
+                <strong>Performance analytics</strong> — win rates, format
+                breakdowns, and opponent history at a glance
+            </li>
+            <li>
+                <strong>Format detection</strong> — Standard, Modern, Legacy,
+                Vintage, Pauper, and more identified automatically
+            </li>
+            <li>
+                <strong>Play/draw and sideboard stats</strong> — see how your
+                decisions before and after boarding affect your results
+            </li>
+        </ul>
+    </section>
+
+    <section class="auth-card landing-cta">
+        <div class="form-actions">
+            <a href="/login" class="btn btn-primary">Sign in</a>
+            {% if registration_open %}
+                <a href="/register" class="btn btn-secondary">Register</a>
+            {% endif %}
+        </div>
+    </section>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- **Landing page**: replaced blank auth-card with a proper hero section, feature list (match tracking, performance analytics, format detection, play/draw stats), and sign-in/register CTA. Uses em-dash characters instead of `&mdash;` entities.
- **User nav menu**: shows MTGO username (first set name) when available, falls back to email. Dropdown items: Profile, Edit Profile, Change Password, My Agents, divider, Log out. Cards link only visible for regular users.
- **Admin nav menu**: "Admin" badge + email display. Dropdown items: Admin Panel, divider, Change Password, divider, Log out. No profile/agents links per the hard role separation.
- **JWT claims**: added `mtgo_usernames` to access tokens so the nav can display the player name without a per-page-load network call to the auth service. Populated on login, refresh, and profile update.

## Test plan

- [x] `uv run ruff check` and `uv run ruff format --check` pass on all changed files
- [x] 231 web service tests pass
- [x] Auth JWT issue unit tests pass
- [x] BrowserUser.display_name returns MTGO username when set, email when not, user ID fallback when both empty
- [ ] CI compose-smoke gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)