### PR TITLE
fix: add missing httpx dependency to parser service

### DIFF
--- a/services/parser/pyproject.toml
+++ b/services/parser/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pydantic>=2.7",
     "pydantic-settings>=2.3",
     "redis>=5.0",
+    "httpx>=0.27",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

- Parser service crash-loops in production with `ModuleNotFoundError: No module named 'httpx'`
- `analytics_client.py` (archetype classifier HTTP calls from #59) imports `httpx` but it was never added to `services/parser/pyproject.toml`
- Adds `httpx>=0.27` to the parser's runtime dependencies

## Audit

Checked all other third-party imports across the parser service — every other package (`fastapi`, `uvicorn`, `structlog`, `prometheus-client`, `sqlalchemy`, `alembic`, `psycopg`, `asyncpg`, `pydantic`, `pydantic-settings`, `redis`) is already declared. `httpx` was the only missing dependency.

Note: `test_healthz.py` also imports `httpx` — this fix covers it as a runtime dep (not just test).

## Test plan

- [ ] CI passes (compose-smoke E2E gate)
- [ ] Parser container starts without `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)