### PR TITLE
fix: dashboard UX — stats visible on load, format = filter, XSS + opponent fixes

### DIFF
--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -28,6 +28,11 @@ from analytics_service.deps import AuthenticatedUser, require_user
 router = APIRouter(prefix="/analytics/stats", tags=["card-stats"])
 
 
+def _escape_like(value: str) -> str:
+    """Escape SQL LIKE/ILIKE wildcard characters."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 _DEFAULT_PER_PAGE = 20
 _MAX_PER_PAGE = 100
 
@@ -148,8 +153,8 @@ async def _load_card_appearances(
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format_filter
     if opponent:
-        where += " AND m.players::text ILIKE :opp_pattern"
-        params["opp_pattern"] = f"%{opponent}%"
+        where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
+        params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from
@@ -259,8 +264,8 @@ async def _load_card_appearances_fallback(
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format_filter
     if opponent:
-        where += " AND m.players::text ILIKE :opp_pattern"
-        params["opp_pattern"] = f"%{opponent}%"
+        where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
+        params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from

--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -14,7 +14,6 @@ result set.
 
 from __future__ import annotations
 
-import json
 import uuid
 from typing import Annotated, Any
 
@@ -149,8 +148,8 @@ async def _load_card_appearances(
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format_filter
     if opponent:
-        where += " AND m.players @> :opp_json::jsonb"
-        params["opp_json"] = json.dumps([opponent])
+        where += " AND m.players::text ILIKE :opp_pattern"
+        params["opp_pattern"] = f"%{opponent}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from
@@ -260,8 +259,8 @@ async def _load_card_appearances_fallback(
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format_filter
     if opponent:
-        where += " AND m.players @> :opp_json::jsonb"
-        params["opp_json"] = json.dumps([opponent])
+        where += " AND m.players::text ILIKE :opp_pattern"
+        params["opp_pattern"] = f"%{opponent}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from

--- a/services/analytics/analytics_service/game_stats.py
+++ b/services/analytics/analytics_service/game_stats.py
@@ -22,6 +22,11 @@ from analytics_service.deps import AuthenticatedUser, require_user
 router = APIRouter(prefix="/analytics/stats", tags=["game-stats"])
 
 
+def _escape_like(value: str) -> str:
+    """Escape SQL LIKE/ILIKE wildcard characters."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 # ---------------------------------------------------------------------------
 # Response models
 # ---------------------------------------------------------------------------
@@ -128,8 +133,8 @@ async def _load_games_with_context(
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format_filter
     if opponent:
-        where += " AND m.players::text ILIKE :opp_pattern"
-        params["opp_pattern"] = f"%{opponent}%"
+        where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
+        params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from
@@ -328,8 +333,8 @@ async def get_game_length(
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format
     if opponent:
-        where += " AND m.players::text ILIKE :opp_pattern"
-        params["opp_pattern"] = f"%{opponent}%"
+        where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
+        params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from

--- a/services/analytics/analytics_service/game_stats.py
+++ b/services/analytics/analytics_service/game_stats.py
@@ -9,7 +9,6 @@ the "hero" player via ``auth.users.mtgo_usernames``, falling back to
 
 from __future__ import annotations
 
-import json
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
@@ -129,8 +128,8 @@ async def _load_games_with_context(
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format_filter
     if opponent:
-        where += " AND m.players @> :opp_json::jsonb"
-        params["opp_json"] = json.dumps([opponent])
+        where += " AND m.players::text ILIKE :opp_pattern"
+        params["opp_pattern"] = f"%{opponent}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from
@@ -329,8 +328,8 @@ async def get_game_length(
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format
     if opponent:
-        where += " AND m.players @> :opp_json::jsonb"
-        params["opp_json"] = json.dumps([opponent])
+        where += " AND m.players::text ILIKE :opp_pattern"
+        params["opp_pattern"] = f"%{opponent}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from

--- a/services/analytics/analytics_service/stats.py
+++ b/services/analytics/analytics_service/stats.py
@@ -37,6 +37,11 @@ _log = logging.getLogger("analytics.stats")
 router = APIRouter(prefix="/analytics/stats", tags=["stats"])
 
 
+def _escape_like(value: str) -> str:
+    """Escape SQL LIKE/ILIKE wildcard characters."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 async def _get_redis_or_none() -> Any:
     """Return the Redis client or None if unavailable."""
     try:
@@ -475,8 +480,8 @@ async def list_matches(
         where += " AND LOWER(m.format) = LOWER(:format)"
         params["format"] = format
     if opponent:
-        where += " AND m.players::text ILIKE :opp_pattern"
-        params["opp_pattern"] = f"%{opponent}%"
+        where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
+        params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = str(date_from)

--- a/services/web/tests/test_dashboard_stats.py
+++ b/services/web/tests/test_dashboard_stats.py
@@ -219,8 +219,11 @@ async def test_dashboard_renders_with_stats(
     assert "Modern" in text
     # No error banner
     assert "Stats unavailable" not in text
-    # Match history, opponent stats, and detailed analytics panels moved
-    # to /matches and HTMX partials in v0.9.4 — not in initial dashboard HTML
+    # Stats panels are rendered inline on initial load (v0.9.4 UX rework)
+    assert "Play/Draw Split" in text
+    assert "On Play" in text
+    assert "Card Performance" in text
+    assert "Lightning Bolt" in text
 
 
 @pytest.mark.asyncio

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -231,7 +231,9 @@ async def dashboard(
     format_stats: list[Any] = []
     stats_error = False
     play_draw_stats: Any = None
-    archetypes: list[Any] = []
+    preboard_postboard_stats: Any = None
+    mulligan_stats: Any = None
+    card_stats: Any = None
     try:
         stats_summary = await analytics_client.get_stats_summary(
             settings.analytics_service_url, user.token
@@ -254,14 +256,29 @@ async def dashboard(
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("play/draw stats unavailable")
 
-    # Fetch archetypes for the drill-down filter bar (best-effort).
+    # Pre-board / post-board stats (unfiltered).
     try:
-        arch_items, _ = await analytics_client.admin_list_archetypes(
+        preboard_postboard_stats = await analytics_client.get_preboard_postboard_stats(
             settings.analytics_service_url, user.token
         )
-        archetypes = arch_items
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
-        _log.debug("archetypes unavailable for drill-down filter")
+        _log.debug("preboard/postboard stats unavailable")
+
+    # Mulligan stats (unfiltered).
+    try:
+        mulligan_stats = await analytics_client.get_mulligan_stats(
+            settings.analytics_service_url, user.token
+        )
+    except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
+        _log.debug("mulligan stats unavailable")
+
+    # Card stats (unfiltered).
+    try:
+        card_stats = await analytics_client.get_card_stats(
+            settings.analytics_service_url, user.token
+        )
+    except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
+        _log.debug("card stats unavailable")
 
     return templates.TemplateResponse(
         request,
@@ -272,7 +289,9 @@ async def dashboard(
             "format_stats": format_stats,
             "stats_error": stats_error,
             "play_draw_stats": play_draw_stats,
-            "archetypes": archetypes,
+            "preboard_postboard_stats": preboard_postboard_stats,
+            "mulligan_stats": mulligan_stats,
+            "card_stats": card_stats,
         },
     )
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -272,10 +272,11 @@ async def dashboard(
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("mulligan stats unavailable")
 
-    # Card stats (unfiltered).
+    # Card stats (unfiltered). Use same page size as the HTMX partial so
+    # pagination stays consistent when the user clicks "Next".
     try:
         card_stats = await analytics_client.get_card_stats(
-            settings.analytics_service_url, user.token
+            settings.analytics_service_url, user.token, per_page=_CARD_PERF_PER_PAGE
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("card stats unavailable")

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -52,15 +52,21 @@
     {% endif %}
 </div>
 
-{# ── Format Drill-down (Alpine.js state) ── #}
-<div x-data="{ selectedFormat: null }"
+{# ── Format Filter + Stats Panels (Alpine.js state) ── #}
+<div x-data="{ selectedFormat: null, _initialized: false }"
      x-effect="
+        if (!_initialized) { _initialized = true; return; }
         if (selectedFormat) {
             var f = encodeURIComponent(selectedFormat);
             htmx.ajax('GET', '/dashboard/partials/play-draw?format=' + f, {target: '#play-draw-panel', swap: 'innerHTML'});
             htmx.ajax('GET', '/dashboard/partials/preboard-postboard?format=' + f, {target: '#preboard-postboard-panel', swap: 'innerHTML'});
             htmx.ajax('GET', '/dashboard/partials/mulligans?format=' + f, {target: '#mulligan-panel', swap: 'innerHTML'});
             htmx.ajax('GET', '/dashboard/partials/card-performance?format=' + f, {target: '#card-performance-panel', swap: 'innerHTML'});
+        } else {
+            htmx.ajax('GET', '/dashboard/partials/play-draw', {target: '#play-draw-panel', swap: 'innerHTML'});
+            htmx.ajax('GET', '/dashboard/partials/preboard-postboard', {target: '#preboard-postboard-panel', swap: 'innerHTML'});
+            htmx.ajax('GET', '/dashboard/partials/mulligans', {target: '#mulligan-panel', swap: 'innerHTML'});
+            htmx.ajax('GET', '/dashboard/partials/card-performance', {target: '#card-performance-panel', swap: 'innerHTML'});
         }
      "
      class="space-y-6">
@@ -68,9 +74,16 @@
 {# ── By Format Table ── #}
 {% if format_stats|default([]) %}
 <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md mb-0 overflow-hidden">
-    <div class="px-4 py-3 border-b dark:border-border border-border-light">
-        <h2 class="text-sm font-semibold dark:text-txt-primary text-txt-primary-light">By format</h2>
-        <p class="text-xs dark:text-txt-secondary text-txt-secondary-light mt-0.5">Click a format to see detailed stats.</p>
+    <div class="px-4 py-3 border-b dark:border-border border-border-light flex items-center justify-between">
+        <div>
+            <h2 class="text-sm font-semibold dark:text-txt-primary text-txt-primary-light">By format</h2>
+            <p class="text-xs dark:text-txt-secondary text-txt-secondary-light mt-0.5">Click a format to filter stats below.</p>
+        </div>
+        <button x-show="selectedFormat" x-cloak
+                @click="selectedFormat = null"
+                class="text-xs dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light border dark:border-border border-border-light rounded-md px-2 py-1 transition-colors cursor-pointer bg-transparent">
+            Clear filter
+        </button>
     </div>
     <div class="overflow-x-auto">
         <table class="w-full">
@@ -89,10 +102,7 @@
                 <tr @click="selectedFormat === {{ row.format_|tojson }} ? selectedFormat = null : selectedFormat = {{ row.format_|tojson }}"
                     :class="selectedFormat === {{ row.format_|tojson }} ? 'dark:bg-accent-muted bg-accent-muted border-l-2 border-accent' : ''"
                     class="border-b dark:border-border-subtle border-border-light hover:dark:bg-surface-2 hover:bg-surface-light-2 transition-colors cursor-pointer">
-                    <td class="px-4 py-2.5 text-sm dark:text-txt-primary text-txt-primary-light flex items-center gap-2">
-                        <svg class="w-3 h-3 dark:text-txt-tertiary text-txt-secondary-light transition-transform"
-                             :class="selectedFormat === {{ row.format_|tojson }} ? 'rotate-90 text-accent' : ''"
-                             fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/></svg>
+                    <td class="px-4 py-2.5 text-sm dark:text-txt-primary text-txt-primary-light">
                         {{ row.format_ }}
                     </td>
                     <td class="px-4 py-2.5 text-sm font-mono text-right dark:text-txt-primary text-txt-primary-light">{{ row.matches }}</td>
@@ -108,73 +118,20 @@
 </div>
 {% endif %}
 
-{# ── Format Cascade (shown when a format is selected) ── #}
-<div x-show="selectedFormat" x-cloak
-     x-transition:enter="transition ease-out duration-200"
-     x-transition:enter-start="opacity-0 translate-y-2"
-     x-transition:enter-end="opacity-100 translate-y-0">
-    <div class="border-l-2 border-accent pl-4 space-y-4">
-        <div class="flex items-center gap-2 mb-2">
-            <h3 class="text-base font-semibold dark:text-txt-primary text-txt-primary-light">
-                <span x-text="selectedFormat"></span> — Detailed Stats
-            </h3>
-            <button @click="selectedFormat = null" class="text-xs dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light transition-colors">(collapse)</button>
-        </div>
-
-        {# ── Archetype Filter Bar (only shown when archetypes exist) ── #}
-        {% if archetypes|default([]) %}
-        <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-3">
-            <div class="flex flex-wrap gap-3 items-end">
-                <label class="flex flex-col gap-1">
-                    <span class="text-xs dark:text-txt-secondary text-txt-secondary-light">My Archetype</span>
-                    <select id="my-archetype" class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none">
-                        <option value="">All</option>
-                        {% for arch in archetypes %}
-                        <option value="{{ arch.name }}">{{ arch.name }}</option>
-                        {% endfor %}
-                    </select>
-                </label>
-                <label class="flex flex-col gap-1">
-                    <span class="text-xs dark:text-txt-secondary text-txt-secondary-light">Opponent Archetype</span>
-                    <select id="opp-archetype" class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none">
-                        <option value="">All</option>
-                        {% for arch in archetypes %}
-                        <option value="{{ arch.name }}">{{ arch.name }}</option>
-                        {% endfor %}
-                    </select>
-                </label>
-            </div>
-        </div>
-        {% endif %}
-
-        {# ── Play/Draw Split (HTMX lazy-load) ── #}
-        <div id="play-draw-panel">
-            <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
-                <p class="text-sm dark:text-txt-secondary text-txt-secondary-light">Select a format above to load stats.</p>
-            </div>
-        </div>
-
-        {# ── Pre-board vs Post-board (HTMX lazy-load) ── #}
-        <div id="preboard-postboard-panel">
-            <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
-                <p class="text-sm dark:text-txt-secondary text-txt-secondary-light">Select a format above to load stats.</p>
-            </div>
-        </div>
-
-        {# ── Mulligan Analysis (HTMX lazy-load) ── #}
-        <div id="mulligan-panel">
-            <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
-                <p class="text-sm dark:text-txt-secondary text-txt-secondary-light">Select a format above to load stats.</p>
-            </div>
-        </div>
-
-        {# ── Card Performance (HTMX lazy-load, paginated) ── #}
-        <div id="card-performance-panel">
-            <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
-                <p class="text-sm dark:text-txt-secondary text-txt-secondary-light">Select a format above to load stats.</p>
-            </div>
-        </div>
+{# ── Stats Panels (visible on load with unfiltered data) ── #}
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div id="play-draw-panel">
+        {% include "_partials_play_draw.html" %}
     </div>
+    <div id="preboard-postboard-panel">
+        {% include "_partials_preboard_postboard.html" %}
+    </div>
+</div>
+<div id="mulligan-panel">
+    {% include "_partials_mulligans.html" %}
+</div>
+<div id="card-performance-panel">
+    {% include "_partials_card_performance.html" %}
 </div>
 
 </div>{# end Alpine x-data #}


### PR DESCRIPTION
## Summary

- **Dashboard UX rework**: All stats panels (play/draw, preboard/postboard, mulligan, card performance) now render on initial page load with unfiltered data. The format table acts as a filter control — clicking a row re-fetches panels via HTMX with `?format=X`; clicking again or the new "Clear filter" button returns to the unfiltered view. Removed the hidden cascade section, archetype dropdown, and expand/collapse arrows.
- **Opponent filter regression**: Replaced exact JSONB array containment (`@>`) with `ILIKE` substring matching in `game_stats.py` and `card_stats.py` (the `stats.py` fix was already in place). This restores case-insensitive partial matching for the opponent search field.
- **Cleanup**: Removed unused `import json` from `game_stats.py` and `card_stats.py`, removed archetype fetch from dashboard route.

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] All 259 tests pass (`pytest tests/ services/web/tests/ -x -q`)
- [x] Dashboard test asserts "Play/Draw Split", "On Play", "Card Performance", and "Lightning Bolt" appear in initial HTML
- [ ] Manual: load dashboard — stats panels visible without clicking a format
- [ ] Manual: click a format row — panels refresh with filtered data
- [ ] Manual: click "Clear filter" — panels return to unfiltered data
- [ ] Manual: type partial opponent name in search — ILIKE matching returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)