### PR TITLE
Add oracle_id and mtgo_id to catalog.cards

### DIFF
--- a/alembic/versions/014_catalog_cards_oracle_mtgo_ids.py
+++ b/alembic/versions/014_catalog_cards_oracle_mtgo_ids.py
@@ -1,0 +1,72 @@
+"""catalog.cards: add oracle_id and mtgo_id columns.
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-05-17
+
+oracle_id (UUID, nullable) — Scryfall's oracle identifier, shared across
+all printings of the same card. Double-faced cards share the same oracle_id
+for both faces. Non-unique index because DFCs produce multiple rows with
+the same oracle_id.
+
+mtgo_id (INTEGER, nullable) — MTGO's internal CatId. Not every Scryfall
+card has one (paper-only printings, tokens, etc.), so nullable. Unique
+where present — each MTGO CatId maps to exactly one card printing.
+
+These columns are prerequisites for the card analytics engine: oracle_id
+enables reprint aggregation, mtgo_id enables resolving MTGO deck
+composition files to card names.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "014"
+down_revision: str | None = "013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "cards",
+        sa.Column("oracle_id", postgresql.UUID(as_uuid=True), nullable=True),
+        schema="catalog",
+    )
+    op.add_column(
+        "cards",
+        sa.Column("mtgo_id", sa.Integer(), nullable=True),
+        schema="catalog",
+    )
+
+    # Non-unique: DFCs share oracle_id across faces.
+    op.create_index(
+        "cards_oracle_id_idx",
+        "cards",
+        ["oracle_id"],
+        schema="catalog",
+    )
+
+    # Unique where present — nullable columns are excluded from unique
+    # constraints by Postgres (NULLs are always distinct), so this
+    # naturally allows multiple rows with mtgo_id IS NULL.
+    op.create_index(
+        "cards_mtgo_id_idx",
+        "cards",
+        ["mtgo_id"],
+        unique=True,
+        schema="catalog",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("cards_mtgo_id_idx", table_name="cards", schema="catalog")
+    op.drop_index("cards_oracle_id_idx", table_name="cards", schema="catalog")
+    op.drop_column("cards", "mtgo_id", schema="catalog")
+    op.drop_column("cards", "oracle_id", schema="catalog")

--- a/services/analytics/analytics_service/scryfall_sync.py
+++ b/services/analytics/analytics_service/scryfall_sync.py
@@ -66,14 +66,18 @@ class SyncResult:
 _UPSERT_SQL = text(
     """
     INSERT INTO catalog.cards (
-        scryfall_id, name, oracle_text, type_line, mana_cost,
-        colors, set_code, image_uri, art_crop_uri, legalities, synced_at
+        scryfall_id, oracle_id, mtgo_id, name, oracle_text, type_line,
+        mana_cost, colors, set_code, image_uri, art_crop_uri,
+        legalities, synced_at
     ) VALUES (
-        :scryfall_id, :name, :oracle_text, :type_line, :mana_cost,
+        :scryfall_id, CAST(:oracle_id AS uuid), :mtgo_id, :name,
+        :oracle_text, :type_line, :mana_cost,
         CAST(:colors AS jsonb), :set_code, :image_uri, :art_crop_uri,
         CAST(:legalities AS jsonb), :synced_at
     )
     ON CONFLICT (scryfall_id) DO UPDATE SET
+        oracle_id = EXCLUDED.oracle_id,
+        mtgo_id = EXCLUDED.mtgo_id,
         name = EXCLUDED.name,
         oracle_text = EXCLUDED.oracle_text,
         type_line = EXCLUDED.type_line,
@@ -102,6 +106,8 @@ def _card_row(card: dict[str, Any], synced_at: datetime) -> dict[str, Any]:
     legalities = card.get("legalities")
     return {
         "scryfall_id": card["id"],
+        "oracle_id": card.get("oracle_id"),
+        "mtgo_id": card.get("mtgo_id"),
         "name": card["name"],
         "oracle_text": card.get("oracle_text"),
         "type_line": card.get("type_line"),


### PR DESCRIPTION
## Summary

- **Migration 014**: adds `oracle_id` (UUID, nullable) and `mtgo_id` (INTEGER, nullable) columns to `catalog.cards`, with a non-unique index on `oracle_id` (DFCs share it across faces) and a unique index on `mtgo_id` (nullable — not all Scryfall cards have MTGO IDs)
- **Scryfall sync**: `_card_row()` now extracts `oracle_id` and `mtgo_id` from the bulk-data feed; `_UPSERT_SQL` includes both columns in INSERT, VALUES (with `CAST(:oracle_id AS uuid)`), and ON CONFLICT UPDATE SET
- No ORM model change needed — `catalog.cards` has no ORM model; it's accessed via raw SQL

## Why

`oracle_id` enables reprint aggregation (same card name across printings shares one oracle_id but has different scryfall_ids). `mtgo_id` enables resolving MTGO's internal CatId from deck composition files to card names. Both are prerequisites for the card analytics engine.

## Test plan

- [ ] Migration runs cleanly (forward and back)
- [ ] Scryfall sync populates oracle_id and mtgo_id on next sync
- [ ] Existing analytics test suite passes (53/53 — 34 pre-existing ERRORs from unrelated `instrument_engine` import issue)
- [ ] ruff check passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)