### PR TITLE
fix: dashboard format filter + admin cards cleanup

### DIFF
--- a/services/web/tests/test_admin_cards_route.py
+++ b/services/web/tests/test_admin_cards_route.py
@@ -1,9 +1,8 @@
 """Tests for the /admin/cards admin route.
 
 Bypasses browser auth via FastAPI dependency overrides and patches the
-analytics client. Covers admin gating, the happy path (status + scraper
-health render), the sync trigger redirect, and the analytics-outage
-banner.
+analytics client. Covers admin gating, the happy path (card-mirror status
+render), the sync trigger redirect, and the analytics-outage banner.
 """
 
 from __future__ import annotations
@@ -74,17 +73,6 @@ def _sample_status() -> dict[str, Any]:
     }
 
 
-def _sample_health(broken: bool = False) -> dict[str, Any]:
-    return {
-        "scraper_name": "mtgo",
-        "last_run_at": datetime(2026, 5, 10, 6, 0, tzinfo=UTC),
-        "last_success_at": datetime(2026, 5, 10, 6, 0, tzinfo=UTC),
-        "consecutive_failures": 3 if broken else 0,
-        "is_broken": broken,
-        "last_error": "boom" if broken else None,
-    }
-
-
 @pytest.mark.asyncio
 async def test_admin_cards_renders(
     app_client: httpx.AsyncClient,
@@ -97,11 +85,7 @@ async def test_admin_cards_renders(
     async def fake_status(_url: str, _token: str) -> Any:
         return _sample_status()
 
-    async def fake_health(_url: str, _token: str) -> Any:
-        return _sample_health()
-
     monkeypatch.setattr(analytics_client, "admin_get_cards_status", fake_status)
-    monkeypatch.setattr(analytics_client, "admin_get_scraper_health", fake_health)
 
     _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
     try:
@@ -112,11 +96,9 @@ async def test_admin_cards_renders(
     assert r.status_code == 200
     text = r.text
     assert "31337" in text
-    assert "MTGO scraper health" in text
-    # Sync button + form present
     assert 'action="/admin/cards/sync"' in text
-    assert "OK" in text  # not broken
-    assert "Sync started" not in text  # not via ?synced=1
+    assert "Sync started" not in text
+    assert "MTGO scraper health" not in text
 
 
 @pytest.mark.asyncio
@@ -131,11 +113,7 @@ async def test_admin_cards_shows_synced_banner(
     async def fake_status(*_a: Any, **_kw: Any) -> Any:
         return _sample_status()
 
-    async def fake_health(*_a: Any, **_kw: Any) -> Any:
-        return _sample_health()
-
     monkeypatch.setattr(analytics_client, "admin_get_cards_status", fake_status)
-    monkeypatch.setattr(analytics_client, "admin_get_scraper_health", fake_health)
 
     _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
     try:
@@ -159,11 +137,7 @@ async def test_admin_cards_outage_banner_when_status_unavailable(
     async def boom_status(*_a: Any, **_kw: Any) -> Any:
         raise analytics_client.AnalyticsClientError("simulated outage")
 
-    async def boom_health(*_a: Any, **_kw: Any) -> Any:
-        raise analytics_client.AnalyticsClientError("simulated outage")
-
     monkeypatch.setattr(analytics_client, "admin_get_cards_status", boom_status)
-    monkeypatch.setattr(analytics_client, "admin_get_scraper_health", boom_health)
 
     _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
     try:
@@ -171,7 +145,6 @@ async def test_admin_cards_outage_banner_when_status_unavailable(
     finally:
         _main.app.dependency_overrides.clear()
 
-    # Both panels failed → 503.
     assert r.status_code == 503
     assert "Analytics service unavailable" in r.text
 
@@ -211,8 +184,6 @@ async def test_admin_cards_sync_redirects_to_synced_marker(
 
     _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
     try:
-        # follow_redirects defaults to False on AsyncClient — we want
-        # to assert the redirect target itself.
         r = await app_client.post("/admin/cards/sync")
     finally:
         _main.app.dependency_overrides.clear()

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -3512,7 +3512,6 @@ def _render_admin_cards(
     user: BrowserUser,
     *,
     cards_status_view: dict[str, Any] | None,
-    scraper_health: dict[str, Any] | None,
     error: str | None,
     synced: bool,
     status_code: int,
@@ -3523,7 +3522,6 @@ def _render_admin_cards(
         {
             "user": user,
             "cards_status": cards_status_view,
-            "scraper_health": scraper_health,
             "error": error,
             "synced": synced,
         },
@@ -3543,7 +3541,6 @@ async def admin_cards_page(
         return blocked
 
     cards_status_view: dict[str, Any] | None = None
-    scraper_health: dict[str, Any] | None = None
     error: str | None = None
     try:
         cards_status_view = await analytics_client.admin_get_cards_status(
@@ -3572,14 +3569,13 @@ async def admin_cards_page(
 
     code = (
         status.HTTP_503_SERVICE_UNAVAILABLE
-        if error and cards_status_view is None and scraper_health is None
+        if error and cards_status_view is None
         else 200
     )
     return _render_admin_cards(
         request,
         user,
         cards_status_view=cards_status_view,
-        scraper_health=scraper_health,
         error=error,
         synced=synced == 1,
         status_code=code,

--- a/services/web/web_service/templates/admin_cards.html
+++ b/services/web/web_service/templates/admin_cards.html
@@ -16,7 +16,6 @@
     <a href="/admin/cards" class="px-4 py-2 text-sm font-medium text-accent border-b-2 border-accent no-underline whitespace-nowrap">Cards</a>
     <a href="/admin/invites" class="px-4 py-2 text-sm dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light border-b-2 border-transparent no-underline whitespace-nowrap">Invites</a>
     <a href="/admin/settings" class="px-4 py-2 text-sm dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light border-b-2 border-transparent no-underline whitespace-nowrap">Settings</a>
-    <a href="/admin/scrapers" class="px-4 py-2 text-sm dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light border-b-2 border-transparent no-underline whitespace-nowrap">Scrapers</a>
 </nav>
 
 {% if error %}
@@ -57,43 +56,4 @@
     </form>
 </div>
 
-{# MTGO scraper health #}
-<div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-6">
-    <h2 class="text-sm font-semibold dark:text-txt-primary text-txt-primary-light mb-3">MTGO scraper health</h2>
-    {% if scraper_health %}
-    <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-3">
-        <div>
-            <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-0.5">Last run</div>
-            <div class="text-sm font-mono dark:text-txt-primary text-txt-primary-light">
-                {% if scraper_health.last_run_at %}{{ scraper_health.last_run_at.strftime("%Y-%m-%d %H:%M UTC") }}{% else %}Never{% endif %}
-            </div>
-        </div>
-        <div>
-            <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-0.5">Last success</div>
-            <div class="text-sm font-mono dark:text-txt-primary text-txt-primary-light">
-                {% if scraper_health.last_success_at %}{{ scraper_health.last_success_at.strftime("%Y-%m-%d %H:%M UTC") }}{% else %}Never{% endif %}
-            </div>
-        </div>
-        <div>
-            <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-0.5">Status</div>
-            <div class="mt-0.5">
-                {% if scraper_health.is_broken %}
-                    <span class="bg-danger-muted text-danger text-xs font-medium px-2 py-0.5 rounded">Broken</span>
-                {% else %}
-                    <span class="bg-success-muted text-success text-xs font-medium px-2 py-0.5 rounded">OK</span>
-                {% endif %}
-            </div>
-        </div>
-        <div>
-            <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-0.5">Consecutive failures</div>
-            <div class="text-sm font-mono dark:text-txt-primary text-txt-primary-light">{{ scraper_health.consecutive_failures }}</div>
-        </div>
-    </div>
-    {% if scraper_health.last_error %}
-    <p class="text-xs dark:text-txt-tertiary text-txt-secondary-light">Last error: {{ scraper_health.last_error }}</p>
-    {% endif %}
-    {% else %}
-        <p class="text-sm dark:text-txt-secondary text-txt-secondary-light">Scraper health unavailable.</p>
-    {% endif %}
-</div>
 {% endblock %}

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -55,9 +55,10 @@
 {# ── Format Filter + Stats Panels (Alpine.js state) ── #}
 <div x-data="{ selectedFormat: null, _initialized: false }"
      x-effect="
+        var fmt = selectedFormat;
         if (!_initialized) { _initialized = true; return; }
-        if (selectedFormat) {
-            var f = encodeURIComponent(selectedFormat);
+        if (fmt) {
+            var f = encodeURIComponent(fmt);
             htmx.ajax('GET', '/dashboard/partials/play-draw?format=' + f, {target: '#play-draw-panel', swap: 'innerHTML'});
             htmx.ajax('GET', '/dashboard/partials/preboard-postboard?format=' + f, {target: '#preboard-postboard-panel', swap: 'innerHTML'});
             htmx.ajax('GET', '/dashboard/partials/mulligans?format=' + f, {target: '#mulligan-panel', swap: 'innerHTML'});


### PR DESCRIPTION
## Summary

- **Dashboard format filter**: Clicking a format row in the "By format" table did nothing. The Alpine.js `x-effect` used a `_initialized` guard that returned early before reading `selectedFormat`, so Alpine never tracked the reactive dependency and never re-ran the effect when the selection changed. Fixed by reading `selectedFormat` into a local variable before the guard check.
- **Admin cards cleanup**: Removed the redundant MTGO scraper health section and Scrapers tab link from `/admin/cards` — this information already lives at `/admin/scrapers`. Cleaned up the backend route handler and `_render_admin_cards` helper to stop fetching/passing `scraper_health`. Updated tests accordingly.

## Test plan
- [x] All 242 web service tests pass (`pytest services/web/tests/ -x`)
- [ ] Verify dashboard format click highlights the row and updates stats panels below
- [ ] Verify "Clear filter" button resets panels to unfiltered state
- [ ] Verify `/admin/cards` shows only the Card Mirror section (no scraper health)
- [ ] Verify `/admin/scrapers` still shows scraper health independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)