### PR TITLE
feat: holding pen for inconclusive match parses

### DIFF
--- a/alembic/versions/025_match_review_status.py
+++ b/alembic/versions/025_match_review_status.py
@@ -1,0 +1,68 @@
+"""parser.matches.review_status: holding pen for inconclusive parses.
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-05-22
+
+Adds a nullable ``review_status`` TEXT column to ``parser.matches`` plus
+an index for the admin filter view and a CHECK constraint that limits
+values to ``'pending_review'`` / ``'rejected'``. NULL is the normal,
+user-visible state — no default — and an admin "accept" sets the column
+back to NULL rather than introducing a separate state.
+
+Rationale: under #75, partial parses (match-level winner None *and* no
+game has a resolved winner) were dropped at the consumer. That hid
+suspicious data but also hid it from the operator. Holding-pen rows
+land here with ``review_status='pending_review'`` instead and are
+surfaced on the admin matches page so a human can decide whether they
+represent a real match worth keeping.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "025"
+down_revision: str | None = "024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "matches",
+        sa.Column("review_status", sa.Text(), nullable=True),
+        schema="parser",
+    )
+    op.create_check_constraint(
+        "ck_matches_review_status_valid",
+        "matches",
+        "review_status IS NULL OR review_status IN ('pending_review', 'rejected')",
+        schema="parser",
+    )
+    op.create_index(
+        "ix_matches_review_status",
+        "matches",
+        ["review_status"],
+        schema="parser",
+        postgresql_where=sa.text("review_status IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_matches_review_status",
+        table_name="matches",
+        schema="parser",
+    )
+    op.drop_constraint(
+        "ck_matches_review_status_valid",
+        "matches",
+        type_="check",
+        schema="parser",
+    )
+    op.drop_column("matches", "review_status", schema="parser")

--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -120,7 +120,9 @@ async def _resolve_hero_name(
                 """
                 SELECT hero_player_name
                 FROM parser.matches
-                WHERE user_id = :user_id AND hero_player_name IS NOT NULL
+                WHERE user_id = :user_id
+                  AND hero_player_name IS NOT NULL
+                  AND review_status IS NULL
                 ORDER BY COALESCE(played_at, parsed_at) DESC
                 LIMIT 1
                 """
@@ -138,6 +140,7 @@ async def _resolve_hero_name(
                 SELECT players->>0
                 FROM parser.matches
                 WHERE user_id = :user_id
+                  AND review_status IS NULL
                 ORDER BY COALESCE(played_at, parsed_at) DESC
                 LIMIT 1
                 """
@@ -156,8 +159,12 @@ def _build_match_where(
     date_to: str | None = None,
     opponent_archetype_id: str | None = None,
 ) -> str:
-    """Build WHERE fragments that filter on parser.matches columns."""
-    clauses: list[str] = []
+    """Build WHERE fragments that filter on parser.matches columns.
+
+    Always emits a ``m.review_status IS NULL`` clause so holding-pen
+    rows never feed into user-facing card stats.
+    """
+    clauses: list[str] = ["m.review_status IS NULL"]
     if format_filter:
         clauses.append("LOWER(m.format) = LOWER(:format)")
         params["format"] = format_filter
@@ -215,6 +222,7 @@ async def _has_card_game_stats(db: AsyncSession, user_id: int) -> bool:
                 "  SELECT 1 FROM analytics.card_game_stats cgs"
                 "  JOIN parser.matches m ON m.id = cgs.match_id"
                 "  WHERE m.user_id = :user_id AND cgs.is_local = true"
+                "    AND m.review_status IS NULL"
                 "  LIMIT 1"
                 ")"
             ),
@@ -346,7 +354,7 @@ async def _load_card_appearances(
     date_to: str | None = None,
 ) -> list[dict[str, Any]]:
     """Load per-game card appearance data using SQL-level JSONB extraction."""
-    where = "WHERE m.user_id = :user_id"
+    where = "WHERE m.user_id = :user_id AND m.review_status IS NULL"
     params: dict[str, Any] = {"user_id": user_id}
     if format_filter:
         where += " AND LOWER(m.format) = LOWER(:format)"
@@ -424,7 +432,7 @@ async def _load_card_appearances_fallback(
     date_to: str | None = None,
 ) -> list[dict[str, Any]]:
     """Fallback loader for battlefield entries stored as plain strings."""
-    where = "WHERE m.user_id = :user_id"
+    where = "WHERE m.user_id = :user_id AND m.review_status IS NULL"
     params: dict[str, Any] = {"user_id": user_id}
     if format_filter:
         where += " AND LOWER(m.format) = LOWER(:format)"
@@ -537,7 +545,7 @@ async def _load_card_appearances_auto(
     if results:
         return results
 
-    where = "WHERE m.user_id = :user_id"
+    where = "WHERE m.user_id = :user_id AND m.review_status IS NULL"
     params: dict[str, Any] = {"user_id": user_id}
     if format_filter:
         where += " AND LOWER(m.format) = LOWER(:format)"
@@ -1005,13 +1013,15 @@ async def get_game_turns(
 
     Scoped to authenticated user (the match must belong to them).
     """
-    # Verify match ownership
+    # Verify match ownership; pending_review / rejected matches are
+    # invisible to the user so the per-game turn view 404s for them too.
     match_row = (
         await db.execute(
             text(
                 """
                 SELECT id FROM parser.matches
                 WHERE id = :match_id AND user_id = :user_id
+                  AND review_status IS NULL
                 """
             ),
             {"match_id": match_id, "user_id": user.user_id},

--- a/services/analytics/analytics_service/game_stats.py
+++ b/services/analytics/analytics_service/game_stats.py
@@ -104,7 +104,7 @@ async def _load_games_with_context(
     Returns a list of dicts with keys: game_number, winner, on_play,
     play_first, opening_hand_sizes, players, format, hero.
     """
-    where = "WHERE m.user_id = :user_id"
+    where = "WHERE m.user_id = :user_id AND m.review_status IS NULL"
     params: dict[str, Any] = {"user_id": user_id}
     if format_filter:
         where += " AND LOWER(m.format) = LOWER(:format)"
@@ -311,7 +311,7 @@ async def get_game_length(
     v0.9.6: JOINs ``parser.game_players`` for hero resolution
     instead of querying ``auth.users`` separately.
     """
-    where = "WHERE m.user_id = :user_id"
+    where = "WHERE m.user_id = :user_id AND m.review_status IS NULL"
     params: dict[str, Any] = {"user_id": user.user_id}
     if format:
         where += " AND LOWER(m.format) = LOWER(:format)"

--- a/services/analytics/analytics_service/main.py
+++ b/services/analytics/analytics_service/main.py
@@ -498,6 +498,11 @@ class AdminMatchItem(BaseModel):
     # mirrors analytics.list_matches / _classify_match. A null winner
     # with no resolved game winners is "incomplete", not a draw.
     is_draw: bool = False
+    # Holding-pen state — see alembic 025. ``None`` is normal /
+    # user-visible, ``'pending_review'`` is awaiting an admin verdict,
+    # ``'rejected'`` is admin-discarded. Admin endpoints surface all
+    # three; user-facing endpoints only return None rows.
+    review_status: str | None = None
 
 
 class AdminMatchListResponse(BaseModel):
@@ -505,6 +510,9 @@ class AdminMatchListResponse(BaseModel):
     total: int = 0
     page: int = 1
     per_page: int = _ADMIN_MATCHES_DEFAULT_PER_PAGE
+
+
+_VALID_REVIEW_STATUS_FILTERS = {"all", "pending_review", "rejected", "normal"}
 
 
 @admin_router.get("/matches", response_model=AdminMatchListResponse)
@@ -519,8 +527,21 @@ async def admin_list_matches(
     result: Annotated[str | None, Query()] = None,
     date_from: Annotated[date | None, Query()] = None,
     date_to: Annotated[date | None, Query()] = None,
+    review_status: Annotated[str | None, Query()] = None,
 ) -> AdminMatchListResponse:
-    """System-wide match listing for admins — all users' matches."""
+    """System-wide match listing for admins — all users' matches.
+
+    Unlike the user-facing list, this surfaces ``pending_review`` and
+    ``'rejected'`` rows (the holding pen) so an admin can triage them.
+    The ``review_status`` filter controls visibility:
+
+    * ``None`` / ``'all'`` — every row, default.
+    * ``'pending_review'`` — only inconclusive parses waiting on a
+      verdict.
+    * ``'rejected'`` — only admin-discarded rows.
+    * ``'normal'`` — only ``review_status IS NULL`` (matches what
+      regular users see).
+    """
     sm = get_sessionmaker()
     async with sm() as session:
         # Build WHERE clauses dynamically
@@ -539,6 +560,23 @@ async def admin_list_matches(
             conditions.append("m.players::text ILIKE :opponent")
             params["opponent"] = f"%{opponent}%"
 
+        rs_filter = (review_status or "").lower()
+        if rs_filter and rs_filter not in _VALID_REVIEW_STATUS_FILTERS:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={
+                    "error": "invalid_review_status",
+                    "allowed": sorted(_VALID_REVIEW_STATUS_FILTERS),
+                },
+            )
+        if rs_filter == "pending_review":
+            conditions.append("m.review_status = 'pending_review'")
+        elif rs_filter == "rejected":
+            conditions.append("m.review_status = 'rejected'")
+        elif rs_filter == "normal":
+            conditions.append("m.review_status IS NULL")
+        # rs_filter == "" or "all" leaves all rows visible.
+
         where_clause = (" AND " + " AND ".join(conditions)) if conditions else ""
 
         # Count total
@@ -551,7 +589,8 @@ async def admin_list_matches(
             f"""
             SELECT m.id, m.user_id, u.email, m.format, m.players,
                    m.match_result, m.winner, m.game_count,
-                   COALESCE(m.played_at, m.parsed_at) AS played_at
+                   COALESCE(m.played_at, m.parsed_at) AS played_at,
+                   m.review_status
             FROM parser.matches m
             LEFT JOIN auth.users u ON u.id = m.user_id
             WHERE 1=1{where_clause}
@@ -606,6 +645,7 @@ async def admin_list_matches(
             winner,
             game_count,
             played_at,
+            row_review_status,
         ) = row
         item = AdminMatchItem(
             match_id=str(match_id),
@@ -618,6 +658,7 @@ async def admin_list_matches(
             game_count=int(game_count) if game_count else 0,
             played_at=played_at,
             is_draw=match_id in draw_match_ids,
+            review_status=row_review_status,
         )
         items.append(item)
 
@@ -637,6 +678,123 @@ async def admin_list_matches(
         items = filtered
 
     return AdminMatchListResponse(matches=items, total=total, page=page, per_page=per_page)
+
+
+# ---------------------------------------------------------------------------
+# Admin match review — holding pen verdicts
+# ---------------------------------------------------------------------------
+
+
+# Values an admin can set via POST /admin/matches/{id}/review. ``None``
+# (encoded as ``null`` in JSON) accepts a held-back parse and makes it
+# user-visible. ``'pending_review'`` re-flags a normal row. ``'rejected'``
+# permanently discards a held parse from users + analytics.
+_VALID_REVIEW_VERDICTS: set[str | None] = {None, "pending_review", "rejected"}
+
+
+class MatchReviewRequest(BaseModel):
+    review_status: str | None = None
+
+
+@admin_router.post("/matches/{match_id}/review", response_model=AdminMatchItem)
+async def admin_update_match_review_status(
+    match_id: uuid.UUID,
+    body: MatchReviewRequest,
+    _admin: AuthenticatedUser = Depends(require_admin),
+) -> AdminMatchItem:
+    """Set the holding-pen verdict on a single match.
+
+    ``review_status=null`` accepts the parse (back to user-visible).
+    ``'rejected'`` permanently discards. ``'pending_review'`` flags a
+    normal row for admin re-review. Other values are 422.
+    """
+    verdict = body.review_status
+    if verdict not in _VALID_REVIEW_VERDICTS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "invalid_review_status",
+                "allowed": [None, "pending_review", "rejected"],
+            },
+        )
+    sm = get_sessionmaker()
+    async with sm() as session:
+        result = await session.execute(
+            text("UPDATE parser.matches SET review_status = :rs WHERE id = :mid RETURNING id"),
+            {"rs": verdict, "mid": match_id},
+        )
+        updated = result.one_or_none()
+        if updated is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": "match_not_found"},
+            )
+        await session.commit()
+        # Cache invalidation — clear the match's user's analytics
+        # summary so the dashboard recomputes with the new visibility.
+        # Best-effort; the user-facing endpoints already filter live.
+        try:
+            owner_row = (
+                await session.execute(
+                    text("SELECT user_id FROM parser.matches WHERE id = :mid"),
+                    {"mid": match_id},
+                )
+            ).scalar_one_or_none()
+        except Exception:  # noqa: BLE001
+            owner_row = None
+        # Re-read the row so the caller gets a coherent post-update view
+        # alongside the user_email and computed is_draw flag.
+        row = (
+            await session.execute(
+                text(
+                    """
+                    SELECT m.id, m.user_id, u.email, m.format, m.players,
+                           m.match_result, m.winner, m.game_count,
+                           COALESCE(m.played_at, m.parsed_at) AS played_at,
+                           m.review_status
+                    FROM parser.matches m
+                    LEFT JOIN auth.users u ON u.id = m.user_id
+                    WHERE m.id = :mid
+                    """
+                ),
+                {"mid": match_id},
+            )
+        ).one()
+        # Recompute is_draw the same way the list endpoint does.
+        game_win_rows = (
+            await session.execute(
+                text(
+                    """
+                    SELECT winner, COUNT(*) AS n
+                    FROM parser.games
+                    WHERE match_id = :mid AND winner IS NOT NULL
+                    GROUP BY winner
+                    """
+                ),
+                {"mid": match_id},
+            )
+        ).all()
+    wins_by_player = {str(w): int(n) for w, n in game_win_rows}
+    is_draw_flag = _is_true_draw(wins_by_player)
+    if owner_row is not None:
+        try:
+            redis_client = await get_redis(get_settings().redis_url)
+            await invalidate_user(redis_client, int(owner_row))
+        except Exception:  # noqa: BLE001
+            _log.debug("review-status cache invalidate failed user_id=%s", owner_row)
+    return AdminMatchItem(
+        match_id=str(row[0]),
+        user_id=int(row[1]),
+        user_email=row[2],
+        format=row[3],
+        players=[str(p) for p in (row[4] or [])],
+        match_result=row[5],
+        winner=row[6],
+        game_count=int(row[7]) if row[7] else 0,
+        played_at=row[8],
+        review_status=row[9],
+        is_draw=is_draw_flag,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/services/analytics/analytics_service/matches.py
+++ b/services/analytics/analytics_service/matches.py
@@ -77,6 +77,7 @@ async def get_match(
                        hero_player_name
                 FROM parser.matches
                 WHERE id = :match_id AND user_id = :user_id
+                  AND review_status IS NULL
                 """
             ),
             {"match_id": match_id, "user_id": user.user_id},
@@ -143,6 +144,7 @@ async def update_match_format(
             UPDATE parser.matches
                SET format = :format, format_source = 'user'
              WHERE id = :match_id AND user_id = :user_id
+               AND review_status IS NULL
             """
         ),
         {"format": key.title(), "match_id": match_id, "user_id": user.user_id},

--- a/services/analytics/analytics_service/stats.py
+++ b/services/analytics/analytics_service/stats.py
@@ -142,6 +142,7 @@ async def _load_user_matches(db: AsyncSession, user_id: int) -> list[dict[str, A
                        hero_player_name
                 FROM parser.matches
                 WHERE user_id = :user_id
+                  AND review_status IS NULL
                 ORDER BY COALESCE(played_at, parsed_at) DESC
                 """
             ),
@@ -371,6 +372,7 @@ async def get_username_suggestion(
                 FROM parser.matches m
                 CROSS JOIN LATERAL jsonb_array_elements_text(m.players) AS pname
                 WHERE m.user_id = :user_id
+                  AND m.review_status IS NULL
                 GROUP BY pname
                 ORDER BY n DESC
                 LIMIT 5
@@ -431,8 +433,10 @@ async def list_matches(
     v0.9.6: Uses ``hero_player_name`` from the match row instead of
     a separate ``auth.users`` lookup.
     """
-    # Build SQL WHERE dynamically for filters that can be pushed to SQL
-    where = "WHERE m.user_id = :user_id"
+    # Build SQL WHERE dynamically for filters that can be pushed to SQL.
+    # ``review_status IS NULL`` keeps holding-pen rows out of the
+    # user-facing list — admins see them via /analytics/admin/matches.
+    where = "WHERE m.user_id = :user_id AND m.review_status IS NULL"
     params: dict[str, Any] = {"user_id": user.user_id}
 
     if format and format.lower() != "all":

--- a/services/analytics/tests/test_review_status_filter.py
+++ b/services/analytics/tests/test_review_status_filter.py
@@ -1,0 +1,174 @@
+"""Tests for the holding-pen review_status filtering on user-facing stats.
+
+The user-facing /stats endpoints must hide ``pending_review`` and
+``'rejected'`` rows so the dashboard reflects the same world a regular
+user would see in the match list. The admin endpoint surfaces them.
+
+These tests cover the handler/aggregation wiring by patching
+``_load_user_matches`` to return only what would survive the SQL
+``WHERE m.review_status IS NULL`` clause — proving the contract: the
+endpoint trusts the loader to filter, and the loader's SQL is the one
+under test below as a separate string-level assertion.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _analytics_test_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    out = tmp_path_factory.mktemp("analytics-jwt-keys-review")
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pub_path = out / "jwt_public.pem"
+    pub_path.write_bytes(pub_pem)
+    os.environ["DA_JWT_PUBLIC_KEY_PATH"] = str(pub_path)
+    os.environ.setdefault("DA_DATABASE_URL", "postgresql+asyncpg://x:x@localhost:5432/x")
+    os.environ.setdefault("DA_REDIS_URL", "redis://localhost:6379/0")
+    yield pub_path
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from analytics_service import main as _main
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 7) -> Any:
+    from analytics_service import deps as _deps
+
+    fake = _deps.AuthenticatedUser(user_id=user_id, role="user")
+
+    async def _dep() -> _deps.AuthenticatedUser:
+        return fake
+
+    return _dep
+
+
+def test_load_user_matches_sql_filters_review_status() -> None:
+    """String-level check: the user-facing match loader emits a
+    ``review_status IS NULL`` clause. This is the contract that keeps
+    holding-pen rows out of every endpoint that reaches through it."""
+    import inspect
+
+    from analytics_service import stats as _stats
+
+    src = inspect.getsource(_stats._load_user_matches)
+    assert "review_status IS NULL" in src
+
+    src_list = inspect.getsource(_stats.list_matches)
+    assert "review_status IS NULL" in src_list
+
+
+def test_matches_detail_sql_filters_review_status() -> None:
+    """Same string-level check on the single-match endpoint — fetching
+    a pending_review match by ID must return 404 to a regular user."""
+    import inspect
+
+    from analytics_service import matches as _matches
+
+    src = inspect.getsource(_matches.get_match)
+    assert "review_status IS NULL" in src
+
+
+def test_admin_matches_endpoint_supports_review_status_filter() -> None:
+    """The admin match list endpoint must accept the ``review_status``
+    query parameter so the UI can filter on it. This is a smoke check
+    that the parameter is declared and the validation list is wired."""
+    from analytics_service import main as _main
+
+    valid = _main._VALID_REVIEW_STATUS_FILTERS
+    assert {"all", "pending_review", "rejected", "normal"} <= valid
+
+
+@pytest.mark.asyncio
+async def test_summary_loader_filtering_contract(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: with a fake loader that already filtered out the
+    holding-pen rows (mirrors what the SQL does), the summary reflects
+    only the user-visible matches. Holding-pen rows would never reach
+    the aggregator."""
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+    from analytics_service import stats as _stats
+
+    # The user has 3 matches in the DB: 1 conclusive, 1 pending_review,
+    # 1 rejected. The SQL filter (`WHERE review_status IS NULL`) means
+    # the loader returns only the conclusive one.
+    conclusive_id = uuid.uuid4()
+    matches = [
+        {
+            "id": conclusive_id,
+            "format": "Modern",
+            "players": ["hero", "villain"],
+            "played_at": datetime.now(UTC),
+            "wins_by_player": {"hero": 2},
+            "hero_player_name": "hero",
+        }
+    ]
+
+    async def fake_loader(_db: Any, _user_id: int) -> list[dict[str, Any]]:
+        return matches
+
+    monkeypatch.setattr(_stats, "_load_user_matches", fake_loader)
+
+    async def _no_redis() -> None:
+        return None
+
+    monkeypatch.setattr(_stats, "_get_redis_or_none", _no_redis)
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get("/analytics/stats/summary")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total_matches"] == 1
+    assert body["wins"] == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_review_endpoint_rejects_invalid_verdict(
+    app_client: httpx.AsyncClient,
+) -> None:
+    """POST /analytics/admin/matches/{id}/review with a bogus
+    review_status string must 422 rather than silently no-op."""
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    fake = _deps.AuthenticatedUser(user_id=1, role="admin")
+
+    async def _dep() -> _deps.AuthenticatedUser:
+        return fake
+
+    _main.app.dependency_overrides[_deps.require_admin] = _dep
+    try:
+        r = await app_client.post(
+            f"/analytics/admin/matches/{uuid.uuid4()}/review",
+            json={"review_status": "bogus_value"},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+    assert r.status_code == 422
+    assert r.json()["detail"]["error"] == "invalid_review_status"

--- a/services/parser/parser_service/consumer.py
+++ b/services/parser/parser_service/consumer.py
@@ -182,21 +182,34 @@ class ParserConsumer:
             return None
 
         parsed = self._parser.parse(content)
-        if _is_partial_parse(parsed):
-            # Either nothing extractable, or only a game header with no
-            # resolved winners. MTGO appends to the log throughout the
-            # match, so the agent ships intermediate snapshots before
-            # any game finishes. Skipping these prevents winner-less
-            # "Draw" husks (issue #71) — a later snapshot of the same
-            # match will carry the resolved winners.
+        if _is_empty_parse(parsed):
+            # No games at all — nothing the agent has captured. There's
+            # no admin value in surfacing these; drop on the floor.
             _log.warning(
-                "skipping partial parse sha=%s user_id=%s games=%d match_winner=%s",
+                "skipping empty parse sha=%s user_id=%s games=0 match_winner=%s",
+                sha256,
+                user_id,
+                parsed.winner,
+            )
+            return parsed
+
+        review_status: str | None = None
+        if _is_partial_parse(parsed):
+            # Games observed but no resolved winners anywhere — could
+            # be an in-progress MTGO snapshot the agent caught during
+            # a natural lull, or a genuine broken parse. Persist with
+            # ``pending_review`` so an admin can decide; a later, more
+            # complete snapshot of the same logical match will UPDATE
+            # this row back to ``review_status=NULL`` automatically
+            # (see persist_match → _update_match_row).
+            _log.info(
+                "holding-pen partial parse sha=%s user_id=%s games=%d match_winner=%s",
                 sha256,
                 user_id,
                 len(parsed.games),
                 parsed.winner,
             )
-            return parsed
+            review_status = "pending_review"
 
         # Resolve the hero player name from auth.users.mtgo_usernames.
         hero_player_name = await self._resolve_hero(user_id, parsed.players)
@@ -209,6 +222,7 @@ class ParserConsumer:
                     sha256,
                     user_id,
                     hero_player_name=hero_player_name,
+                    review_status=review_status,
                 )
             except Exception:
                 _log.exception("persist failed sha=%s user_id=%s", sha256, user_id)
@@ -419,22 +433,35 @@ class ParserConsumer:
 # ---------------------------------------------------------------------------
 
 
+def _is_empty_parse(parsed: ParsedMatch) -> bool:
+    """True when the parse extracted no games at all.
+
+    Distinct from :func:`_is_partial_parse`: an empty parse is pure
+    garbage (no header, no game data, nothing observable) and there's
+    no admin value in surfacing it for review. Empty parses are dropped
+    outright; partial parses with games but no winners land in the
+    holding pen.
+    """
+    return not parsed.games
+
+
 def _is_partial_parse(parsed: ParsedMatch) -> bool:
-    """Decide whether a parse is too incomplete to persist (issue #71).
+    """Decide whether a parse is "winner-less" — holding-pen candidate.
 
-    A parse is "partial" — and must NOT be stored — when there is no
-    match-level winner AND no game has a resolved winner either. That
-    catches both:
-
-    * empty parses (no games, no winner, no format)
-    * snapshots where MTGO has emitted a game header but the game has
-      not finished yet (the agent's 5-second stability gate fires
-      during natural lulls in play)
+    Returns True when there is no match-level winner AND no game has a
+    resolved winner either. That catches snapshots where MTGO has
+    emitted a game header but the game has not finished yet (the
+    agent's 5-second stability gate fires during natural lulls in
+    play).
 
     A real Magic draw is *not* partial: each game has a winner field
     but neither player wins the majority, so ``parsed.winner`` is None
     while ``parsed.games[*].winner`` is populated. That case must be
-    persisted.
+    persisted normally.
+
+    Under v0.9.8 the consumer no longer drops partial parses outright
+    — it now persists them with ``review_status='pending_review'`` so
+    an admin can choose to accept or reject.
     """
     if parsed.winner:
         return False

--- a/services/parser/parser_service/models.py
+++ b/services/parser/parser_service/models.py
@@ -29,6 +29,7 @@ from typing import Any
 from sqlalchemy import (
     BigInteger,
     Boolean,
+    CheckConstraint,
     DateTime,
     Float,
     ForeignKey,
@@ -76,6 +77,13 @@ class Match(Base):
     parsed_with_version: Mapped[str | None] = mapped_column(Text, nullable=True)
     archetype_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     hero_player_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Holding-pen state for inconclusive parses. NULL = normal,
+    # user-visible. ``'pending_review'`` = parse came in without a
+    # match winner or any per-game winner; hidden from users and
+    # analytics until an admin accepts (back to NULL) or rejects.
+    # ``'rejected'`` = admin discarded; permanently hidden. The DB
+    # CHECK constraint (alembic 025) enforces the allowed values.
+    review_status: Mapped[str | None] = mapped_column(Text, nullable=True)
     deck_composition_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("parser.deck_compositions.id", ondelete="SET NULL"),
@@ -98,6 +106,15 @@ class Match(Base):
         Index("ix_matches_user_id_parsed_at", "user_id", "parsed_at"),
         Index("ix_matches_sha256", "sha256"),
         Index("ix_matches_raw_match_id", "raw_match_id"),
+        Index(
+            "ix_matches_review_status",
+            "review_status",
+            postgresql_where=text("review_status IS NOT NULL"),
+        ),
+        CheckConstraint(
+            "review_status IS NULL OR review_status IN ('pending_review', 'rejected')",
+            name="ck_matches_review_status_valid",
+        ),
     )
 
 

--- a/services/parser/parser_service/persistence.py
+++ b/services/parser/parser_service/persistence.py
@@ -128,6 +128,7 @@ async def _insert_new_match(
     user_id: int,
     raw_match_id: str | None,
     hero_player_name: str | None,
+    review_status: str | None,
     now: datetime,
 ) -> uuid.UUID:
     """Insert a fresh ``matches`` row and return its id."""
@@ -146,6 +147,7 @@ async def _insert_new_match(
         played_at=parsed.played_at,
         parsed_with_version=PARSER_VERSION,
         hero_player_name=hero_player_name,
+        review_status=review_status,
     )
     session.add(match)
     # Flush surfaces unique-violation collisions to the caller without
@@ -162,6 +164,8 @@ async def _update_match_row(
     raw_match_id: str | None,
     parsed: ParsedMatch,
     hero_player_name: str | None,
+    review_status: str | None,
+    existing_review_status: str | None,
     now: datetime,
     preserve_manual_format: bool,
 ) -> None:
@@ -170,6 +174,15 @@ async def _update_match_row(
     ``preserve_manual_format`` keeps the stored ``format`` and
     ``format_source`` when an admin has set ``format_source='manual'``
     so reparses don't clobber the manual override.
+
+    ``review_status`` is the new desired status from the caller
+    (``None`` for a conclusive parse, ``'pending_review'`` for a
+    partial one). ``existing_review_status`` is what's already on the
+    row. The rule: a row that an admin has already ``'rejected'`` stays
+    rejected on reparse — admin verdicts are not auto-undone. Otherwise
+    the new status wins, which is what upgrades a previous
+    ``pending_review`` row to NULL when a later conclusive snapshot
+    arrives for the same logical match.
     """
     values: dict[str, Any] = {
         "sha256": sha256,
@@ -186,6 +199,11 @@ async def _update_match_row(
         "parsed_with_version": PARSER_VERSION,
         "hero_player_name": hero_player_name,
     }
+    if existing_review_status == "rejected":
+        # Preserve admin's rejection — a later snapshot must not undo it.
+        values["review_status"] = "rejected"
+    else:
+        values["review_status"] = review_status
     if not preserve_manual_format:
         values["format"] = parsed.format
         values["format_source"] = None
@@ -198,6 +216,7 @@ async def persist_match(
     sha256: str,
     user_id: int,
     hero_player_name: str | None = None,
+    review_status: str | None = None,
 ) -> Match:
     """Insert or update a parsed match (plus games and per-turn states).
 
@@ -226,6 +245,14 @@ async def persist_match(
     ``hero_player_name`` is the resolved MTGO username of the uploader,
     determined by cross-referencing ``auth.users.mtgo_usernames`` with
     the parsed player list.
+
+    ``review_status`` carries the consumer's verdict on the incoming
+    parse — ``None`` for conclusive parses, ``'pending_review'`` for
+    holding-pen parses (winner-less but at least one game observed).
+    On reparse, the new status wins so a later, conclusive snapshot
+    upgrades a ``pending_review`` row back to NULL. Admin rejections
+    (``'rejected'``) survive across reparses — see
+    :func:`_update_match_row`.
     """
     now = datetime.now(UTC)
     raw_match_id = parsed.raw_match_id
@@ -279,6 +306,8 @@ async def persist_match(
             raw_match_id=raw_match_id or existing.raw_match_id,
             parsed=parsed,
             hero_player_name=hero_player_name,
+            review_status=review_status,
+            existing_review_status=existing.review_status,
             now=now,
             preserve_manual_format=existing.format_source == "manual",
         )
@@ -291,6 +320,7 @@ async def persist_match(
                 user_id=user_id,
                 raw_match_id=raw_match_id,
                 hero_player_name=hero_player_name,
+                review_status=review_status,
                 now=now,
             )
         except IntegrityError:
@@ -310,6 +340,8 @@ async def persist_match(
                 raw_match_id=raw_match_id or existing.raw_match_id,
                 parsed=parsed,
                 hero_player_name=hero_player_name,
+                review_status=review_status,
+                existing_review_status=existing.review_status,
                 now=now,
                 preserve_manual_format=existing.format_source == "manual",
             )

--- a/services/parser/parser_service/scripts/backfill_holding_pen.py
+++ b/services/parser/parser_service/scripts/backfill_holding_pen.py
@@ -179,7 +179,7 @@ async def _flush_analytics_caches(
             _log.info("cache flush: would delete %d analytics keys", len(matched))
     finally:
         with contextlib.suppress(Exception):
-            await client.aclose()  # type: ignore[attr-defined]
+            await client.aclose()
 
 
 async def _run(apply: bool) -> int:

--- a/services/parser/parser_service/scripts/backfill_holding_pen.py
+++ b/services/parser/parser_service/scripts/backfill_holding_pen.py
@@ -132,12 +132,16 @@ async def _flush_analytics_caches(
     *,
     apply: bool,
 ) -> None:
-    """Best-effort: invalidate per-user analytics summary keys.
+    """Best-effort: invalidate per-user analytics cache keys.
 
     Mirrors :func:`cleanup_71_duplicates._flush_analytics_caches`. The
     backfill changes what shows up on the user dashboard for every
     affected user, so caches must be flushed for the change to be
     visible without waiting for the cached value to expire.
+
+    Uses :func:`common.cache.invalidate_user`, which deletes everything
+    matching ``da:stats:{user_id}:*`` — the namespace the analytics
+    service actually writes (see ``common/cache.py``).
     """
     if not affected_user_ids:
         return
@@ -146,7 +150,7 @@ async def _flush_analytics_caches(
     except ImportError:
         _log.warning(
             "redis client unavailable — cannot flush analytics caches. "
-            "Operator: flush per-user analytics:* keys manually."
+            "Operator: flush per-user `da:stats:{user_id}:*` keys manually."
         )
         return
 
@@ -155,28 +159,32 @@ async def _flush_analytics_caches(
         client = redis.from_url(settings.redis_url)
     except Exception:  # noqa: BLE001
         _log.warning(
-            "could not connect to redis — flush analytics:summary:user:* "
-            "and analytics:by-format:user:* keys manually",
+            "could not connect to redis — flush per-user `da:stats:{user_id}:*` keys manually",
         )
         return
 
-    patterns = [
-        "analytics:summary:user:*",
-        "analytics:by-format:user:*",
-        "analytics:stats:user:*",
-    ]
-    matched: list[bytes] = []
+    if not apply:
+        _log.info(
+            "cache flush: would invalidate da:stats:{user_id}:* for %d user(s)",
+            len(affected_user_ids),
+        )
+        with contextlib.suppress(Exception):
+            await client.aclose()
+        return
+
+    from common.cache import invalidate_user
+
+    total = 0
     try:
-        for pattern in patterns:
-            async for key in client.scan_iter(match=pattern, count=200):
-                matched.append(key)
-        if not matched:
-            _log.info("cache flush: no analytics keys matched standard patterns")
-        elif apply:
-            await client.delete(*matched)
-            _log.info("cache flush: deleted %d analytics keys", len(matched))
-        else:
-            _log.info("cache flush: would delete %d analytics keys", len(matched))
+        for user_id in affected_user_ids:
+            deleted = await invalidate_user(client, user_id)
+            _log.info("cache flush: user_id=%s deleted=%d keys", user_id, deleted)
+            total += deleted
+        _log.info(
+            "cache flush: deleted %d da:stats keys across %d user(s)",
+            total,
+            len(affected_user_ids),
+        )
     finally:
         with contextlib.suppress(Exception):
             await client.aclose()

--- a/services/parser/parser_service/scripts/backfill_holding_pen.py
+++ b/services/parser/parser_service/scripts/backfill_holding_pen.py
@@ -1,0 +1,250 @@
+"""One-shot backfill — flag legacy partial parses as pending_review.
+
+Pre-v0.9.8, the consumer either dropped partial parses (post-#75) or
+persisted them as winner-less "draw husks" (pre-#75). v0.9.8 introduces
+the holding pen: partial parses now land with
+``review_status='pending_review'`` so an admin can decide. This script
+walks existing ``parser.matches`` rows and applies the same verdict to
+legacy data the consumer can't see anymore.
+
+Run order (operator):
+
+1. Deploy v0.9.8 — adds ``parser.matches.review_status`` (alembic 025)
+   and the new consumer + persistence behavior.
+2. Then run this script inside the parser container::
+
+       python -m parser_service.scripts.backfill_holding_pen --dry-run
+       python -m parser_service.scripts.backfill_holding_pen --apply
+
+   Dry-run is the default and only prints what it *would* do.
+
+Identification rule (mirrors :func:`consumer._is_partial_parse`):
+
+A row is queued for flagging when **all** of the following hold:
+
+* ``review_status IS NULL`` (already flagged rows are left alone).
+* ``winner IS NULL`` on ``parser.matches``.
+* No row in ``parser.games`` for this ``match_id`` has a non-null
+  ``winner`` (i.e. no game has a resolved per-game winner).
+
+A real Magic draw — match winner null but at least one ``parser.games``
+row has a winner — is preserved as user-visible. Empty rows with no
+games at all are also flagged; the consumer drops empty *new* parses,
+but legacy empties already exist in the DB and the admin should see
+them too.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import sys
+from collections import defaultdict
+from typing import NamedTuple
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from parser_service.db import get_sessionmaker
+from parser_service.settings import get_settings
+
+_log = logging.getLogger("parser.backfill_holding_pen")
+
+
+class _Candidate(NamedTuple):
+    """A row identified as a holding-pen candidate."""
+
+    match_id: str
+    user_id: int
+
+
+# Identifies "would flag" rows: review_status NULL + match-level winner
+# NULL + no per-game winner. ``LEFT JOIN ... GROUP BY ... HAVING
+# BOOL_OR(g.winner IS NOT NULL) IS NOT TRUE`` evaluates to true both for
+# matches with no games at all and matches whose games all have NULL
+# winners — the same union the consumer's _is_empty_parse OR
+# _is_partial_parse catches on the live path.
+_CANDIDATE_SQL = text(
+    """
+    SELECT m.id, m.user_id
+      FROM parser.matches m
+      LEFT JOIN parser.games g ON g.match_id = m.id
+     WHERE m.review_status IS NULL
+       AND m.winner IS NULL
+     GROUP BY m.id, m.user_id
+    HAVING BOOL_OR(g.winner IS NOT NULL) IS NOT TRUE
+    """
+)
+
+
+async def discover_candidates(
+    sm: async_sessionmaker[AsyncSession],
+) -> list[_Candidate]:
+    """Return all rows that would be flagged as pending_review.
+
+    Pure-read query — safe to call from --dry-run.
+    """
+    async with sm() as session:
+        rows = (await session.execute(_CANDIDATE_SQL)).all()
+    return [_Candidate(match_id=str(r[0]), user_id=int(r[1])) for r in rows]
+
+
+async def apply_flags(
+    sm: async_sessionmaker[AsyncSession],
+    candidates: list[_Candidate],
+) -> int:
+    """Set ``review_status='pending_review'`` on the given matches.
+
+    Returns the number of rows actually updated. The WHERE clause
+    re-checks ``review_status IS NULL`` so a concurrent admin verdict
+    between discover and apply is preserved.
+    """
+    if not candidates:
+        return 0
+    ids = [c.match_id for c in candidates]
+    async with sm() as session:
+        result = await session.execute(
+            text(
+                "UPDATE parser.matches "
+                "SET review_status = 'pending_review' "
+                "WHERE id = ANY(:ids) AND review_status IS NULL "
+                "RETURNING id"
+            ),
+            {"ids": ids},
+        )
+        updated = len(result.all())
+        await session.commit()
+    return updated
+
+
+def per_user_counts(candidates: list[_Candidate]) -> dict[int, int]:
+    """Aggregate candidates by user_id for operator-friendly logging."""
+    counts: dict[int, int] = defaultdict(int)
+    for c in candidates:
+        counts[c.user_id] += 1
+    return dict(counts)
+
+
+async def _flush_analytics_caches(
+    affected_user_ids: list[int],
+    *,
+    apply: bool,
+) -> None:
+    """Best-effort: invalidate per-user analytics summary keys.
+
+    Mirrors :func:`cleanup_71_duplicates._flush_analytics_caches`. The
+    backfill changes what shows up on the user dashboard for every
+    affected user, so caches must be flushed for the change to be
+    visible without waiting for the cached value to expire.
+    """
+    if not affected_user_ids:
+        return
+    try:
+        import redis.asyncio as redis
+    except ImportError:
+        _log.warning(
+            "redis client unavailable — cannot flush analytics caches. "
+            "Operator: flush per-user analytics:* keys manually."
+        )
+        return
+
+    try:
+        settings = get_settings()
+        client = redis.from_url(settings.redis_url)
+    except Exception:  # noqa: BLE001
+        _log.warning(
+            "could not connect to redis — flush analytics:summary:user:* "
+            "and analytics:by-format:user:* keys manually",
+        )
+        return
+
+    patterns = [
+        "analytics:summary:user:*",
+        "analytics:by-format:user:*",
+        "analytics:stats:user:*",
+    ]
+    matched: list[bytes] = []
+    try:
+        for pattern in patterns:
+            async for key in client.scan_iter(match=pattern, count=200):
+                matched.append(key)
+        if not matched:
+            _log.info("cache flush: no analytics keys matched standard patterns")
+        elif apply:
+            await client.delete(*matched)
+            _log.info("cache flush: deleted %d analytics keys", len(matched))
+        else:
+            _log.info("cache flush: would delete %d analytics keys", len(matched))
+    finally:
+        with contextlib.suppress(Exception):
+            await client.aclose()  # type: ignore[attr-defined]
+
+
+async def _run(apply: bool) -> int:
+    _configure_logging()
+    sm = get_sessionmaker()
+    mode = "APPLY" if apply else "DRY-RUN"
+    _log.info("holding-pen backfill starting mode=%s", mode)
+
+    candidates = await discover_candidates(sm)
+    counts = per_user_counts(candidates)
+    total = len(candidates)
+
+    _log.info("discover: total=%d affected_users=%d", total, len(counts))
+    if counts:
+        for uid in sorted(counts):
+            _log.info("  user_id=%s would_flag=%d", uid, counts[uid])
+
+    if not apply:
+        _log.info("holding-pen backfill done mode=%s total_would_flag=%d", mode, total)
+        return 0
+
+    updated = await apply_flags(sm, candidates)
+    _log.info("applied: rows_flagged=%d (of %d planned)", updated, total)
+
+    await _flush_analytics_caches(sorted(counts), apply=True)
+
+    _log.info(
+        "holding-pen backfill done mode=%s total_flagged=%d affected_users=%d",
+        mode,
+        updated,
+        len(counts),
+    )
+    return 0
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stderr,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m parser_service.scripts.backfill_holding_pen",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    grp = parser.add_mutually_exclusive_group()
+    grp.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Print what would be done without mutating the database (default).",
+    )
+    grp.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually flag the rows as pending_review.",
+    )
+    args = parser.parse_args(argv)
+    apply = bool(args.apply)
+    return asyncio.run(_run(apply=apply))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/services/parser/tests/test_backfill_holding_pen.py
+++ b/services/parser/tests/test_backfill_holding_pen.py
@@ -1,0 +1,238 @@
+"""Tests for the holding-pen legacy-data backfill script.
+
+End-to-end exercises against a real Postgres (gated on
+``DA_TEST_DATABASE_URL``). Verifies that:
+
+* ``discover_candidates`` correctly identifies legacy partial parses
+  (winner None on match, no per-game winner anywhere) AND empty parses
+  (no games), and leaves real draws + conclusive parses + already-flagged
+  rows alone.
+* ``--dry-run`` (apply=False) finds them but doesn't mutate.
+* ``--apply`` (apply=True) sets ``review_status='pending_review'`` on
+  exactly the discovered rows.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from parser_service.models import Game, Match
+from parser_service.scripts.backfill_holding_pen import (
+    apply_flags,
+    discover_candidates,
+    per_user_counts,
+)
+from sqlalchemy import select
+
+
+@pytest.mark.asyncio
+async def test_discover_identifies_winnerless_matches(parser_session) -> None:
+    """Mixed fixture: real partial, real draw, conclusive, empty, and
+    already-flagged. Only the partial and the empty get picked up."""
+    # 1. Partial: winner None, one game with no winner. Should be flagged.
+    partial = Match(
+        id=uuid.uuid4(),
+        sha256="1" * 64,
+        user_id=1,
+        players=["alice", "bob"],
+        winner=None,
+        game_count=1,
+    )
+    parser_session.add(partial)
+    await parser_session.flush()
+    parser_session.add(Game(id=uuid.uuid4(), match_id=partial.id, game_number=1, winner=None))
+
+    # 2. True draw: winner None on match BUT each game has a winner. Skip.
+    draw = Match(
+        id=uuid.uuid4(),
+        sha256="2" * 64,
+        user_id=1,
+        players=["alice", "bob"],
+        winner=None,
+        game_count=3,
+    )
+    parser_session.add(draw)
+    await parser_session.flush()
+    parser_session.add_all(
+        [
+            Game(id=uuid.uuid4(), match_id=draw.id, game_number=1, winner="alice"),
+            Game(id=uuid.uuid4(), match_id=draw.id, game_number=2, winner="bob"),
+            Game(id=uuid.uuid4(), match_id=draw.id, game_number=3, winner=None),
+        ]
+    )
+
+    # 3. Conclusive: winner set. Skip.
+    conclusive = Match(
+        id=uuid.uuid4(),
+        sha256="3" * 64,
+        user_id=2,
+        players=["alice", "bob"],
+        winner="alice",
+        game_count=2,
+    )
+    parser_session.add(conclusive)
+    await parser_session.flush()
+    parser_session.add_all(
+        [
+            Game(id=uuid.uuid4(), match_id=conclusive.id, game_number=1, winner="alice"),
+            Game(id=uuid.uuid4(), match_id=conclusive.id, game_number=2, winner="alice"),
+        ]
+    )
+
+    # 4. Empty: no games at all. Should be flagged (legacy garbage).
+    empty = Match(
+        id=uuid.uuid4(),
+        sha256="4" * 64,
+        user_id=2,
+        players=[],
+        winner=None,
+        game_count=0,
+    )
+    parser_session.add(empty)
+
+    # 5. Already-flagged partial: review_status='pending_review'. Skip.
+    already = Match(
+        id=uuid.uuid4(),
+        sha256="5" * 64,
+        user_id=3,
+        players=["alice", "bob"],
+        winner=None,
+        game_count=1,
+        review_status="pending_review",
+    )
+    parser_session.add(already)
+    await parser_session.flush()
+    parser_session.add(Game(id=uuid.uuid4(), match_id=already.id, game_number=1, winner=None))
+
+    # 6. Already-rejected: skip.
+    rejected = Match(
+        id=uuid.uuid4(),
+        sha256="6" * 64,
+        user_id=3,
+        players=["alice", "bob"],
+        winner=None,
+        game_count=0,
+        review_status="rejected",
+    )
+    parser_session.add(rejected)
+
+    await parser_session.commit()
+
+    sm = _session_maker_returning(parser_session)
+    candidates = await discover_candidates(sm)
+    flagged_ids = {c.match_id for c in candidates}
+
+    assert str(partial.id) in flagged_ids
+    assert str(empty.id) in flagged_ids
+    assert str(draw.id) not in flagged_ids
+    assert str(conclusive.id) not in flagged_ids
+    assert str(already.id) not in flagged_ids
+    assert str(rejected.id) not in flagged_ids
+    assert len(candidates) == 2
+
+
+@pytest.mark.asyncio
+async def test_apply_flags_sets_pending_review(parser_session) -> None:
+    """`apply_flags` updates exactly the candidates passed to it and
+    leaves other rows alone."""
+    target_id = uuid.uuid4()
+    untouched_id = uuid.uuid4()
+    parser_session.add_all(
+        [
+            Match(
+                id=target_id,
+                sha256="a" * 64,
+                user_id=1,
+                players=["alice", "bob"],
+                winner=None,
+                game_count=0,
+            ),
+            Match(
+                id=untouched_id,
+                sha256="b" * 64,
+                user_id=1,
+                players=["alice", "bob"],
+                winner="alice",
+                game_count=2,
+            ),
+        ]
+    )
+    await parser_session.commit()
+
+    sm = _session_maker_returning(parser_session)
+    from parser_service.scripts.backfill_holding_pen import _Candidate
+
+    candidates = [_Candidate(match_id=str(target_id), user_id=1)]
+    updated = await apply_flags(sm, candidates)
+    assert updated == 1
+
+    parser_session.expire_all()
+    target = (await parser_session.execute(select(Match).where(Match.id == target_id))).scalar_one()
+    untouched = (
+        await parser_session.execute(select(Match).where(Match.id == untouched_id))
+    ).scalar_one()
+    assert target.review_status == "pending_review"
+    assert untouched.review_status is None
+
+
+@pytest.mark.asyncio
+async def test_apply_flags_preserves_existing_admin_verdict(parser_session) -> None:
+    """If a row was concurrently rejected between discover and apply,
+    the apply UPDATE must not overwrite it. The WHERE re-checks
+    ``review_status IS NULL``."""
+    rejected_id = uuid.uuid4()
+    parser_session.add(
+        Match(
+            id=rejected_id,
+            sha256="c" * 64,
+            user_id=1,
+            players=["alice", "bob"],
+            winner=None,
+            game_count=0,
+            review_status="rejected",  # concurrent admin verdict
+        )
+    )
+    await parser_session.commit()
+
+    from parser_service.scripts.backfill_holding_pen import _Candidate
+
+    sm = _session_maker_returning(parser_session)
+    candidates = [_Candidate(match_id=str(rejected_id), user_id=1)]
+    updated = await apply_flags(sm, candidates)
+    assert updated == 0, "must not overwrite an existing verdict"
+
+    parser_session.expire_all()
+    row = (await parser_session.execute(select(Match).where(Match.id == rejected_id))).scalar_one()
+    assert row.review_status == "rejected"
+
+
+def test_per_user_counts_aggregates() -> None:
+    """Pure function — no DB needed."""
+    from parser_service.scripts.backfill_holding_pen import _Candidate
+
+    candidates = [
+        _Candidate(match_id="m1", user_id=1),
+        _Candidate(match_id="m2", user_id=1),
+        _Candidate(match_id="m3", user_id=2),
+    ]
+    counts = per_user_counts(candidates)
+    assert counts == {1: 2, 2: 1}
+
+
+def _session_maker_returning(session):
+    class _Wrapper:
+        def __call__(self):
+            return _Ctx(session)
+
+    class _Ctx:
+        def __init__(self, s):
+            self._s = s
+
+        async def __aenter__(self):
+            return self._s
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return _Wrapper()

--- a/services/parser/tests/test_backfill_holding_pen.py
+++ b/services/parser/tests/test_backfill_holding_pen.py
@@ -220,6 +220,86 @@ def test_per_user_counts_aggregates() -> None:
     assert counts == {1: 2, 2: 1}
 
 
+# ---------------------------------------------------------------------------
+# Cache invalidation — `da:stats:{user_id}:*` namespace
+# ---------------------------------------------------------------------------
+
+
+class _StubRedis:
+    """Minimal stand-in for redis.asyncio.Redis used by the cache flush."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _install_redis_and_settings_stubs(monkeypatch) -> _StubRedis:
+    """Patch `redis.asyncio.from_url` + `get_settings` for cache-flush tests.
+
+    Avoids needing the parser service's full env-var stack
+    (database_url, jwt_public_key_path, etc.) just to exercise the flush.
+    """
+    stub_client = _StubRedis()
+
+    import redis.asyncio as redis_asyncio
+
+    monkeypatch.setattr(redis_asyncio, "from_url", lambda _url: stub_client)
+
+    from parser_service.scripts import backfill_holding_pen as mod
+
+    monkeypatch.setattr(mod, "get_settings", lambda: type("S", (), {"redis_url": "redis://stub"})())
+    return stub_client
+
+
+@pytest.mark.asyncio
+async def test_flush_calls_invalidate_user_per_affected_user(monkeypatch) -> None:
+    """`--apply` path calls `invalidate_user` once per affected user."""
+    from parser_service.scripts import backfill_holding_pen as mod
+
+    stub_client = _install_redis_and_settings_stubs(monkeypatch)
+
+    calls: list[tuple[object, int]] = []
+
+    async def _fake_invalidate(client, user_id: int) -> int:
+        calls.append((client, user_id))
+        return 3
+
+    import common.cache
+
+    monkeypatch.setattr(common.cache, "invalidate_user", _fake_invalidate)
+
+    await mod._flush_analytics_caches([7, 9, 11], apply=True)
+
+    assert [uid for _c, uid in calls] == [7, 9, 11]
+    assert all(c is stub_client for c, _uid in calls)
+    assert stub_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_flush_dry_run_does_not_invalidate(monkeypatch) -> None:
+    """`--dry-run` path must not call `invalidate_user` (no Redis writes)."""
+    from parser_service.scripts import backfill_holding_pen as mod
+
+    stub_client = _install_redis_and_settings_stubs(monkeypatch)
+
+    calls: list[int] = []
+
+    async def _fake_invalidate(_client, user_id: int) -> int:
+        calls.append(user_id)
+        return 0
+
+    import common.cache
+
+    monkeypatch.setattr(common.cache, "invalidate_user", _fake_invalidate)
+
+    await mod._flush_analytics_caches([7, 9], apply=False)
+
+    assert calls == []
+    assert stub_client.closed is True
+
+
 def _session_maker_returning(session):
     class _Wrapper:
         def __call__(self):

--- a/services/parser/tests/test_holding_pen.py
+++ b/services/parser/tests/test_holding_pen.py
@@ -1,0 +1,340 @@
+"""Tests for the holding-pen behavior introduced in v0.9.8.
+
+The consumer no longer drops partial parses outright (#75's Fix B);
+instead it persists them with ``review_status='pending_review'`` so an
+admin can decide. These tests cover:
+
+* Empty parses (zero games) still drop on the floor.
+* Partial parses (games present, no winners anywhere) land with
+  ``review_status='pending_review'``.
+* Conclusive parses (winner OR per-game winner) persist as
+  ``review_status=NULL`` — same as v0.9.7.
+* A later conclusive snapshot of the same logical match upgrades a
+  ``pending_review`` row back to NULL (via _parse_quality_key + the
+  persistence UPDATE path).
+* An admin-rejected row is preserved across reparses (admin verdicts
+  do not silently undo themselves).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from parser_service.consumer import (
+    ParserConsumer,
+    _is_empty_parse,
+    _is_partial_parse,
+)
+from parser_service.models import Match
+from parser_service.parsing.models import ParsedGame, ParsedMatch
+from parser_service.persistence import persist_match
+from sqlalchemy import select
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no DB
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyVsPartial:
+    def test_empty_parse_no_games(self) -> None:
+        assert _is_empty_parse(ParsedMatch()) is True
+        assert _is_empty_parse(ParsedMatch(players=["alice", "bob"])) is True
+
+    def test_partial_parse_games_no_winners(self) -> None:
+        parsed = ParsedMatch(
+            players=["alice", "bob"],
+            games=[ParsedGame(game_number=1, winner=None)],
+        )
+        assert _is_empty_parse(parsed) is False
+        assert _is_partial_parse(parsed) is True
+
+    def test_conclusive_parse_with_match_winner(self) -> None:
+        parsed = ParsedMatch(
+            players=["alice", "bob"],
+            winner="alice",
+            games=[ParsedGame(game_number=1, winner="alice")],
+        )
+        assert _is_empty_parse(parsed) is False
+        assert _is_partial_parse(parsed) is False
+
+    def test_real_draw_is_neither_empty_nor_partial(self) -> None:
+        """Match-winner None but each game has a winner — that's a true
+        Magic draw and must not be flagged."""
+        parsed = ParsedMatch(
+            players=["alice", "bob"],
+            winner=None,
+            games=[
+                ParsedGame(game_number=1, winner="alice"),
+                ParsedGame(game_number=2, winner="bob"),
+                ParsedGame(game_number=3, winner=None, result="draw"),
+            ],
+        )
+        assert _is_empty_parse(parsed) is False
+        assert _is_partial_parse(parsed) is False
+
+
+# ---------------------------------------------------------------------------
+# Consumer-level: empty drops, partial → pending_review, conclusive → NULL
+# ---------------------------------------------------------------------------
+
+
+class _StubParser:
+    """Test double — return the queued ``ParsedMatch`` from .parse()."""
+
+    def __init__(self, parsed: ParsedMatch) -> None:
+        self._parsed = parsed
+
+    def parse(self, content: bytes) -> ParsedMatch:
+        return self._parsed
+
+
+def _consumer_with(parsed: ParsedMatch, sm, raw_root: Path) -> ParserConsumer:
+    """Build a consumer using stub redis/parser dependencies.
+
+    ``_resolve_hero`` is short-circuited: it queries ``auth.users``,
+    which the parser test schema doesn't create. Letting the real
+    impl run would poison the (shared) test session with an
+    aborted-transaction state. The fallback returns
+    ``parsed.players[0]`` — what the real path does too when the
+    auth lookup misses, so behavior matches production for these
+    tests.
+    """
+
+    class _DummyRedis:
+        # The consumer needs *something* for the publisher constructor.
+        def pubsub(self) -> Any:
+            raise NotImplementedError
+
+    consumer = ParserConsumer(
+        redis_client=_DummyRedis(),
+        sessionmaker=sm,
+        raw_root=raw_root,
+        parser=_StubParser(parsed),
+        publisher=_NoopPublisher(),
+    )
+
+    async def _stub_resolve_hero(_user_id: int, players: list[str]) -> str | None:
+        return str(players[0]) if players else None
+
+    consumer._resolve_hero = _stub_resolve_hero
+    return consumer
+
+
+class _NoopPublisher:
+    async def publish(self, channel: str, payload: dict[str, Any]) -> None:
+        return None
+
+
+def _write_raw(raw_root: Path, sha: str) -> None:
+    """Write a non-empty raw file at the ingest shard path for ``sha``."""
+    shard = raw_root / sha[0:2] / sha[2:4]
+    shard.mkdir(parents=True, exist_ok=True)
+    (shard / f"{sha}.dat").write_bytes(b"unused-by-stub-parser")
+
+
+@pytest.mark.asyncio
+async def test_consumer_drops_empty_parse(parser_session, tmp_path) -> None:
+    sha = "e" * 64
+    _write_raw(tmp_path, sha)
+    sm = _session_maker_returning(parser_session)
+    consumer = _consumer_with(ParsedMatch(), sm, tmp_path)
+
+    await consumer.handle_event(sha, user_id=1)
+
+    rows = (await parser_session.execute(select(Match))).scalars().all()
+    assert rows == [], "empty parse must drop, not persist"
+
+
+@pytest.mark.asyncio
+async def test_consumer_persists_partial_as_pending_review(parser_session, tmp_path) -> None:
+    sha = "f" * 64
+    _write_raw(tmp_path, sha)
+    partial = ParsedMatch(
+        raw_match_id="pending-uuid-1",
+        players=["alice", "bob"],
+        games=[ParsedGame(game_number=1, winner=None)],
+    )
+    sm = _session_maker_returning(parser_session)
+    consumer = _consumer_with(partial, sm, tmp_path)
+
+    await consumer.handle_event(sha, user_id=1)
+    parser_session.expire_all()
+
+    row = (await parser_session.execute(select(Match))).scalar_one()
+    assert row.review_status == "pending_review"
+    assert row.raw_match_id == "pending-uuid-1"
+    assert row.winner is None
+
+
+@pytest.mark.asyncio
+async def test_consumer_persists_conclusive_with_null_review_status(
+    parser_session, tmp_path
+) -> None:
+    sha = "a" * 64
+    _write_raw(tmp_path, sha)
+    conclusive = ParsedMatch(
+        raw_match_id="conclusive-uuid-1",
+        players=["alice", "bob"],
+        winner="alice",
+        match_result="2-0",
+        games=[
+            ParsedGame(game_number=1, winner="alice"),
+            ParsedGame(game_number=2, winner="alice"),
+        ],
+    )
+    sm = _session_maker_returning(parser_session)
+    consumer = _consumer_with(conclusive, sm, tmp_path)
+
+    await consumer.handle_event(sha, user_id=1)
+    parser_session.expire_all()
+
+    row = (await parser_session.execute(select(Match))).scalar_one()
+    assert row.review_status is None
+    assert row.winner == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Persistence-level: pending_review → NULL on conclusive reparse,
+# rejected survives reparse.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pending_review_upgrades_to_null_on_conclusive_reparse(parser_session) -> None:
+    """The same logical match: first the agent ships a partial snapshot
+    (caught mid-game), then later a conclusive snapshot. The second
+    persist must UPDATE the existing row, including clearing
+    ``review_status`` so the match becomes user-visible."""
+    raw_id = "logical-uuid-1"
+    sha_partial = "1" * 64
+    sha_conclusive = "2" * 64
+
+    partial = ParsedMatch(
+        raw_match_id=raw_id,
+        players=["alice", "bob"],
+        games=[ParsedGame(game_number=1, winner=None)],
+    )
+    await persist_match(
+        parser_session,
+        partial,
+        sha256=sha_partial,
+        user_id=1,
+        review_status="pending_review",
+    )
+
+    parser_session.expire_all()
+    after_partial = (await parser_session.execute(select(Match))).scalar_one()
+    assert after_partial.review_status == "pending_review"
+
+    conclusive = ParsedMatch(
+        raw_match_id=raw_id,
+        players=["alice", "bob"],
+        winner="alice",
+        match_result="2-0",
+        games=[
+            ParsedGame(game_number=1, winner="alice"),
+            ParsedGame(game_number=2, winner="alice"),
+        ],
+    )
+    await persist_match(
+        parser_session,
+        conclusive,
+        sha256=sha_conclusive,
+        user_id=1,
+        review_status=None,
+    )
+
+    parser_session.expire_all()
+    after_conclusive = (await parser_session.execute(select(Match))).scalar_one()
+    assert after_conclusive.id == after_partial.id, "logical identity preserved"
+    assert after_conclusive.review_status is None, "upgraded back to user-visible"
+    assert after_conclusive.winner == "alice"
+
+
+@pytest.mark.asyncio
+async def test_rejected_row_survives_conclusive_reparse(parser_session) -> None:
+    """An admin's 'rejected' verdict must not be silently overturned by
+    a later snapshot of the same logical match — even if that snapshot
+    is conclusive."""
+    raw_id = "logical-uuid-2"
+    sha_a = "3" * 64
+    sha_b = "4" * 64
+
+    # Seed a rejected row directly (admin verdict happened in the UI).
+    rejected = Match(
+        id=uuid.uuid4(),
+        sha256=sha_a,
+        user_id=1,
+        raw_match_id=raw_id,
+        players=["alice", "bob"],
+        winner=None,
+        game_count=1,
+        review_status="rejected",
+    )
+    parser_session.add(rejected)
+    await parser_session.commit()
+
+    conclusive = ParsedMatch(
+        raw_match_id=raw_id,
+        players=["alice", "bob"],
+        winner="alice",
+        match_result="2-0",
+        games=[
+            ParsedGame(game_number=1, winner="alice"),
+            ParsedGame(game_number=2, winner="alice"),
+        ],
+    )
+    await persist_match(
+        parser_session,
+        conclusive,
+        sha256=sha_b,
+        user_id=1,
+        review_status=None,
+    )
+
+    parser_session.expire_all()
+    survivor = (await parser_session.execute(select(Match))).scalar_one()
+    assert survivor.review_status == "rejected", "admin rejection must survive"
+    # Conclusive parse fields still update (winner, game_count) — the
+    # admin's verdict applies to whether to surface the row, not to
+    # whether to record what the parser saw.
+    assert survivor.winner == "alice"
+    assert survivor.game_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Wrappers — share the session-maker adapter pattern from
+# test_cleanup_71_collision.
+# ---------------------------------------------------------------------------
+
+
+def _session_maker_returning(session):
+    """Adapt the test's session into something the consumer can ``async with``."""
+
+    class _Wrapper:
+        def __call__(self):
+            return _Ctx(session)
+
+    class _Ctx:
+        def __init__(self, s):
+            self._s = s
+
+        async def __aenter__(self):
+            return self._s
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return _Wrapper()
+
+
+# Make pytest-asyncio understand the asyncio default loop scope.
+@pytest.fixture(autouse=True)
+def _ensure_loop_policy() -> None:
+    # Some runners need the policy explicitly set when there is no
+    # surrounding event loop fixture; this is harmless when one exists.
+    asyncio.get_event_loop_policy()

--- a/services/web/tests/test_admin_matches_review.py
+++ b/services/web/tests/test_admin_matches_review.py
@@ -1,0 +1,291 @@
+"""Tests for the holding-pen admin actions on /admin/matches.
+
+Covers:
+
+* The list template renders the review_status badge (Pending review /
+  Rejected) and the action buttons appropriate to each row's state.
+* The chip filter passes ``review_status`` through to the analytics
+  client.
+* POST /admin/matches/{id}/review forwards the verdict to the analytics
+  client and redirects on success.
+* Invalid verdict values 422 instead of silently no-op.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_admin(user_id: int = 1) -> Any:
+    from web_service import deps as _deps
+
+    fake_admin = _deps.BrowserUser(
+        user_id=user_id,
+        email="admin@local",
+        role="admin",
+        must_change_password=False,
+        scope=None,
+        token="admin-tok",
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_admin
+
+    return _dep
+
+
+def _matches_response(review_statuses: list[str | None]) -> Any:
+    """Build a fake AdminMatchListResponse with one row per status."""
+    from web_service import analytics_client
+
+    items = []
+    for idx, rs in enumerate(review_statuses, start=1):
+        items.append(
+            analytics_client.AdminMatchItem(
+                match_id=f"00000000-0000-0000-0000-{idx:012d}",
+                user_id=42,
+                user_email="alice@local",
+                format_="Modern",
+                players=["alice", "bob"],
+                match_result="2-0" if rs is None else None,
+                winner="alice" if rs is None else None,
+                game_count=2,
+                played_at=datetime(2026, 5, 22, 12, 0, tzinfo=UTC),
+                is_draw=False,
+                review_status=rs,
+            )
+        )
+    return analytics_client.AdminMatchListResponse(
+        matches=items,
+        total=len(items),
+        page=1,
+        per_page=20,
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_matches_renders_review_status_badges(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_list(*_a: Any, **_kw: Any) -> Any:
+        return _matches_response([None, "pending_review", "rejected"])
+
+    monkeypatch.setattr(analytics_client, "admin_list_matches", fake_list)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        r = await app_client.get("/admin/matches")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.text
+    assert "Pending review" in body
+    assert "Rejected" in body
+    # Action buttons appropriate to each row's state.
+    assert "Accept" in body
+    assert "Reject" in body
+    assert "Restore" in body
+    assert "Flag" in body
+
+
+@pytest.mark.asyncio
+async def test_admin_matches_chip_filter_propagates(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``?review_status=pending_review`` chip filter must reach the
+    analytics client as ``review_status='pending_review'``."""
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_list(*args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _matches_response(["pending_review"])
+
+    monkeypatch.setattr(analytics_client, "admin_list_matches", fake_list)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        r = await app_client.get("/admin/matches?review_status=pending_review")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert captured.get("review_status") == "pending_review"
+
+
+@pytest.mark.asyncio
+async def test_post_review_accept_calls_client_with_none(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accept (verdict="") posts ``review_status=None`` to analytics."""
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_set(
+        _base_url: str,
+        _token: str,
+        match_id: str,
+        review_status: str | None,
+    ) -> tuple[Any, str | None]:
+        captured["match_id"] = match_id
+        captured["review_status"] = review_status
+        item = analytics_client.AdminMatchItem(
+            match_id=match_id,
+            user_id=42,
+            user_email="alice@local",
+            format_="Modern",
+            players=["alice", "bob"],
+            match_result="2-0",
+            winner="alice",
+            game_count=2,
+            played_at=datetime(2026, 5, 22, 12, 0, tzinfo=UTC),
+            is_draw=False,
+            review_status=review_status,
+        )
+        return item, None
+
+    monkeypatch.setattr(analytics_client, "admin_set_match_review_status", fake_set)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        r = await app_client.post(
+            "/admin/matches/00000000-0000-0000-0000-000000000001/review",
+            data={"verdict": "", "return_to": "/admin/matches"},
+            follow_redirects=False,
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 303
+    assert captured["match_id"] == "00000000-0000-0000-0000-000000000001"
+    assert captured["review_status"] is None
+    # The success message is encoded into the redirect URL.
+    assert "Match+accepted" in r.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_post_review_reject_passes_string_through(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_set(
+        _base_url: str,
+        _token: str,
+        match_id: str,
+        review_status: str | None,
+    ) -> tuple[Any, str | None]:
+        captured["review_status"] = review_status
+        item = analytics_client.AdminMatchItem(
+            match_id=match_id,
+            user_id=42,
+            user_email="alice@local",
+            format_=None,
+            players=[],
+            match_result=None,
+            winner=None,
+            game_count=0,
+            played_at=None,
+            is_draw=False,
+            review_status=review_status,
+        )
+        return item, None
+
+    monkeypatch.setattr(analytics_client, "admin_set_match_review_status", fake_set)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        r = await app_client.post(
+            "/admin/matches/00000000-0000-0000-0000-000000000002/review",
+            data={"verdict": "rejected"},
+            follow_redirects=False,
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 303
+    assert captured["review_status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_post_review_invalid_verdict_returns_422(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        r = await app_client.post(
+            "/admin/matches/00000000-0000-0000-0000-000000000003/review",
+            data={"verdict": "totally-bogus"},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_admin_matches_unknown_review_status_filter_falls_back(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown ``review_status`` chip value falls back to "all" rather
+    than 422'ing the page — the chip UI can't get to an invalid value
+    via clicks, but a hand-crafted URL shouldn't crash."""
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_list(*_a: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _matches_response([None])
+
+    monkeypatch.setattr(analytics_client, "admin_list_matches", fake_list)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_admin()
+    try:
+        r = await app_client.get("/admin/matches?review_status=bogus")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    # Unknown filter sanitized to None, so the analytics call doesn't
+    # receive a review_status param.
+    assert captured.get("review_status") is None

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -798,6 +798,7 @@ class AdminMatchItem:
     game_count: int
     played_at: datetime | None
     is_draw: bool = False
+    review_status: str | None = None
 
 
 @dataclass
@@ -820,6 +821,7 @@ def _to_admin_match(payload: dict[str, Any]) -> AdminMatchItem:
         game_count=int(payload.get("game_count") or 0),
         played_at=_parse_dt(payload.get("played_at")),
         is_draw=bool(payload.get("is_draw") or False),
+        review_status=payload.get("review_status"),
     )
 
 
@@ -834,6 +836,7 @@ async def admin_list_matches(
     result: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
+    review_status: str | None = None,
 ) -> AdminMatchListResponse:
     params: dict[str, Any] = {"page": page, "per_page": per_page}
     if format_filter and format_filter.lower() != "all":
@@ -846,6 +849,8 @@ async def admin_list_matches(
         params["date_from"] = date_from
     if date_to:
         params["date_to"] = date_to
+    if review_status and review_status.lower() != "all":
+        params["review_status"] = review_status
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(
@@ -867,6 +872,46 @@ async def admin_list_matches(
         total=int(data.get("total", 0)),
         page=int(data.get("page", 1)),
         per_page=int(data.get("per_page", 20)),
+    )
+
+
+async def admin_set_match_review_status(
+    base_url: str,
+    token: str,
+    match_id: str,
+    review_status: str | None,
+) -> tuple[AdminMatchItem | None, str | None]:
+    """Set the holding-pen verdict on a match.
+
+    ``review_status`` may be ``None`` (accept), ``'pending_review'``
+    (flag for review), or ``'rejected'`` (permanently discard). Returns
+    ``(item, None)`` on success, ``(None, "match_not_found")`` on 404,
+    or ``(None, "invalid_review_status")`` on 422.
+    """
+    body = {"review_status": review_status}
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{base_url}/analytics/admin/matches/{match_id}/review",
+                headers={"Authorization": f"Bearer {token}"},
+                json=body,
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics POST /admin/matches/{{id}}/review transport error: {exc}"
+        ) from exc
+    if resp.status_code == 200:
+        return _to_admin_match(resp.json()), None
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(
+            f"analytics POST /admin/matches/{{id}}/review returned {resp.status_code}"
+        )
+    if resp.status_code == 404:
+        return None, "match_not_found"
+    if resp.status_code in (400, 422):
+        return None, "invalid_review_status"
+    raise AnalyticsClientError(
+        f"analytics POST /admin/matches/{{id}}/review returned {resp.status_code}: {resp.text}"
     )
 
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -3126,6 +3126,13 @@ _MATCH_FORMAT_OPTIONS = [
 ]
 
 
+_VALID_REVIEW_STATUS_FILTERS = {"all", "pending_review", "rejected", "normal"}
+# Accept verdicts the admin can post via the inline action buttons.
+# ``""`` encodes "accept" (back to NULL); the form posts the verdict as
+# a string and we translate to ``None`` on the way to the JSON client.
+_VALID_REVIEW_VERDICT_FORM_VALUES = {"", "pending_review", "rejected"}
+
+
 @app.get("/admin/matches", response_class=HTMLResponse)
 async def admin_matches_list(
     request: Request,
@@ -3141,10 +3148,16 @@ async def admin_matches_list(
     result: Annotated[str, Query()] = "",
     date_from: Annotated[str, Query()] = "",
     date_to: Annotated[str, Query()] = "",
+    review_status: Annotated[str, Query()] = "",
+    msg: Annotated[str, Query()] = "",
 ) -> Response:
     blocked = _require_admin_or_403(request, user)
     if blocked is not None:
         return blocked
+
+    review_status_clean = review_status.lower() if review_status else ""
+    if review_status_clean and review_status_clean not in _VALID_REVIEW_STATUS_FILTERS:
+        review_status_clean = ""
 
     filters = {
         "format": format,
@@ -3152,6 +3165,7 @@ async def admin_matches_list(
         "result": result,
         "date_from": date_from,
         "date_to": date_to,
+        "review_status": review_status_clean,
     }
     filter_qs = urlencode({k: v for k, v in filters.items() if v})
 
@@ -3166,6 +3180,7 @@ async def admin_matches_list(
             result=result or None,
             date_from=date_from or None,
             date_to=date_to or None,
+            review_status=review_status_clean or None,
         )
     except analytics_client.AnalyticsForbidden:
         _log.info("admin.matches.list.forbidden", extra={"user_id": user.user_id})
@@ -3182,6 +3197,7 @@ async def admin_matches_list(
                 "filter_qs": filter_qs,
                 "format_options": _MATCH_FORMAT_OPTIONS,
                 "error": "Analytics service unavailable. Please try again.",
+                "msg": msg,
             },
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
@@ -3195,7 +3211,74 @@ async def admin_matches_list(
             "filter_qs": filter_qs,
             "format_options": _MATCH_FORMAT_OPTIONS,
             "error": None,
+            "msg": msg,
         },
+    )
+
+
+@app.post("/admin/matches/{match_id}/review")
+async def admin_match_set_review_status(
+    match_id: uuid.UUID,
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+    # ``verdict`` is intentionally optional: the Accept button submits
+    # an empty string (which encodes "back to NULL = user-visible").
+    # Newer FastAPI versions reject empty form fields when the param is
+    # typed as a required ``str``; a default value keeps the form
+    # working without making the field optional in the template.
+    verdict: Annotated[str, Form()] = "",
+    return_to: Annotated[str, Form()] = "",
+) -> Response:
+    """Accept, reject, or flag a match.
+
+    ``verdict`` is one of ``""`` (accept → back to NULL),
+    ``"pending_review"`` (flag for admin review), or ``"rejected"``
+    (permanently discard). Anything else 422s.
+    """
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+    if verdict not in _VALID_REVIEW_VERDICT_FORM_VALUES:
+        return Response(
+            content="Invalid verdict.",
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+    new_review_status: str | None = verdict if verdict else None
+
+    try:
+        item, err = await analytics_client.admin_set_match_review_status(
+            settings.analytics_service_url,
+            user.token,
+            str(match_id),
+            new_review_status,
+        )
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.matches.review.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics POST /admin/matches/%s/review failed", match_id)
+        return Response(
+            content="Analytics service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if item is None and err == "match_not_found":
+        msg = "That match no longer exists."
+    elif item is None:
+        msg = "Could not update match."
+    elif new_review_status is None:
+        msg = "Match accepted."
+    elif new_review_status == "rejected":
+        msg = "Match rejected."
+    else:
+        msg = "Match flagged for review."
+
+    target = _safe_next(return_to) if return_to else "/admin/matches"
+    sep = "&" if "?" in target else "?"
+    return RedirectResponse(
+        url=f"{target}{sep}{urlencode({'msg': msg})}",
+        status_code=status.HTTP_303_SEE_OTHER,
     )
 
 

--- a/services/web/web_service/templates/admin_matches.html
+++ b/services/web/web_service/templates/admin_matches.html
@@ -23,10 +23,31 @@
 <div class="bg-danger-muted border border-danger/20 text-danger rounded-md p-3 text-sm mb-4" role="alert">{{ error }}</div>
 {% endif %}
 
+{% if msg %}
+<div class="bg-surface-3 dark:bg-surface-2 border dark:border-border border-border-light rounded-md p-3 text-sm dark:text-txt-primary text-txt-primary-light mb-4" role="status">{{ msg }}</div>
+{% endif %}
+
+{# Review-status filter chips — kept outside the main filter form so
+   they navigate independently and pre-set the dropdown for the user. #}
+{% set rs = filters.review_status %}
+<div class="flex flex-wrap gap-2 mb-4 text-xs">
+    {% set chip_base = "px-3 py-1 rounded-full border no-underline transition-colors" %}
+    {% set chip_off = "dark:border-border border-border-light dark:text-txt-secondary text-txt-secondary-light hover:dark:bg-surface-2 hover:bg-surface-light-3" %}
+    {% set chip_on = "bg-accent text-white border-accent" %}
+    <a href="/admin/matches" class="{{ chip_base }} {% if not rs %}{{ chip_on }}{% else %}{{ chip_off }}{% endif %}">All</a>
+    <a href="/admin/matches?review_status=pending_review" class="{{ chip_base }} {% if rs == 'pending_review' %}{{ chip_on }}{% else %}{{ chip_off }}{% endif %}">Pending review</a>
+    <a href="/admin/matches?review_status=rejected" class="{{ chip_base }} {% if rs == 'rejected' %}{{ chip_on }}{% else %}{{ chip_off }}{% endif %}">Rejected</a>
+    <a href="/admin/matches?review_status=normal" class="{{ chip_base }} {% if rs == 'normal' %}{{ chip_on }}{% else %}{{ chip_off }}{% endif %}">Normal</a>
+</div>
+
 {# Filter bar #}
 <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md mb-6 overflow-hidden">
     <div class="px-4 py-3 border-b dark:border-border border-border-light">
         <form method="get" action="/admin/matches" class="flex flex-wrap gap-3 items-end">
+            {# Preserve the review_status chip selection across other-filter submits. #}
+            {% if filters.review_status %}
+            <input type="hidden" name="review_status" value="{{ filters.review_status }}">
+            {% endif %}
             <label class="flex flex-col gap-1">
                 <span class="text-xs dark:text-txt-secondary text-txt-secondary-light">Format</span>
                 <select name="format" class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none">
@@ -70,6 +91,7 @@
     {% if not match_list or not match_list.matches %}
         <div class="px-4 py-6 text-sm dark:text-txt-secondary text-txt-secondary-light">No matches found.</div>
     {% else %}
+    {% set return_to = "/admin/matches?" ~ filter_qs ~ ("&" if filter_qs else "") ~ "page=" ~ match_list.page ~ "&per_page=" ~ match_list.per_page %}
     <div class="overflow-x-auto">
         <table class="w-full">
             <thead>
@@ -80,6 +102,8 @@
                     <th class="text-xs uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light font-medium text-left px-4 py-2.5">Result</th>
                     <th class="text-xs uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light font-medium text-right px-4 py-2.5">Games</th>
                     <th class="text-xs uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light font-medium text-left px-4 py-2.5">Played</th>
+                    <th class="text-xs uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light font-medium text-left px-4 py-2.5">Review</th>
+                    <th class="text-xs uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light font-medium text-left px-4 py-2.5">Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -113,6 +137,43 @@
                         {% else %}
                             —
                         {% endif %}
+                    </td>
+                    <td class="px-4 py-2.5 text-sm">
+                        {% if m.review_status == "pending_review" %}
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-warning/10 text-warning border border-warning/20">Pending review</span>
+                        {% elif m.review_status == "rejected" %}
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-danger-muted text-danger border border-danger/20">Rejected</span>
+                        {% else %}
+                            <span class="dark:text-txt-tertiary text-txt-secondary-light">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-4 py-2.5 text-sm">
+                        <div class="flex gap-1 items-center">
+                        {% if m.review_status == "pending_review" %}
+                            <form method="post" action="/admin/matches/{{ m.match_id }}/review" class="inline">
+                                <input type="hidden" name="verdict" value="">
+                                <input type="hidden" name="return_to" value="{{ return_to }}">
+                                <button type="submit" class="border border-success/40 text-success hover:bg-success/10 rounded px-2 py-0.5 text-xs transition-colors" title="Accept this match — back to user-visible.">Accept</button>
+                            </form>
+                            <form method="post" action="/admin/matches/{{ m.match_id }}/review" class="inline">
+                                <input type="hidden" name="verdict" value="rejected">
+                                <input type="hidden" name="return_to" value="{{ return_to }}">
+                                <button type="submit" class="border border-danger/40 text-danger hover:bg-danger/10 rounded px-2 py-0.5 text-xs transition-colors" title="Discard permanently.">Reject</button>
+                            </form>
+                        {% elif m.review_status == "rejected" %}
+                            <form method="post" action="/admin/matches/{{ m.match_id }}/review" class="inline">
+                                <input type="hidden" name="verdict" value="">
+                                <input type="hidden" name="return_to" value="{{ return_to }}">
+                                <button type="submit" class="border dark:border-border border-border-light dark:text-txt-primary text-txt-primary-light hover:dark:bg-surface-2 hover:bg-surface-light-3 rounded px-2 py-0.5 text-xs transition-colors" title="Restore — back to user-visible.">Restore</button>
+                            </form>
+                        {% else %}
+                            <form method="post" action="/admin/matches/{{ m.match_id }}/review" class="inline">
+                                <input type="hidden" name="verdict" value="pending_review">
+                                <input type="hidden" name="return_to" value="{{ return_to }}">
+                                <button type="submit" class="border dark:border-border border-border-light dark:text-txt-secondary text-txt-secondary-light hover:dark:bg-surface-2 hover:bg-surface-light-3 rounded px-2 py-0.5 text-xs transition-colors" title="Flag this match for review — hidden from users.">Flag</button>
+                            </form>
+                        {% endif %}
+                        </div>
                     </td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
## Summary

- Replaces #75's Fix B (drop partial parses at the consumer) with a holding pen: partial parses persist with `review_status='pending_review'`, hidden from users + analytics, surfaced on `/admin/matches` for accept/reject review.
- Empty parses (no games) still drop. Conclusive parses are unchanged. A later conclusive snapshot of the same logical match upgrades a `pending_review` row back to NULL. Admin `'rejected'` verdicts survive reparse.
- Admin UI gains a status badge column, filter chips (All / Pending / Rejected / Normal), and inline Accept / Reject / Restore / Flag buttons.

## What changed

**Schema (alembic 025)**
- Adds `review_status TEXT NULL` to `parser.matches` with a `CHECK (review_status IS NULL OR review_status IN ('pending_review', 'rejected'))` constraint and a partial index for filter queries.

**Consumer + persistence**
- `_is_partial_parse` is now narrower (winner-less, games present); new `_is_empty_parse` catches the no-games case that still drops.
- `persist_match` plumbs `review_status` through both insert and update paths. The update path preserves an existing `'rejected'` verdict — admin decisions are not silently overturned.

**User-facing filtering**
- Every `parser.matches` query in user-facing analytics adds `WHERE review_status IS NULL` (stats summary, by-format, by-opponent, matches list + detail, game-stats, card-stats, mulligans, game-length, username suggestions). A user navigating to `/matches/<uuid>` of a `pending_review` match gets a 404.
- Admin analytics endpoints surface all rows and accept a `review_status` filter (`all` / `pending_review` / `rejected` / `normal`).

**Admin actions**
- New `POST /analytics/admin/matches/<id>/review` (analytics) + `POST /admin/matches/<id>/review` (web) — verdict body is `null` (accept), `'pending_review'` (flag), or `'rejected'` (discard). 422 on invalid input, 404 on missing rows. Invalidates the owning user's cached stats on success.

**Backfill script**
- `services/parser/parser_service/scripts/backfill_holding_pen.py` — dry-run-by-default, walks existing rows and flags those that would have landed in the holding pen pre-v0.9.8 (winner None + no per-game winner anywhere, including empty matches). Skips real draws, conclusive parses, and rows that already carry a verdict. The apply UPDATE re-checks `review_status IS NULL` so a concurrent admin verdict is not overwritten. Best-effort flushes Redis analytics caches for affected users.

## Operator runbook

After deploy:

```bash
# Inside the parser container:
python -m parser_service.scripts.backfill_holding_pen --dry-run
# Review the per-user counts in the log output, then:
python -m parser_service.scripts.backfill_holding_pen --apply
```

The script logs per-user counts and a grand total. It is safe to re-run — the apply UPDATE is idempotent (re-checks `IS NULL`).

## Test plan

- [x] `services/parser/tests/test_holding_pen.py` — empty drops, partial → pending_review, conclusive → NULL, pending_review → NULL on conclusive reparse, rejected survives reparse, helper unit tests for `_is_empty_parse` / `_is_partial_parse`.
- [x] `services/parser/tests/test_backfill_holding_pen.py` — discover identifies the right rows (partial + empty + skips real draws + skips already-flagged), apply flips them, and the WHERE re-check protects against concurrent admin verdicts.
- [x] `services/analytics/tests/test_review_status_filter.py` — user-facing match loader and detail endpoint emit the `review_status IS NULL` clause; admin endpoint validates the verdict body.
- [x] `services/web/tests/test_admin_matches_review.py` — template renders the badge column and per-state action buttons, filter chip propagates to the analytics client, POST handler maps verdict strings to the correct review_status value, invalid verdict returns 422.

Local test counts: 190 parser, 150 analytics, 250 web — all green. Ruff clean, no new mypy errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)