### PR TITLE
fix: invalidate correct cache key namespace in cleanup_71_duplicates

### DIFF
--- a/services/parser/parser_service/scripts/cleanup_71_duplicates.py
+++ b/services/parser/parser_service/scripts/cleanup_71_duplicates.py
@@ -388,12 +388,12 @@ async def _flush_analytics_caches(
     *,
     apply: bool,
 ) -> None:
-    """Try to invalidate per-user analytics summary keys in Redis.
+    """Invalidate per-user analytics cache keys in Redis.
 
-    The exact key shape lives in the analytics service; this script
-    runs in the parser container and may not have an exact mirror, so
-    we attempt a best-effort SCAN/DEL by user_id substring and log a
-    warning if anything looks off.
+    Uses :func:`common.cache.invalidate_user`, which deletes everything
+    matching ``da:stats:{user_id}:*`` — the namespace the analytics
+    service actually writes (see ``common/cache.py``). Best-effort: any
+    Redis failure is logged but does not abort the cleanup run.
     """
     if not affected_user_ids:
         return
@@ -403,7 +403,7 @@ async def _flush_analytics_caches(
     except ImportError:
         _log.warning(
             "redis client unavailable — cannot flush analytics caches. "
-            "Operator: flush per-user summary/by-format keys manually."
+            "Operator: flush per-user `da:stats:{user_id}:*` keys manually."
         )
         return
 
@@ -413,32 +413,33 @@ async def _flush_analytics_caches(
     except Exception:  # noqa: BLE001
         _log.warning(
             "could not connect to redis (redis_url=%s) — flush per-user "
-            "analytics:summary:* and analytics:by-format:* keys manually",
+            "`da:stats:{user_id}:*` keys manually",
             getattr(get_settings(), "redis_url", "<unset>"),
         )
         return
 
-    patterns = [
-        "analytics:summary:user:*",
-        "analytics:by-format:user:*",
-        "analytics:stats:user:*",
-    ]
-    matched: list[bytes] = []
+    if not apply:
+        _log.info(
+            "cache flush: would invalidate da:stats:{user_id}:* for %d user(s)",
+            len(affected_user_ids),
+        )
+        with contextlib.suppress(Exception):
+            await client.aclose()
+        return
+
+    from common.cache import invalidate_user
+
+    total = 0
     try:
-        for pattern in patterns:
-            async for key in client.scan_iter(match=pattern, count=200):
-                matched.append(key)
-        if not matched:
-            _log.info(
-                "cache flush: no analytics:* keys matched standard patterns. "
-                "If the dashboard still shows stale totals after this run, "
-                "operator should flush analytics keys manually."
-            )
-        elif apply:
-            await client.delete(*matched)
-            _log.info("cache flush: deleted %d analytics keys", len(matched))
-        else:
-            _log.info("cache flush: would delete %d analytics keys", len(matched))
+        for user_id in affected_user_ids:
+            deleted = await invalidate_user(client, user_id)
+            _log.info("cache flush: user_id=%s deleted=%d keys", user_id, deleted)
+            total += deleted
+        _log.info(
+            "cache flush: deleted %d da:stats keys across %d user(s)",
+            total,
+            len(affected_user_ids),
+        )
     finally:
         with contextlib.suppress(Exception):
             await client.aclose()

--- a/services/parser/tests/test_cleanup_71_collision.py
+++ b/services/parser/tests/test_cleanup_71_collision.py
@@ -319,3 +319,83 @@ def _session_maker_returning(session):
             return False
 
     return _Wrapper()
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation — `da:stats:{user_id}:*` namespace
+# ---------------------------------------------------------------------------
+
+
+class _StubRedis:
+    """Minimal stand-in for redis.asyncio.Redis used by the cache flush."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _install_redis_and_settings_stubs(monkeypatch) -> _StubRedis:
+    """Patch `redis.asyncio.from_url` + `get_settings` for cache-flush tests.
+
+    Avoids needing the parser service's full env-var stack
+    (database_url, jwt_public_key_path, etc.) just to exercise the flush.
+    """
+    stub_client = _StubRedis()
+
+    import redis.asyncio as redis_asyncio
+
+    monkeypatch.setattr(redis_asyncio, "from_url", lambda _url: stub_client)
+
+    from parser_service.scripts import cleanup_71_duplicates as mod
+
+    monkeypatch.setattr(mod, "get_settings", lambda: type("S", (), {"redis_url": "redis://stub"})())
+    return stub_client
+
+
+@pytest.mark.asyncio
+async def test_flush_calls_invalidate_user_per_affected_user(monkeypatch) -> None:
+    """`--apply` path calls `invalidate_user` once per affected user."""
+    from parser_service.scripts import cleanup_71_duplicates as mod
+
+    stub_client = _install_redis_and_settings_stubs(monkeypatch)
+
+    calls: list[tuple[object, int]] = []
+
+    async def _fake_invalidate(client, user_id: int) -> int:
+        calls.append((client, user_id))
+        return 5
+
+    import common.cache
+
+    monkeypatch.setattr(common.cache, "invalidate_user", _fake_invalidate)
+
+    await mod._flush_analytics_caches(None, [2, 4, 8], apply=True)
+
+    assert [uid for _c, uid in calls] == [2, 4, 8]
+    assert all(c is stub_client for c, _uid in calls)
+    assert stub_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_flush_dry_run_does_not_invalidate(monkeypatch) -> None:
+    """`--dry-run` path must not call `invalidate_user` (no Redis writes)."""
+    from parser_service.scripts import cleanup_71_duplicates as mod
+
+    stub_client = _install_redis_and_settings_stubs(monkeypatch)
+
+    calls: list[int] = []
+
+    async def _fake_invalidate(_client, user_id: int) -> int:
+        calls.append(user_id)
+        return 0
+
+    import common.cache
+
+    monkeypatch.setattr(common.cache, "invalidate_user", _fake_invalidate)
+
+    await mod._flush_analytics_caches(None, [2, 4], apply=False)
+
+    assert calls == []
+    assert stub_client.closed is True


### PR DESCRIPTION
## Summary

- `_flush_analytics_caches` in the issue-#71 cleanup script was scanning Redis for `analytics:summary:user:*`, `analytics:by-format:user:*`, and `analytics:stats:user:*` — but the analytics service writes keys under `da:stats:{user_id}:*` (per `common/cache.py`). The scan matched nothing in production, so users whose duplicate matches got cleaned up kept seeing stale dashboards until TTL expiry.
- Sibling fix to the same bug Codex flagged on PR #76's `backfill_holding_pen.py`; this PR cleans up the already-merged `cleanup_71_duplicates.py` on main.

## Fix

- Replace the three-pattern SCAN/DEL with a per-user loop calling `common.cache.invalidate_user(client, user_id)` — the same helper the analytics service uses for its `match.parsed` cache busts.
- Dry-run still hits Redis only to log intent (no writes).
- Defensive guidance text now names the correct `da:stats:{user_id}:*` namespace if Redis is unavailable.

## Test plan

- [x] `services/parser/tests/test_cleanup_71_collision.py` adds two unit tests:
  - `test_flush_calls_invalidate_user_per_affected_user` — `--apply` calls `invalidate_user` once per affected user.
  - `test_flush_dry_run_does_not_invalidate` — `--dry-run` never calls `invalidate_user`.
- [x] Full `test_cleanup_71_collision.py` suite passes locally (10 passed, 2 DB-gated skips).
- [x] `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)