### PR TITLE
fix(#70): wire dashboard By format filter via ?format= query param

### DIFF
--- a/services/web/tests/test_dashboard_stats.py
+++ b/services/web/tests/test_dashboard_stats.py
@@ -341,3 +341,193 @@ async def test_dashboard_admin_redirects_to_admin_users(
 
     assert r.status_code == 302
     assert r.headers["location"] == "/admin/users"
+
+
+# ---------------------------------------------------------------------------
+# Format filter (#70)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dashboard_format_filter_threads_through(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``?format=Modern`` is forwarded to the per-dimension analytics calls."""
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_summary(_url: str, _token: str) -> Any:
+        return _sample_summary(total=7)
+
+    async def fake_format(_url: str, _token: str) -> Any:
+        return _sample_format_stats()
+
+    async def fake_play_draw(_url: str, _token: str, **kw: Any) -> Any:
+        captured["play_draw"] = kw.get("format_filter")
+        return analytics_client.PlayDrawStats(
+            on_play_matches=4,
+            on_play_wins=3,
+            on_play_win_rate=75.0,
+            on_draw_matches=1,
+            on_draw_wins=0,
+            on_draw_win_rate=0.0,
+        )
+
+    async def fake_preboard(_url: str, _token: str, **kw: Any) -> Any:
+        captured["preboard"] = kw.get("format_filter")
+        return analytics_client.PreboardPostboardStats(
+            game1_matches=5,
+            game1_wins=3,
+            game1_win_rate=60.0,
+            games23_matches=4,
+            games23_wins=2,
+            games23_win_rate=50.0,
+        )
+
+    async def fake_mulligan(_url: str, _token: str, **kw: Any) -> Any:
+        captured["mulligan"] = kw.get("format_filter")
+        return analytics_client.MulliganStats(buckets=[])
+
+    async def fake_card_stats(_url: str, _token: str, **kw: Any) -> Any:
+        captured["card_stats"] = kw.get("format_filter")
+        return analytics_client.CardStatsResponse(cards=[], total=0, page=1, per_page=10)
+
+    monkeypatch.setattr(analytics_client, "get_stats_summary", fake_summary)
+    monkeypatch.setattr(analytics_client, "get_stats_by_format", fake_format)
+    monkeypatch.setattr(analytics_client, "get_play_draw_stats", fake_play_draw)
+    monkeypatch.setattr(analytics_client, "get_preboard_postboard_stats", fake_preboard)
+    monkeypatch.setattr(analytics_client, "get_mulligan_stats", fake_mulligan)
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_card_stats)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/dashboard?format=Modern")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    # Every filterable dimension received the format.
+    assert captured["play_draw"] == "Modern"
+    assert captured["preboard"] == "Modern"
+    assert captured["mulligan"] == "Modern"
+    assert captured["card_stats"] == "Modern"
+    # Filtered view exposes a Clear filter affordance back to /dashboard.
+    assert "Clear filter" in r.text
+    assert 'href="/dashboard"' in r.text
+
+
+@pytest.mark.asyncio
+async def test_dashboard_format_filter_overrides_headline_numbers(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headline cards reflect the selected format's row when filtered."""
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_summary(_url: str, _token: str) -> Any:
+        # Overall: 7 matches, 4-2-1, win rate 66.7%.
+        return _sample_summary(total=7)
+
+    async def fake_format(_url: str, _token: str) -> Any:
+        return [
+            analytics_client.FormatStatItem(
+                format_="Modern",
+                matches=5,
+                wins=3,
+                losses=2,
+                draws=0,
+                win_rate=60.0,
+            ),
+            analytics_client.FormatStatItem(
+                format_="Legacy",
+                matches=2,
+                wins=1,
+                losses=0,
+                draws=1,
+                win_rate=100.0,
+            ),
+        ]
+
+    async def fake_play_draw(_url: str, _token: str, **_kw: Any) -> Any:
+        return analytics_client.PlayDrawStats(
+            on_play_matches=3,
+            on_play_wins=2,
+            on_play_win_rate=66.7,
+            on_draw_matches=2,
+            on_draw_wins=1,
+            on_draw_win_rate=50.0,
+        )
+
+    async def fake_none(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("not needed")
+
+    monkeypatch.setattr(analytics_client, "get_stats_summary", fake_summary)
+    monkeypatch.setattr(analytics_client, "get_stats_by_format", fake_format)
+    monkeypatch.setattr(analytics_client, "get_play_draw_stats", fake_play_draw)
+    monkeypatch.setattr(analytics_client, "get_preboard_postboard_stats", fake_none)
+    monkeypatch.setattr(analytics_client, "get_mulligan_stats", fake_none)
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_none)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/dashboard?format=Modern")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    # Modern row (60.0%) replaces the overall 66.7% in the headline card.
+    assert "60.0%" in r.text
+    # Selected-state highlight class is present on the active row.
+    assert 'data-format="Modern"' in r.text
+
+
+@pytest.mark.asyncio
+async def test_dashboard_unfiltered_has_no_clear_link(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without ``?format=``, no Clear filter affordance is rendered."""
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_summary(_url: str, _token: str) -> Any:
+        return _sample_summary(total=7)
+
+    async def fake_format(_url: str, _token: str) -> Any:
+        return _sample_format_stats()
+
+    async def fake_play_draw(_url: str, _token: str, **_kw: Any) -> Any:
+        return analytics_client.PlayDrawStats(
+            on_play_matches=3,
+            on_play_wins=2,
+            on_play_win_rate=66.7,
+            on_draw_matches=2,
+            on_draw_wins=1,
+            on_draw_win_rate=50.0,
+        )
+
+    async def fake_none(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("not needed")
+
+    monkeypatch.setattr(analytics_client, "get_stats_summary", fake_summary)
+    monkeypatch.setattr(analytics_client, "get_stats_by_format", fake_format)
+    monkeypatch.setattr(analytics_client, "get_play_draw_stats", fake_play_draw)
+    monkeypatch.setattr(analytics_client, "get_preboard_postboard_stats", fake_none)
+    monkeypatch.setattr(analytics_client, "get_mulligan_stats", fake_none)
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_none)
+
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/dashboard")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Clear filter" not in r.text

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -223,9 +223,12 @@ async def dashboard(
     request: Request,
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
+    format: Annotated[str, Query(alias="format")] = "",
 ) -> Response:
     if user.role == "admin":
         return RedirectResponse(url=_ADMIN_LANDING_PATH, status_code=status.HTTP_302_FOUND)
+
+    format_filter = format or None
 
     stats_summary: Any = None
     format_stats: list[Any] = []
@@ -248,38 +251,48 @@ async def dashboard(
         _log.exception("analytics stats call failed; rendering dashboard with error banner")
         stats_error = True
 
-    # Play/draw stats for the overview stat card (unfiltered).
     try:
         play_draw_stats = await analytics_client.get_play_draw_stats(
-            settings.analytics_service_url, user.token
+            settings.analytics_service_url, user.token, format_filter=format_filter
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("play/draw stats unavailable")
 
-    # Pre-board / post-board stats (unfiltered).
     try:
         preboard_postboard_stats = await analytics_client.get_preboard_postboard_stats(
-            settings.analytics_service_url, user.token
+            settings.analytics_service_url, user.token, format_filter=format_filter
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("preboard/postboard stats unavailable")
 
-    # Mulligan stats (unfiltered).
     try:
         mulligan_stats = await analytics_client.get_mulligan_stats(
-            settings.analytics_service_url, user.token
+            settings.analytics_service_url, user.token, format_filter=format_filter
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("mulligan stats unavailable")
 
-    # Card stats (unfiltered). Use same page size as the HTMX partial so
-    # pagination stays consistent when the user clicks "Next".
+    # Card stats. Page size matches the HTMX partial so pagination stays
+    # consistent when the user clicks "Next".
     try:
         card_stats = await analytics_client.get_card_stats(
-            settings.analytics_service_url, user.token, per_page=_CARD_PERF_PER_PAGE
+            settings.analytics_service_url,
+            user.token,
+            per_page=_CARD_PERF_PER_PAGE,
+            format_filter=format_filter,
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("card stats unavailable")
+
+    # When a format is selected, swap in that format's row from the
+    # by-format breakdown as the headline numbers (Total / Record /
+    # Win rate). Falls back to the overall summary when no row matches.
+    filtered_summary: Any = None
+    if format_filter:
+        for row in format_stats:
+            if row.format_ == format_filter:
+                filtered_summary = row
+                break
 
     return templates.TemplateResponse(
         request,
@@ -293,6 +306,8 @@ async def dashboard(
             "preboard_postboard_stats": preboard_postboard_stats,
             "mulligan_stats": mulligan_stats,
             "card_stats": card_stats,
+            "format_filter": format,
+            "filtered_summary": filtered_summary,
         },
     )
 

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -24,20 +24,29 @@
     <p class="dark:text-txt-secondary text-txt-secondary-light">No matches yet. Upload a game log to get started.</p>
 </div>
 {% else %}
+{# When a format filter is active and we have a matching row, use it
+   for the headline numbers so the cards reflect the filter. #}
+{% set headline_total = filtered_summary.matches if filtered_summary else stats_summary.total_matches %}
+{% set headline_wins = filtered_summary.wins if filtered_summary else stats_summary.wins %}
+{% set headline_losses = filtered_summary.losses if filtered_summary else stats_summary.losses %}
+{% set headline_draws = filtered_summary.draws if filtered_summary else stats_summary.draws %}
+{% set headline_win_rate = filtered_summary.win_rate if filtered_summary else stats_summary.win_rate %}
 <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
     <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
-        <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-1">Total matches</div>
-        <div class="text-2xl font-mono font-semibold dark:text-txt-primary text-txt-primary-light">{{ stats_summary.total_matches }}</div>
+        <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-1">
+            Total matches{% if format_filter %} &middot; {{ format_filter }}{% endif %}
+        </div>
+        <div class="text-2xl font-mono font-semibold dark:text-txt-primary text-txt-primary-light">{{ headline_total }}</div>
     </div>
     <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
         <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-1">Record</div>
         <div class="text-2xl font-mono font-semibold dark:text-txt-primary text-txt-primary-light">
-            <span class="text-success">{{ stats_summary.wins }}</span><span class="dark:text-txt-tertiary text-txt-secondary-light">-</span><span class="text-danger">{{ stats_summary.losses }}</span><span class="dark:text-txt-tertiary text-txt-secondary-light">-</span><span class="text-warning">{{ stats_summary.draws }}</span>
+            <span class="text-success">{{ headline_wins }}</span><span class="dark:text-txt-tertiary text-txt-secondary-light">-</span><span class="text-danger">{{ headline_losses }}</span><span class="dark:text-txt-tertiary text-txt-secondary-light">-</span><span class="text-warning">{{ headline_draws }}</span>
         </div>
     </div>
     <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
         <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-1">Win rate</div>
-        <div class="text-2xl font-mono font-semibold dark:text-txt-primary text-txt-primary-light">{{ "%.1f"|format(stats_summary.win_rate) }}%</div>
+        <div class="text-2xl font-mono font-semibold dark:text-txt-primary text-txt-primary-light">{{ "%.1f"|format(headline_win_rate) }}%</div>
     </div>
     {% if play_draw_stats %}
     <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
@@ -47,30 +56,12 @@
     {% else %}
     <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
         <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-1">Matches Won</div>
-        <div class="text-2xl font-mono font-semibold text-success">{{ stats_summary.wins }}</div>
+        <div class="text-2xl font-mono font-semibold text-success">{{ headline_wins }}</div>
     </div>
     {% endif %}
 </div>
 
-{# ── Format Filter + Stats Panels (Alpine.js state) ── #}
-<div x-data="{ selectedFormat: null, _initialized: false }"
-     x-effect="
-        var fmt = selectedFormat;
-        if (!_initialized) { _initialized = true; return; }
-        if (fmt) {
-            var f = encodeURIComponent(fmt);
-            htmx.ajax('GET', '/dashboard/partials/play-draw?format=' + f, {target: '#play-draw-panel', swap: 'innerHTML'});
-            htmx.ajax('GET', '/dashboard/partials/preboard-postboard?format=' + f, {target: '#preboard-postboard-panel', swap: 'innerHTML'});
-            htmx.ajax('GET', '/dashboard/partials/mulligans?format=' + f, {target: '#mulligan-panel', swap: 'innerHTML'});
-            htmx.ajax('GET', '/dashboard/partials/card-performance?format=' + f, {target: '#card-performance-panel', swap: 'innerHTML'});
-        } else {
-            htmx.ajax('GET', '/dashboard/partials/play-draw', {target: '#play-draw-panel', swap: 'innerHTML'});
-            htmx.ajax('GET', '/dashboard/partials/preboard-postboard', {target: '#preboard-postboard-panel', swap: 'innerHTML'});
-            htmx.ajax('GET', '/dashboard/partials/mulligans', {target: '#mulligan-panel', swap: 'innerHTML'});
-            htmx.ajax('GET', '/dashboard/partials/card-performance', {target: '#card-performance-panel', swap: 'innerHTML'});
-        }
-     "
-     class="space-y-6">
+<div class="space-y-6">
 
 {# ── By Format Table ── #}
 {% if format_stats|default([]) %}
@@ -80,11 +71,12 @@
             <h2 class="text-sm font-semibold dark:text-txt-primary text-txt-primary-light">By format</h2>
             <p class="text-xs dark:text-txt-secondary text-txt-secondary-light mt-0.5">Click a format to filter stats below.</p>
         </div>
-        <button x-show="selectedFormat" x-cloak
-                @click="selectedFormat = null"
-                class="text-xs dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light border dark:border-border border-border-light rounded-md px-2 py-1 transition-colors cursor-pointer bg-transparent">
+        {% if format_filter %}
+        <a href="/dashboard"
+           class="text-xs dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light border dark:border-border border-border-light rounded-md px-2 py-1 transition-colors no-underline">
             Clear filter
-        </button>
+        </a>
+        {% endif %}
     </div>
     <div class="overflow-x-auto">
         <table class="w-full">
@@ -100,12 +92,16 @@
             </thead>
             <tbody>
                 {% for row in format_stats %}
-                <tr @click="selectedFormat === {{ row.format_|tojson }} ? selectedFormat = null : selectedFormat = {{ row.format_|tojson }}"
-                    :class="selectedFormat === {{ row.format_|tojson }} ? 'dark:bg-accent-muted bg-accent-muted border-l-2 border-accent' : ''"
-                    class="border-b dark:border-border-subtle border-border-light hover:dark:bg-surface-2 hover:bg-surface-light-2 transition-colors cursor-pointer">
-                    <td class="px-4 py-2.5 text-sm dark:text-txt-primary text-txt-primary-light">
-                        {{ row.format_ }}
-                    </td>
+                {% set is_selected = (format_filter == row.format_) %}
+                {% set row_href = "/dashboard" if is_selected else "/dashboard?format=" + (row.format_|urlencode) %}
+                <tr data-format="{{ row.format_ }}"
+                    data-href="{{ row_href }}"
+                    role="button"
+                    tabindex="0"
+                    onclick="window.location.href=this.dataset.href"
+                    onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.location.href=this.dataset.href}"
+                    class="border-b dark:border-border-subtle border-border-light hover:dark:bg-surface-2 hover:bg-surface-light-2 transition-colors cursor-pointer {% if is_selected %}dark:bg-accent-muted bg-accent-muted border-l-2 border-accent{% endif %}">
+                    <td class="px-4 py-2.5 text-sm dark:text-txt-primary text-txt-primary-light">{{ row.format_ }}</td>
                     <td class="px-4 py-2.5 text-sm font-mono text-right dark:text-txt-primary text-txt-primary-light">{{ row.matches }}</td>
                     <td class="px-4 py-2.5 text-sm font-mono text-right dark:text-txt-primary text-txt-primary-light">{{ row.wins }}</td>
                     <td class="px-4 py-2.5 text-sm font-mono text-right dark:text-txt-primary text-txt-primary-light">{{ row.losses }}</td>
@@ -119,7 +115,7 @@
 </div>
 {% endif %}
 
-{# ── Stats Panels (visible on load with unfiltered data) ── #}
+{# ── Stats Panels (rendered server-side; filtered by ?format= when set) ── #}
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
     <div id="play-draw-panel">
         {% include "_partials_play_draw.html" %}
@@ -135,7 +131,7 @@
     {% include "_partials_card_performance.html" %}
 </div>
 
-</div>{# end Alpine x-data #}
+</div>
 
 {% endif %}{# end stats_summary.total_matches > 0 #}
 {% endif %}{# end stats available #}


### PR DESCRIPTION
## Summary

Closes #70. The dashboard's "By format" table promised to filter the stats panels below it, but clicking a row did nothing — the existing Alpine/HTMX wiring never fired the partial requests. This swaps that out for a plain server-rendered `?format=<value>` filter.

- `/dashboard` now accepts `?format=`, passes `format_filter` to the play/draw, pre-board/post-board, mulligan, and card-stats analytics calls, and renders the panels filtered in one round-trip.
- Each row in the "By format" table navigates to `/dashboard?format=<format>` (clicking the active row toggles back to unfiltered). Selected row gets the existing accent highlight; `role="button"` + `tabindex` + an Enter/Space `onkeydown` handler give it keyboard parity.
- Headline cards (Total / Record / Win rate) now reflect the selected format using its row from the by-format breakdown. A "Clear filter" link appears in filtered state.
- No analytics-side changes; this only wires up the format filter that the per-dimension endpoints already accepted.

## Test plan

- [x] `uv run pytest services/web/tests/` — 253 passed
- [x] `uv run ruff check services/web/` — clean
- [x] `uv run ruff format --check services/web/` — clean
- [x] `uv run mypy services/web/` — clean
- [x] New tests in `test_dashboard_stats.py`:
  - `test_dashboard_format_filter_threads_through` — verifies the format reaches every filterable analytics call and the Clear filter link is present
  - `test_dashboard_format_filter_overrides_headline_numbers` — verifies the headline cards reflect the selected format's row
  - `test_dashboard_unfiltered_has_no_clear_link` — verifies no Clear filter when no `?format=`