### PR TITLE
fix(#72, #73): scraper decklist visibility + real selectors

### DIFF
--- a/services/analytics/analytics_service/main.py
+++ b/services/analytics/analytics_service/main.py
@@ -978,6 +978,24 @@ async def scraper_events(
     return {"events": events, "total": total, "page": page, "per_page": per_page}
 
 
+def _decklist_card_count(decklist: Any) -> int:
+    """Sum the quantities in a ``{card_name: qty}`` decklist.
+
+    Used so the dashboard can show "60/15" for results that have cards
+    but no archetype name (MTGO, which doesn't tag deck archetypes).
+    Tolerant of None, non-dict values, and non-integer qty fields.
+    """
+    if not isinstance(decklist, dict):
+        return 0
+    total = 0
+    for qty in decklist.values():
+        try:
+            total += int(qty)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
 @admin_router.get("/scrapers/{name}/events/{event_id}")
 async def scraper_event_detail(
     name: str,
@@ -1034,6 +1052,8 @@ async def scraper_event_detail(
                         "deck_name": r[2],
                         "decklist_main": r[3],
                         "decklist_sideboard": r[4],
+                        "main_card_count": _decklist_card_count(r[3]),
+                        "sideboard_card_count": _decklist_card_count(r[4]),
                     }
                     for r in result_rows
                 ],
@@ -1080,6 +1100,8 @@ async def scraper_event_detail(
                         "deck_name": None,
                         "decklist_main": r[2],
                         "decklist_sideboard": r[3],
+                        "main_card_count": _decklist_card_count(r[2]),
+                        "sideboard_card_count": _decklist_card_count(r[3]),
                     }
                     for r in result_rows
                 ],

--- a/services/analytics/analytics_service/mtgtop8_scraper.py
+++ b/services/analytics/analytics_service/mtgtop8_scraper.py
@@ -269,33 +269,43 @@ def extract_decklists_from_event_page(html: str, event_url: str) -> list[dict[st
 def _extract_decklists_strategy_player_rows(
     soup: BeautifulSoup, event_url: str
 ) -> list[dict[str, Any]]:
-    """Primary strategy: player links in table rows on the event page.
+    """Primary strategy: player rows in the event-page div layout.
 
-    mtgtop8 event pages list players in rows with a link containing ``d=ID``.
-    Each player row has a placement and a deck archetype name. The actual
-    decklist cards are sometimes shown inline on the page.
+    mtgtop8 event pages render finisher rows as ``<div class="chosen_tr">``
+    (top finisher) and ``<div class="hover_tr">`` (everyone else) — *not*
+    real ``<tr>`` table rows. Each row has the shape::
+
+        <div class="chosen_tr"> | <div class="hover_tr">
+          <div class="S14">PLACEMENT</div>     <!-- "1", "3-4", "5-8", ... -->
+          <div>...thumbnail...</div>
+          <div style="flex:1;">
+            <div class="S14"><a href="?e=…&d=…">DECK_ARCHETYPE</a></div>
+            <div class="G11"><a class="player" href="search?player=…">PLAYER</a></div>
+          </div>
+        </div>
     """
     out: list[dict[str, Any]] = []
     seen_players: set[str] = set()
 
-    # Look for rows with deck links
-    for anchor in soup.find_all("a", href=_DECK_HREF_RE):
-        if not isinstance(anchor, Tag):
+    rows = soup.find_all("div", class_=re.compile(r"^(chosen_tr|hover_tr)$"))
+    for row in rows:
+        if not isinstance(row, Tag):
             continue
 
-        # Extract player info from surrounding context
-        parent_row = anchor.find_parent("tr")
-        if not isinstance(parent_row, Tag):
+        # Each row has two deck anchors with the same href: a thumbnail
+        # (image, no text) and a text label. Pick the first one with text.
+        deck_name: str | None = None
+        for candidate in row.find_all("a", href=_DECK_HREF_RE):
+            if not isinstance(candidate, Tag):
+                continue
+            text_val = candidate.get_text(strip=True)
+            if text_val:
+                deck_name = text_val
+                break
+        player_anchor = row.find("a", class_="player")
+        if not isinstance(player_anchor, Tag):
             continue
-
-        cells = parent_row.find_all("td")
-        if len(cells) < 2:
-            continue
-
-        deck_name = anchor.get_text(strip=True) or None
-
-        # Player name: look for a separate text element in the row
-        player_name = _extract_player_name(cells, anchor)
+        player_name = player_anchor.get_text(strip=True)
         if not player_name:
             continue
 
@@ -304,7 +314,7 @@ def _extract_decklists_strategy_player_rows(
             continue
         seen_players.add(dedup_key)
 
-        placement = _extract_placement(cells)
+        placement = _placement_from_row(row)
 
         out.append(
             {
@@ -317,6 +327,29 @@ def _extract_decklists_strategy_player_rows(
         )
 
     return out
+
+
+def _placement_from_row(row: Tag) -> int | None:
+    """Pull the leading placement int from a finisher row.
+
+    mtgtop8 prints placement as ``"1"``, ``"3-4"``, ``"5-8"``, ``"9-16"``,
+    etc. We collapse ranges to the top finishing position (3 for "3-4").
+    """
+    # The first <div class="S14"> in the row holds the placement;
+    # fall back to any leading "N" / "N-M" text in the row.
+    placement_div = row.find("div", class_="S14")
+    if isinstance(placement_div, Tag):
+        match = _PLACEMENT_RE.match(placement_div.get_text(strip=True))
+        if match:
+            value = int(match.group(1))
+            if 1 <= value <= 999:
+                return value
+    match = _PLACEMENT_RE.match(row.get_text(" ", strip=True))
+    if match:
+        value = int(match.group(1))
+        if 1 <= value <= 999:
+            return value
+    return None
 
 
 def _extract_decklists_strategy_deck_blocks(
@@ -388,28 +421,33 @@ def _extract_cards_from_detail(soup: BeautifulSoup) -> tuple[dict[str, int], dic
     side: dict[str, int] = {}
     in_sideboard = False
 
-    # Strategy 1: look for card name spans with quantity divs
-    # mtgtop8 uses a structure where card quantities and names appear
-    # in adjacent elements
-    card_containers = soup.find_all(
-        "div", attrs={"class": re.compile(r"(deck_line|G\d)", re.IGNORECASE)}
-    )
-    if card_containers:
-        for container in card_containers:
-            if not isinstance(container, Tag):
-                continue
-            text_content = container.get_text(" ", strip=True)
-            # Check for sideboard header
-            if re.search(r"sideboard", text_content, re.IGNORECASE) and len(text_content) < 30:
-                in_sideboard = True
-                continue
-            match = _CARD_LINE_RE.match(text_content)
-            if match:
-                qty = int(match.group(1))
-                name = match.group(2).strip()
-                if qty > 0 and name:
-                    target = side if in_sideboard else main
-                    target[name] = target.get(name, 0) + qty
+    # Strategy 1: walk the deck-column container in document order so the
+    # SIDEBOARD section header (a sibling ``<div class="O14">SIDEBOARD</div>``,
+    # not a deck_line) flips the in_sideboard flag for everything after it.
+    deck_columns = _find_deck_column_parents(soup)
+    if deck_columns:
+        for column in deck_columns:
+            for elem in column.find_all("div", recursive=True):
+                if not isinstance(elem, Tag):
+                    continue
+                raw_classes: str | list[str] = elem.get("class") or []
+                classes = raw_classes if isinstance(raw_classes, list) else [raw_classes]
+                text_content = elem.get_text(" ", strip=True)
+                # Section header (LANDS / CREATURES / SIDEBOARD / …) lives
+                # in <div class="O14">. Only "SIDEBOARD" flips the board flag.
+                if "O14" in classes:
+                    if re.search(r"sideboard", text_content, re.IGNORECASE):
+                        in_sideboard = True
+                    continue
+                if "deck_line" not in classes:
+                    continue
+                match = _CARD_LINE_RE.match(text_content)
+                if match:
+                    qty = int(match.group(1))
+                    name = match.group(2).strip()
+                    if qty > 0 and name:
+                        target = side if in_sideboard else main
+                        target[name] = target.get(name, 0) + qty
         if main or side:
             return main, side
 
@@ -434,6 +472,33 @@ def _extract_cards_from_detail(soup: BeautifulSoup) -> tuple[dict[str, int], dic
                 target[name] = target.get(name, 0) + qty
 
     return main, side
+
+
+def _find_deck_column_parents(soup: BeautifulSoup) -> list[Tag]:
+    """Return the smallest containers that hold both deck_line cards and
+    the SIDEBOARD section header.
+
+    mtgtop8 deck pages render mainboard + sideboard inside a single flex
+    column. Walking that column in document order lets the SIDEBOARD
+    header act as a separator. We pick the narrowest ancestor so adjacent
+    page chrome (sidebar, related decks) doesn't bleed in.
+    """
+    deck_lines = soup.find_all("div", class_="deck_line")
+    if not deck_lines:
+        return []
+    columns: list[Tag] = []
+    seen: set[int] = set()
+    for deck_line in deck_lines:
+        if not isinstance(deck_line, Tag):
+            continue
+        parent = deck_line.parent
+        if not isinstance(parent, Tag):
+            continue
+        if id(parent) in seen:
+            continue
+        seen.add(id(parent))
+        columns.append(parent)
+    return columns
 
 
 def _looks_like_non_card(name: str) -> bool:
@@ -490,43 +555,6 @@ def _extract_player_from_block(block: Tag) -> str | None:
             text_blob = heading.get_text(strip=True)
             if text_blob and len(text_blob) < 60:
                 return text_blob
-    return None
-
-
-def _extract_player_name(cells: list[Tag], deck_anchor: Tag) -> str | None:
-    """Extract player name from table cells adjacent to the deck link."""
-    for cell in cells:
-        if not isinstance(cell, Tag):
-            continue
-        # Skip the cell that contains the deck link itself
-        if cell.find("a", href=_DECK_HREF_RE):
-            continue
-        text_blob = cell.get_text(strip=True)
-        if not text_blob:
-            continue
-        # Skip cells that are purely numeric (placement, player count)
-        if text_blob.isdigit():
-            continue
-        # Skip very short or date-like cells
-        if len(text_blob) < 2 or _DATE_RE.match(text_blob):
-            continue
-        return text_blob
-    return None
-
-
-def _extract_placement(cells: list[Tag]) -> int | None:
-    """Extract placement from a row's first numeric cell."""
-    for cell in cells:
-        if not isinstance(cell, Tag):
-            continue
-        text_blob = cell.get_text(strip=True)
-        if not text_blob:
-            continue
-        match = _PLACEMENT_RE.match(text_blob)
-        if match:
-            value = int(match.group(1))
-            if 1 <= value <= 999:
-                return value
     return None
 
 

--- a/services/analytics/analytics_service/mtgtop8_scraper.py
+++ b/services/analytics/analytics_service/mtgtop8_scraper.py
@@ -427,6 +427,9 @@ def _extract_cards_from_detail(soup: BeautifulSoup) -> tuple[dict[str, int], dic
     deck_columns = _find_deck_column_parents(soup)
     if deck_columns:
         for column in deck_columns:
+            # Reset per column so a SIDEBOARD header in an earlier column
+            # doesn't leak the flag into the next column's main-deck cards.
+            in_sideboard = False
             for elem in column.find_all("div", recursive=True):
                 if not isinstance(elem, Tag):
                     continue

--- a/services/analytics/tests/test_mtgtop8_scraper.py
+++ b/services/analytics/tests/test_mtgtop8_scraper.py
@@ -272,6 +272,44 @@ def test_extract_decklist_detail_page() -> None:
     assert result["decklist_sideboard"]["Searing Blood"] == 3
 
 
+def test_extract_decklist_detail_page_multi_column_sideboard_isolated() -> None:
+    """Regression: ``in_sideboard`` must reset between deck columns.
+
+    mtgtop8 detail pages sometimes render multiple sibling deck columns
+    (e.g. a separate sideboard column). Without a per-column reset the
+    SIDEBOARD header in the first column would leak the flag into the
+    second column, mis-routing its main-deck cards into the sideboard
+    bucket.
+    """
+    html = """
+    <html><body>
+      <div style="margin:3px;flex:1;">
+        <div class="O14">SIDEBOARD</div>
+        <div class="deck_line">2 Smash to Smithereens</div>
+        <div class="deck_line">3 Searing Blood</div>
+      </div>
+      <div style="margin:3px;flex:1;">
+        <div class="O14">20 LANDS</div>
+        <div class="deck_line">4 Mountain</div>
+        <div class="O14">28 INSTANTS and SORC.</div>
+        <div class="deck_line">4 Lightning Bolt</div>
+      </div>
+    </body></html>
+    """
+    result = extract_decklist_from_detail_page(
+        html, "Alice", "https://mtgtop8.com/event?e=1&d=2&f=MO"
+    )
+    assert result is not None
+    # Second column's cards belong in main, not sideboard.
+    assert result["decklist_main"]["Mountain"] == 4
+    assert result["decklist_main"]["Lightning Bolt"] == 4
+    assert "Mountain" not in result["decklist_sideboard"]
+    assert "Lightning Bolt" not in result["decklist_sideboard"]
+    # First column's cards still land in sideboard.
+    assert result["decklist_sideboard"]["Smash to Smithereens"] == 2
+    assert result["decklist_sideboard"]["Searing Blood"] == 3
+
+
 def test_extract_decklist_detail_page_text_fallback() -> None:
     """Fallback: plain text card lines without deck_line class."""
     html = """

--- a/services/analytics/tests/test_mtgtop8_scraper.py
+++ b/services/analytics/tests/test_mtgtop8_scraper.py
@@ -111,7 +111,66 @@ def test_extract_events_all_format_codes() -> None:
 
 
 def test_extract_decklists_player_rows() -> None:
-    """Primary strategy: player rows with deck links."""
+    """Primary strategy: ``div.chosen_tr`` / ``div.hover_tr`` finisher rows.
+
+    Regression test for #73. mtgtop8 event pages render finishers in div-based
+    rows, not real ``<tr>`` table rows. Each row has the placement in a leading
+    ``S14`` div, the deck archetype in an anchor (with a sibling thumbnail
+    anchor that points to the same href but carries no text), and the player
+    name in an ``a.player`` link.
+    """
+    html = """
+    <html><body>
+      <div class="chosen_tr">
+        <div style="display:flex;">
+          <div class="S14" style="width:42px;">1</div>
+          <div style="width:80px;"><a href="?e=54321&d=100001&f=MO"><img/></a></div>
+          <div style="flex:1;">
+            <div class="S14"><a href="?e=54321&d=100001&f=MO">Burn</a></div>
+            <div class="G11"><a class="player" href="search?player=Alice">Alice</a></div>
+          </div>
+        </div>
+      </div>
+      <div class="hover_tr">
+        <div style="display:flex;">
+          <div class="S14" style="width:42px;">2</div>
+          <div style="width:80px;"><a href="?e=54321&d=100002&f=MO"><img/></a></div>
+          <div style="flex:1;">
+            <div class="S14"><a href="?e=54321&d=100002&f=MO">Tron</a></div>
+            <div class="G11"><a class="player" href="search?player=Bob">Bob</a></div>
+          </div>
+        </div>
+      </div>
+      <div class="hover_tr">
+        <div style="display:flex;">
+          <div class="S14" style="width:42px;">3-4</div>
+          <div style="width:80px;"><a href="?e=54321&d=100003&f=MO"><img/></a></div>
+          <div style="flex:1;">
+            <div class="S14"><a href="?e=54321&d=100003&f=MO">Reanimator</a></div>
+            <div class="G11"><a class="player" href="search?player=Carol">Carol</a></div>
+          </div>
+        </div>
+      </div>
+    </body></html>
+    """
+    decks = extract_decklists_from_event_page(html, "https://mtgtop8.com/event?e=54321&f=MO")
+    assert len(decks) == 3
+    by_player = {d["player_name"]: d for d in decks}
+    assert by_player["Alice"]["placement"] == 1
+    assert by_player["Alice"]["deck_name"] == "Burn"
+    assert by_player["Bob"]["placement"] == 2
+    assert by_player["Bob"]["deck_name"] == "Tron"
+    # Placement ranges like "3-4" collapse to the top finishing position.
+    assert by_player["Carol"]["placement"] == 3
+    assert by_player["Carol"]["deck_name"] == "Reanimator"
+
+
+def test_extract_decklists_player_rows_old_table_shape_returns_empty() -> None:
+    """The pre-fix ``<tr>``/``<td>`` shape no longer matches.
+
+    Guards against re-introducing the table-row assumption that caused #73 —
+    the real site uses div-based rows.
+    """
     html = """
     <html><body>
       <table>
@@ -120,23 +179,13 @@ def test_extract_decklists_player_rows() -> None:
           <td><a href="?e=54321&d=100001&f=MO">Burn</a></td>
           <td>Alice</td>
         </tr>
-        <tr>
-          <td>2</td>
-          <td><a href="?e=54321&d=100002&f=MO">Tron</a></td>
-          <td>Bob</td>
-        </tr>
       </table>
     </body></html>
     """
+    # No chosen_tr / hover_tr, no a.player → primary strategy yields nothing,
+    # and the fallback finds no card lines either.
     decks = extract_decklists_from_event_page(html, "https://mtgtop8.com/event?e=54321&f=MO")
-    assert len(decks) == 2
-    by_player = {d["player_name"]: d for d in decks}
-    assert "Alice" in by_player
-    assert "Bob" in by_player
-    assert by_player["Alice"]["placement"] == 1
-    assert by_player["Alice"]["deck_name"] == "Burn"
-    assert by_player["Bob"]["placement"] == 2
-    assert by_player["Bob"]["deck_name"] == "Tron"
+    assert decks == []
 
 
 def test_extract_decklists_empty() -> None:
@@ -178,16 +227,30 @@ def test_extract_decklists_deck_blocks_fallback() -> None:
 
 
 def test_extract_decklist_detail_page() -> None:
-    """Individual deck detail page with card lines."""
+    """Individual deck detail page using mtgtop8's real layout.
+
+    Regression test for #73. mtgtop8 separates the mainboard and sideboard
+    with a sibling ``<div class="O14">SIDEBOARD</div>`` header (not a
+    deck_line), so the parser has to walk the deck column in document order
+    and flip into the sideboard section when it sees that header.
+    """
     html = """
     <html><body>
-      <div class="deck_line">4 Lightning Bolt</div>
-      <div class="deck_line">4 Goblin Guide</div>
-      <div class="deck_line">4 Lava Spike</div>
-      <div class="deck_line">4 Rift Bolt</div>
-      <div class="deck_line">Sideboard</div>
-      <div class="deck_line">2 Smash to Smithereens</div>
-      <div class="deck_line">3 Eidolon of the Great Revel</div>
+      <div style="margin:3px;flex:1;">
+        <div class="O14">20 LANDS</div>
+        <div class="deck_line">4 Mountain</div>
+        <div class="deck_line">4 Inspiring Vantage</div>
+        <div class="O14">12 CREATURES</div>
+        <div class="deck_line">4 Goblin Guide</div>
+        <div class="deck_line">4 Eidolon of the Great Revel</div>
+        <div class="O14">28 INSTANTS and SORC.</div>
+        <div class="deck_line">4 Lightning Bolt</div>
+        <div class="deck_line">4 Lava Spike</div>
+        <div class="deck_line">4 Rift Bolt</div>
+        <div class="O14">SIDEBOARD</div>
+        <div class="deck_line">2 Smash to Smithereens</div>
+        <div class="deck_line">3 Searing Blood</div>
+      </div>
     </body></html>
     """
     result = extract_decklist_from_detail_page(
@@ -195,12 +258,18 @@ def test_extract_decklist_detail_page() -> None:
     )
     assert result is not None
     assert result["player_name"] == "Alice"
+    # Section headers like "20 LANDS" and "12 CREATURES" are <div class="O14">,
+    # not deck_line — they must not be picked up as cards.
+    assert "LANDS" not in result["decklist_main"]
+    assert "CREATURES" not in result["decklist_main"]
     assert result["decklist_main"]["Lightning Bolt"] == 4
     assert result["decklist_main"]["Goblin Guide"] == 4
-    assert result["decklist_main"]["Lava Spike"] == 4
-    assert result["decklist_main"]["Rift Bolt"] == 4
+    assert result["decklist_main"]["Mountain"] == 4
+    # Sideboard cards land in the sideboard bucket, not main.
+    assert "Smash to Smithereens" not in result["decklist_main"]
+    assert "Searing Blood" not in result["decklist_main"]
     assert result["decklist_sideboard"]["Smash to Smithereens"] == 2
-    assert result["decklist_sideboard"]["Eidolon of the Great Revel"] == 3
+    assert result["decklist_sideboard"]["Searing Blood"] == 3
 
 
 def test_extract_decklist_detail_page_text_fallback() -> None:

--- a/services/analytics/tests/test_scraper_event_detail.py
+++ b/services/analytics/tests/test_scraper_event_detail.py
@@ -1,0 +1,66 @@
+"""Unit tests for the admin scraper-event-detail response shape.
+
+Regression coverage for #72: the dashboard "Deck" column used to read
+``deck_name`` only, which is always ``None`` for MTGO results (MTGO doesn't
+publish archetype labels). The API now ships ``main_card_count`` and
+``sideboard_card_count`` so the dashboard can show a meaningful "60 / 15"
+fallback when the decklists exist but no archetype name does.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from analytics_service.main import _decklist_card_count
+
+
+def test_decklist_card_count_sums_quantities() -> None:
+    """Quantities are summed across all cards in the decklist."""
+    decklist = {"Lightning Bolt": 4, "Goblin Guide": 4, "Lava Spike": 4}
+    assert _decklist_card_count(decklist) == 12
+
+
+def test_decklist_card_count_typical_mtgo_mainboard() -> None:
+    """A standard 60-card mainboard sums to 60."""
+    decklist = {
+        "Mountain": 20,
+        "Lightning Bolt": 4,
+        "Goblin Guide": 4,
+        "Lava Spike": 4,
+        "Rift Bolt": 4,
+        "Skewer the Critics": 4,
+        "Searing Blaze": 4,
+        "Boros Charm": 4,
+        "Eidolon of the Great Revel": 4,
+        "Monastery Swiftspear": 4,
+        "Inspiring Vantage": 4,
+    }
+    assert _decklist_card_count(decklist) == 60
+
+
+def test_decklist_card_count_handles_string_quantities() -> None:
+    """JSONB sometimes round-trips quantities as strings; coerce them."""
+    decklist = {"Lightning Bolt": "4", "Goblin Guide": "4"}
+    assert _decklist_card_count(decklist) == 8
+
+
+def test_decklist_card_count_skips_non_integer_values() -> None:
+    """Garbage values are skipped, not fatal."""
+    decklist: dict[str, Any] = {"Lightning Bolt": 4, "Bogus": None, "Other": "abc"}
+    assert _decklist_card_count(decklist) == 4
+
+
+def test_decklist_card_count_empty_dict() -> None:
+    assert _decklist_card_count({}) == 0
+
+
+def test_decklist_card_count_none() -> None:
+    """``None`` decklists come back from the DB when the JSONB column is NULL."""
+    assert _decklist_card_count(None) == 0
+
+
+def test_decklist_card_count_non_dict() -> None:
+    """Defensive: any unexpected shape returns 0 rather than raising."""
+    assert _decklist_card_count("not a dict") == 0
+    assert _decklist_card_count(42) == 0
+    assert _decklist_card_count([("Lightning Bolt", 4)]) == 0

--- a/services/web/web_service/templates/admin_scraper_events.html
+++ b/services/web/web_service/templates/admin_scraper_events.html
@@ -74,7 +74,15 @@
                 <tr class="border-b dark:border-border-subtle border-border-light hover:dark:bg-surface-2 hover:bg-surface-light-2 transition-colors">
                     <td class="px-4 py-2.5 text-sm font-mono dark:text-txt-secondary text-txt-secondary-light">{% if r.placement is not none %}{{ r.placement }}{% else %}--{% endif %}</td>
                     <td class="px-4 py-2.5 text-sm dark:text-txt-primary text-txt-primary-light">{{ r.player_name }}</td>
-                    <td class="px-4 py-2.5 text-sm dark:text-txt-secondary text-txt-secondary-light">{{ r.deck_name or "--" }}</td>
+                    <td class="px-4 py-2.5 text-sm dark:text-txt-secondary text-txt-secondary-light">
+                        {%- if r.deck_name -%}
+                            {{ r.deck_name }}
+                        {%- elif (r.main_card_count or 0) > 0 or (r.sideboard_card_count or 0) > 0 -%}
+                            <span class="font-mono" title="mainboard / sideboard">{{ r.main_card_count or 0 }} / {{ r.sideboard_card_count or 0 }}</span>
+                        {%- else -%}
+                            --
+                        {%- endif -%}
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
## Summary

- **#72 (MTGO)** was *not* a scraper bug — the scraper has been capturing decklists all along. The dashboard "Deck" column only renders `deck_name`, which MTGO never publishes (MTGO ships raw cards, not archetype labels). Every MTGO row therefore showed `--` even when 60+15 cards were sitting in the JSONB column. Fix is on the API + template side: the admin scraper-event-detail endpoint now returns `main_card_count` / `sideboard_card_count`, and the template falls back to `60 / 15` when no archetype name is available.
- **#73 (mtgtop8)** was a real scraper bug. mtgtop8 event pages render finisher rows as `<div class="chosen_tr">` and `<div class="hover_tr">`, not real `<tr>` table rows. The primary extractor required `find_parent("tr")` and silently returned zero rows for every event — hence "75 event(s) fetched but all had zero results." Rewrote the strategy around the real div layout (placement in the leading `S14` div, deck name in the text anchor, player in the `a.player` link), with placement ranges like `"3-4"` collapsing to the top finishing position. Also fixed sideboard separation in `extract_decklist_from_detail_page`: mtgtop8's SIDEBOARD label lives in a sibling `<div class="O14">`, not a deck_line, so the parser now walks the deck column in document order and flips into sideboard mode when it sees that header.

Two issues, two different root causes, addressed in one PR because they were filed as sibling symptoms of the same "scrapers don't pull decklists" complaint.

## Verification

End-to-end sanity check against live HTML pulled at fix time:

| Source | Before | After |
|--|--|--|
| `https://www.mtgtop8.com/event?e=84765&f=MO` (event) | 0 rows | 16 finishers with placement + player + archetype |
| `https://www.mtgtop8.com/event?e=84765&d=843951&f=MO` (deck detail) | 75/0 cards (sideboard merged into main) | 60/15 (correctly separated) |
| `https://www.mtgo.com/decklist/pauper-challenge-32-…` | UI showed `--`, DB had 60/15 | UI now shows `60 / 15` |

## Files changed

- `services/analytics/analytics_service/main.py` — `_decklist_card_count` helper + two dict additions
- `services/analytics/analytics_service/mtgtop8_scraper.py` — primary strategy rewrite, sideboard separator fix, dead-helper cleanup
- `services/analytics/tests/test_mtgtop8_scraper.py` — replaced obsolete `<tr>`-shape test with one exercising the real div layout, added old-shape-returns-empty guard, added sideboard-separation regression test
- `services/analytics/tests/test_scraper_event_detail.py` (new) — unit tests for `_decklist_card_count`
- `services/web/web_service/templates/admin_scraper_events.html` — Deck column fallback

## Test plan

- [x] `uv run pytest services/analytics/tests/` — 158 passed
- [x] `uv run pytest services/web/tests/ tests/common/` — 260 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy common/ services/` — clean
- [ ] CI green on push

## Open questions / monitoring

- The new mtgtop8 selectors target stable-looking class names (`chosen_tr`/`hover_tr`/`O14`/`a.player`) and the layout looks long-lived, but the site has no API contract and can change at any time. Worth monitoring scraper health for a week after deploy to confirm the live result counts stay healthy.
- This fix only addresses the two cited scrapers; Goldfish + mtgdecks remain blocked by Cloudflare per prior ToS findings and were left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)