### PR TITLE
fix(#74): dedupe MTGO and mtgtop8 scraper feeds into one canonical event list

### DIFF
--- a/services/analytics/analytics_service/event_merger.py
+++ b/services/analytics/analytics_service/event_merger.py
@@ -314,10 +314,13 @@ def find_supplements_for(
     for candidate in candidate_events:
         if match_key(candidate) == primary_key:
             # Skip the primary itself if the caller mixed it into the
-            # candidate pool (same source, same id).
+            # candidate pool. Both id AND source must match — ids are
+            # only unique within their source table, so a candidate
+            # from the other feed with the same numeric id is a
+            # legitimate sibling, not the primary.
             if (
                 candidate.get("id") == primary_event.get("id")
-                and candidate.get("source", primary_source) == primary_source
+                and candidate.get("source") == primary_source
             ):
                 continue
             out.append(candidate)
@@ -327,14 +330,22 @@ def find_supplements_for(
 def merge_results(
     primary_results: list[dict[str, Any]],
     supplement_results: list[dict[str, Any]],
+    *,
+    supplement_source: str | None = None,
 ) -> list[dict[str, Any]]:
     """Union per-player rows from the primary and supplementing sources.
 
     Keyed by ``player_name`` (case-insensitive, trimmed). Primary
     entries always win — they carry the archetype label (``deck_name``)
     from mtgtop8 which we don't want to drop. Supplement-only players
-    (e.g., the top-9-to-32 from an MTGO league that mtgtop8 skipped)
-    land in the merged list with their MTGO data and ``deck_name=None``.
+    land in the merged list with their supplement-source data; whether
+    the archetype label survives depends on *supplement_source*:
+
+    - ``"mtgo"`` — clear ``deck_name`` (MTGO doesn't carry archetype
+      labels; null any stale value so the UI doesn't render schema
+      noise).
+    - ``"mtgtop8"`` (or any other value, or ``None``) — preserve
+      ``deck_name`` as-is. mtgtop8 IS the archetype source.
 
     The function never mutates its inputs.
 
@@ -360,10 +371,8 @@ def merge_results(
         if not key or key in seen:
             continue
         copied = dict(entry)
-        # MTGO-only players don't carry an archetype label; null it
-        # explicitly so the UI doesn't render a stale value from the
-        # supplement source's schema.
-        copied["deck_name"] = None
+        if supplement_source == "mtgo":
+            copied["deck_name"] = None
         seen[key] = copied
         out.append(copied)
 

--- a/services/analytics/analytics_service/event_merger.py
+++ b/services/analytics/analytics_service/event_merger.py
@@ -1,0 +1,377 @@
+"""Canonical-event merger for the mtgtop8 and mtgo scraper feeds.
+
+The two scrapers populate independent tables (``analytics.mtgtop8_events``
+and ``analytics.mtgo_events``). The same real-world event — say a Pauper
+League on 2026-05-21 — often shows up in both. The user-facing metagame
+view wants a single canonical entry per logical event, but the two
+sources aren't strictly redundant:
+
+- mtgtop8 carries archetype labels (``deck_name``) — those are gold; we
+  don't want to throw them away or re-derive them.
+- mtgo.com sometimes publishes deeper standings (more participants) than
+  mtgtop8 covers — for leagues especially, the MTGO listing may include
+  the full top-32 while mtgtop8 only shows the top-8.
+
+Rule:
+    * Event metadata (name, date, format) — **mtgtop8 wins** when both
+      sources have it.
+    * Participants / decklists — **union** both sources keyed by player
+      name. mtgtop8-derived entries keep their archetype labels;
+      MTGO-only entries land without labels (the classifier can attempt
+      them later).
+    * When only one source has the event, that source is used as-is.
+
+This module is pure logic — no DB, no HTTP. Callers load events from
+each scraper's tables, hand them to :func:`merge_events`, and get back
+a list of :class:`CanonicalEvent` for display. :func:`merge_results`
+performs the same union on per-event participant rows for the detail
+view.
+
+Match key
+---------
+Two events match iff all three of these agree, and none of them is
+missing:
+
+    (format, event_date, event_signature)
+
+``event_signature`` is the event name with format names, dates, and
+numeric suffixes stripped — so ``"Pauper League May212026"`` and
+``"Pauper League — May 21, 2026"`` both reduce to ``"league"`` and
+match on the same date + format.
+
+If any of (format, date, signature) is missing for an event, it does
+not merge — it stands alone. That's conservative: we miss some
+genuine duplicates rather than false-merge unrelated events.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from datetime import date
+from typing import Any
+
+# Format tokens that appear in event names and should be stripped before
+# the signature is computed. Keep lowercase, no plurals.
+_FORMAT_TOKENS = (
+    "vintage",
+    "legacy",
+    "modern",
+    "pioneer",
+    "pauper",
+    "standard",
+    "historic",
+    "explorer",
+    "alchemy",
+    "timeless",
+    "premodern",
+    "limited",
+    "draft",
+    "sealed",
+)
+
+# Patterns that look like dates inside the event name. mtgo.com uses
+# both YYYY-MM-DD and the slug form, mtgtop8 uses DD/MM/YY, and humans
+# write things like "May 21, 2026" or "21st May 2026".
+_DATE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\d{4}-\d{2}-\d{2}"),
+    re.compile(r"\d{1,2}/\d{1,2}/\d{2,4}"),
+    # Day-first ("21st May 2026", "21 May 2026"). Run before the
+    # month-first pattern so the ordinal suffix doesn't get stranded
+    # when the month-first pattern would otherwise claim "may 2026"
+    # and leave "21st" behind.
+    re.compile(
+        r"\b\d{1,2}(st|nd|rd|th)?\s*(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s*\d{2,4}\b",
+        re.IGNORECASE,
+    ),
+    # Month-first ("May 21, 2026" or "May 21 2026"). The ``\s+`` between
+    # day and year (rather than ``\s*``) is what stops it from greedily
+    # matching just "May 2026" — we want a real day token in between.
+    re.compile(
+        r"\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+\d{1,2}\s*,?\s+\d{2,4}\b",
+        re.IGNORECASE,
+    ),
+    # MTGO often joins month + day + year with no spaces:
+    # "May212026" or "may212026". Match a month name followed by
+    # 5-8 digits.
+    re.compile(
+        r"\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\d{4,8}\b",
+        re.IGNORECASE,
+    ),
+)
+
+
+def normalize_format(value: str | None) -> str | None:
+    """Lower-case and trim a format string. ``None`` / blank → ``None``."""
+    if not value:
+        return None
+    cleaned = value.strip().lower()
+    return cleaned or None
+
+
+def event_signature(name: str | None) -> str | None:
+    """Reduce an event name to its 'type' tokens.
+
+    The signature is what's left of the name after stripping format
+    words, date patterns, and numeric suffixes. Empty result → ``None``.
+
+    Examples:
+        "Pauper League May212026"          -> "league"
+        "Pauper League — May 21, 2026"     -> "league"
+        "Modern Challenge 32 2026-05-08"   -> "challenge"
+        "Modern Showcase Challenge"        -> "showcase challenge"
+        "Vintage Super Qualifier"          -> "super qualifier"
+    """
+    if not name:
+        return None
+    text = name.lower()
+    for pattern in _DATE_PATTERNS:
+        text = pattern.sub(" ", text)
+    for token in _FORMAT_TOKENS:
+        text = re.sub(r"\b" + re.escape(token) + r"\b", " ", text)
+    # Drop standalone numbers (event sizes like "32", "64", years like
+    # "2026") and punctuation. We keep letters and whitespace only.
+    text = re.sub(r"[^a-z\s]+", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text or None
+
+
+@dataclasses.dataclass(frozen=True)
+class MatchKey:
+    """Three-tuple that identifies the same logical event across sources."""
+
+    format: str
+    event_date: date
+    signature: str
+
+
+def match_key(event: dict[str, Any]) -> MatchKey | None:
+    """Return a :class:`MatchKey` for *event*, or ``None`` if it can't merge.
+
+    An event with any of (format, event_date, signature) missing is
+    treated as un-mergeable — it stands alone in the output.
+    """
+    fmt = normalize_format(event.get("format"))
+    if fmt is None:
+        return None
+    event_date = event.get("event_date")
+    if not isinstance(event_date, date):
+        return None
+    signature = event_signature(event.get("event_name"))
+    if signature is None:
+        return None
+    return MatchKey(format=fmt, event_date=event_date, signature=signature)
+
+
+@dataclasses.dataclass
+class CanonicalEvent:
+    """A single canonical event after merging the two scraper feeds."""
+
+    primary_source: str
+    primary_event_id: int
+    event_name: str
+    event_date: date | None
+    format: str | None
+    player_count: int | None
+    # ``sources`` lists every feed that contributed to this canonical
+    # event, primary first. Used by the UI to show "merged from N
+    # sources" attribution.
+    sources: list[str]
+    # ``supplement_events`` lists ``(source, event_id)`` pairs for the
+    # non-primary contributors. The detail view loads these and unions
+    # their participants into the primary's result list.
+    supplement_events: list[tuple[str, int]]
+
+
+def merge_events(
+    mtgtop8_events: list[dict[str, Any]],
+    mtgo_events: list[dict[str, Any]],
+) -> list[CanonicalEvent]:
+    """Merge per-source event lists into a canonical list.
+
+    Each input event dict must carry at least ``id``, ``event_name``,
+    ``event_date``, and ``format``; ``player_count`` is optional.
+
+    Output ordering: events with a date are sorted by date descending,
+    then by name. Date-less events come last.
+    """
+    by_key: dict[MatchKey, dict[str, list[dict[str, Any]]]] = {}
+    no_key: list[tuple[str, dict[str, Any]]] = []
+
+    def assign(source: str, event: dict[str, Any]) -> None:
+        key = match_key(event)
+        if key is None:
+            no_key.append((source, event))
+            return
+        by_key.setdefault(key, {"mtgtop8": [], "mtgo": []})[source].append(event)
+
+    for event in mtgtop8_events:
+        assign("mtgtop8", event)
+    for event in mtgo_events:
+        assign("mtgo", event)
+
+    out: list[CanonicalEvent] = []
+
+    for sources in by_key.values():
+        mtgtop8_group = sources["mtgtop8"]
+        mtgo_group = sources["mtgo"]
+        if mtgtop8_group:
+            # The first mtgtop8 entry absorbs every MTGO sibling as a
+            # supplement. Any additional mtgtop8 entries at the same key
+            # stand alone — we don't second-guess mtgtop8's own list of
+            # events; it deliberately separates them.
+            primary = mtgtop8_group[0]
+            out.append(
+                _canonical(
+                    primary_source="mtgtop8",
+                    primary=primary,
+                    sources=["mtgtop8"] + (["mtgo"] if mtgo_group else []),
+                    supplements=[("mtgo", e["id"]) for e in mtgo_group],
+                )
+            )
+            for extra in mtgtop8_group[1:]:
+                out.append(
+                    _canonical(
+                        primary_source="mtgtop8",
+                        primary=extra,
+                        sources=["mtgtop8"],
+                        supplements=[],
+                    )
+                )
+        else:
+            for event in mtgo_group:
+                out.append(
+                    _canonical(
+                        primary_source="mtgo",
+                        primary=event,
+                        sources=["mtgo"],
+                        supplements=[],
+                    )
+                )
+
+    for source, event in no_key:
+        out.append(
+            _canonical(
+                primary_source=source,
+                primary=event,
+                sources=[source],
+                supplements=[],
+            )
+        )
+
+    out.sort(
+        key=lambda c: (
+            c.event_date is None,
+            -(c.event_date.toordinal() if c.event_date else 0),
+            c.event_name or "",
+        )
+    )
+    return out
+
+
+def _canonical(
+    *,
+    primary_source: str,
+    primary: dict[str, Any],
+    sources: list[str],
+    supplements: list[tuple[str, int]],
+) -> CanonicalEvent:
+    raw_date = primary.get("event_date")
+    return CanonicalEvent(
+        primary_source=primary_source,
+        primary_event_id=int(primary["id"]),
+        event_name=str(primary.get("event_name") or ""),
+        event_date=raw_date if isinstance(raw_date, date) else None,
+        format=primary.get("format"),
+        player_count=(
+            int(primary["player_count"]) if primary.get("player_count") is not None else None
+        ),
+        sources=sources,
+        supplement_events=supplements,
+    )
+
+
+def find_supplements_for(
+    *,
+    primary_source: str,
+    primary_event: dict[str, Any],
+    candidate_events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return the events from *candidate_events* that match *primary_event*.
+
+    Used by the detail endpoint to supplement an mtgtop8 event with its
+    sibling MTGO event(s) (or the reverse, though in practice mtgtop8
+    wins primary so the reverse never fires through the UI).
+
+    Candidates with a different source than expected are returned as-is;
+    callers are responsible for sorting that out. The function is a pure
+    key match — no source check beyond the *primary_event* anchor.
+    """
+    primary_key = match_key(primary_event)
+    if primary_key is None:
+        return []
+    out: list[dict[str, Any]] = []
+    for candidate in candidate_events:
+        if match_key(candidate) == primary_key:
+            # Skip the primary itself if the caller mixed it into the
+            # candidate pool (same source, same id).
+            if (
+                candidate.get("id") == primary_event.get("id")
+                and candidate.get("source", primary_source) == primary_source
+            ):
+                continue
+            out.append(candidate)
+    return out
+
+
+def merge_results(
+    primary_results: list[dict[str, Any]],
+    supplement_results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Union per-player rows from the primary and supplementing sources.
+
+    Keyed by ``player_name`` (case-insensitive, trimmed). Primary
+    entries always win — they carry the archetype label (``deck_name``)
+    from mtgtop8 which we don't want to drop. Supplement-only players
+    (e.g., the top-9-to-32 from an MTGO league that mtgtop8 skipped)
+    land in the merged list with their MTGO data and ``deck_name=None``.
+
+    The function never mutates its inputs.
+
+    Output ordering: by placement ascending (NULLs last), then by
+    player name.
+    """
+    seen: dict[str, dict[str, Any]] = {}
+    out: list[dict[str, Any]] = []
+
+    def _key(entry: dict[str, Any]) -> str:
+        return (entry.get("player_name") or "").strip().lower()
+
+    for entry in primary_results:
+        key = _key(entry)
+        if not key or key in seen:
+            continue
+        copied = dict(entry)
+        seen[key] = copied
+        out.append(copied)
+
+    for entry in supplement_results:
+        key = _key(entry)
+        if not key or key in seen:
+            continue
+        copied = dict(entry)
+        # MTGO-only players don't carry an archetype label; null it
+        # explicitly so the UI doesn't render a stale value from the
+        # supplement source's schema.
+        copied["deck_name"] = None
+        seen[key] = copied
+        out.append(copied)
+
+    out.sort(
+        key=lambda r: (
+            r.get("placement") is None,
+            r.get("placement") if r.get("placement") is not None else 0,
+            (r.get("player_name") or "").lower(),
+        )
+    )
+    return out

--- a/services/analytics/analytics_service/metagame.py
+++ b/services/analytics/analytics_service/metagame.py
@@ -19,6 +19,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from analytics_service.db import get_session
 from analytics_service.deps import AuthenticatedUser, require_user
+from analytics_service.event_merger import (
+    find_supplements_for,
+    merge_events,
+    merge_results,
+)
 from analytics_service.schemas import (
     ArchetypeTier,
     EventDetail,
@@ -201,51 +206,78 @@ async def format_events(
     page: Annotated[int, Query(ge=1)] = 1,
     per_page: Annotated[int, Query(ge=1, le=_MAX_PER_PAGE)] = _DEFAULT_PER_PAGE,
 ) -> MetagameEventList:
-    """Paginated recent events for a format, combining both sources."""
+    """Paginated recent events for a format, deduped across both feeds.
+
+    The two scrapers run independently and frequently land the same
+    real-world event in both tables (e.g. Pauper Leagues). We load
+    everything for the format from each source and run the in-process
+    :func:`analytics_service.event_merger.merge_events` matcher so the
+    user sees one canonical row per logical event with mtgtop8 metadata
+    winning when present. Pagination runs on the merged list.
+
+    The format string is matched case-insensitively against the
+    ``format`` column on both source tables.
+    """
     fmt = format.title()
+    params: dict[str, Any] = {"format": fmt}
+
+    mtgtop8_rows = (
+        await db.execute(
+            text(
+                "SELECT id, event_name, event_date, format, player_count "
+                "FROM analytics.mtgtop8_events "
+                "WHERE INITCAP(format) = :format"
+            ),
+            params,
+        )
+    ).all()
+    mtgo_rows = (
+        await db.execute(
+            text(
+                "SELECT id, event_name, event_date, format "
+                "FROM analytics.mtgo_events "
+                "WHERE INITCAP(format) = :format"
+            ),
+            params,
+        )
+    ).all()
+
+    mtgtop8_events = [
+        {
+            "id": int(r[0]),
+            "event_name": r[1],
+            "event_date": r[2],
+            "format": r[3],
+            "player_count": int(r[4]) if r[4] is not None else None,
+        }
+        for r in mtgtop8_rows
+    ]
+    mtgo_events = [
+        {
+            "id": int(r[0]),
+            "event_name": r[1],
+            "event_date": r[2],
+            "format": r[3],
+            "player_count": None,
+        }
+        for r in mtgo_rows
+    ]
+
+    canonical = merge_events(mtgtop8_events, mtgo_events)
+    total = len(canonical)
+
     offset = (page - 1) * per_page
-    params: dict[str, Any] = {"format": fmt, "limit": per_page, "offset": offset}
-
-    # Count total across both sources.
-    count_sql = text("""
-        SELECT
-            (SELECT COUNT(*) FROM analytics.mtgtop8_events
-             WHERE INITCAP(format) = :format)
-            +
-            (SELECT COUNT(*) FROM analytics.mtgo_events
-             WHERE INITCAP(format) = :format)
-    """)
-    total = int((await db.execute(count_sql, params)).scalar_one())
-
-    # UNION ALL both sources, paginated.
-    events_sql = text("""
-        SELECT event_id, event_name, event_date, player_count, source
-        FROM (
-            SELECT id AS event_id, event_name, event_date, player_count,
-                   'mtgtop8' AS source
-            FROM analytics.mtgtop8_events
-            WHERE INITCAP(format) = :format
-
-            UNION ALL
-
-            SELECT id AS event_id, event_name, event_date, NULL AS player_count,
-                   'mtgo' AS source
-            FROM analytics.mtgo_events
-            WHERE INITCAP(format) = :format
-        ) combined
-        ORDER BY event_date DESC NULLS LAST, event_name
-        LIMIT :limit OFFSET :offset
-    """)
-    rows = (await db.execute(events_sql, params)).all()
+    page_slice = canonical[offset : offset + per_page]
     events = [
         MetagameEvent(
-            event_id=int(row[0]),
-            event_name=row[1],
-            event_date=row[2],
-            player_count=int(row[3]) if row[3] is not None else None,
-            source=row[4],
+            event_id=c.primary_event_id,
+            event_name=c.event_name,
+            event_date=c.event_date,
+            player_count=c.player_count,
+            source=c.primary_source,
+            sources=list(c.sources),
         )
-        for row in rows
+        for c in page_slice
     ]
     return MetagameEventList(events=events, total=total, page=page, per_page=per_page)
 
@@ -265,103 +297,208 @@ async def event_detail(
     _user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ) -> EventDetail:
-    """Single event detail with all results."""
+    """Single event detail. Participants are unioned across feeds when
+    the same logical event exists in both mtgtop8 and MTGO.
+
+    The primary event (identified by *source* and *id*) provides the
+    metadata. We then look up any matching event in the other source
+    by the merger's match key (format + date + event-type signature)
+    and union its participant rows into the result list. mtgtop8
+    entries win on collisions so we don't drop the archetype labels.
+    """
     if source not in _VALID_SOURCES:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"error": f"invalid source; allowed: {sorted(_VALID_SOURCES)}"},
         )
+
+    fmt = format.title()
+    primary_event = await _load_primary_event(db, source, id, fmt)
+    if primary_event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "event_not_found"},
+        )
+
+    primary_results = await _load_results(db, source, id)
+
+    # Find the sibling event in the OTHER source (only one direction —
+    # an mtgtop8 event looks for an MTGO twin, an MTGO event looks for
+    # an mtgtop8 twin). We use the same matcher as the listing so what
+    # the user clicks through to mirrors what they saw in the list.
+    other_source = "mtgo" if source == "mtgtop8" else "mtgtop8"
+    other_candidates = await _load_candidate_events(db, other_source, fmt)
+    siblings = find_supplements_for(
+        primary_source=source,
+        primary_event=primary_event,
+        candidate_events=other_candidates,
+    )
+
+    sources_used = [source]
+    supplement_rows: list[dict[str, Any]] = []
+    for sibling in siblings:
+        sib_results = await _load_results(db, other_source, int(sibling["id"]))
+        supplement_rows.extend(sib_results)
+    if siblings:
+        sources_used.append(other_source)
+
+    merged = merge_results(primary_results, supplement_rows)
+
+    return EventDetail(
+        event_id=int(primary_event["id"]),
+        event_name=primary_event["event_name"],
+        event_date=primary_event["event_date"],
+        player_count=primary_event.get("player_count"),
+        source=source,
+        sources=sources_used,
+        results=[
+            EventResultEntry(
+                player_name=r["player_name"],
+                placement=r.get("placement"),
+                deck_name=r.get("deck_name"),
+                decklist_main=r.get("decklist_main") or {},
+                decklist_sideboard=r.get("decklist_sideboard") or {},
+            )
+            for r in merged
+        ],
+    )
+
+
+async def _load_primary_event(
+    db: AsyncSession, source: str, event_id: int, fmt: str
+) -> dict[str, Any] | None:
     if source == "mtgtop8":
-        event_row = (
+        row = (
             await db.execute(
-                text("""
-                    SELECT id, event_name, event_date, player_count
-                    FROM analytics.mtgtop8_events
-                    WHERE id = :id AND INITCAP(format) = :format
-                """),
-                {"id": id, "format": format.title()},
+                text(
+                    "SELECT id, event_name, event_date, format, player_count "
+                    "FROM analytics.mtgtop8_events "
+                    "WHERE id = :id AND INITCAP(format) = :format"
+                ),
+                {"id": event_id, "format": fmt},
             )
         ).one_or_none()
-        if event_row is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail={"error": "event_not_found"},
-            )
-        result_rows = (
+        if row is None:
+            return None
+        return {
+            "id": int(row[0]),
+            "event_name": row[1],
+            "event_date": row[2],
+            "format": row[3],
+            "player_count": int(row[4]) if row[4] is not None else None,
+        }
+    row = (
+        await db.execute(
+            text(
+                "SELECT id, event_name, event_date, format "
+                "FROM analytics.mtgo_events "
+                "WHERE id = :id AND INITCAP(format) = :format"
+            ),
+            {"id": event_id, "format": fmt},
+        )
+    ).one_or_none()
+    if row is None:
+        return None
+    return {
+        "id": int(row[0]),
+        "event_name": row[1],
+        "event_date": row[2],
+        "format": row[3],
+        "player_count": None,
+    }
+
+
+async def _load_candidate_events(db: AsyncSession, source: str, fmt: str) -> list[dict[str, Any]]:
+    """Load all events for *source* filtered to *fmt*, for matcher lookups."""
+    if source == "mtgtop8":
+        rows = (
             await db.execute(
-                text("""
-                    SELECT player_name, placement, deck_name,
-                           decklist_main, decklist_sideboard
-                    FROM analytics.mtgtop8_results
-                    WHERE event_id = :event_id
-                    ORDER BY placement NULLS LAST, player_name
-                """),
-                {"event_id": id},
+                text(
+                    "SELECT id, event_name, event_date, format, player_count "
+                    "FROM analytics.mtgtop8_events "
+                    "WHERE INITCAP(format) = :format"
+                ),
+                {"format": fmt},
             )
         ).all()
-        return EventDetail(
-            event_id=int(event_row[0]),
-            event_name=event_row[1],
-            event_date=event_row[2],
-            player_count=int(event_row[3]) if event_row[3] is not None else None,
-            source="mtgtop8",
-            results=[
-                EventResultEntry(
-                    player_name=r[0],
-                    placement=int(r[1]) if r[1] is not None else None,
-                    deck_name=r[2],
-                    decklist_main=r[3],
-                    decklist_sideboard=r[4],
-                )
-                for r in result_rows
-            ],
+        return [
+            {
+                "id": int(r[0]),
+                "event_name": r[1],
+                "event_date": r[2],
+                "format": r[3],
+                "player_count": int(r[4]) if r[4] is not None else None,
+            }
+            for r in rows
+        ]
+    rows = (
+        await db.execute(
+            text(
+                "SELECT id, event_name, event_date, format "
+                "FROM analytics.mtgo_events "
+                "WHERE INITCAP(format) = :format"
+            ),
+            {"format": fmt},
         )
-    else:
-        # mtgo source
-        event_row = (
+    ).all()
+    return [
+        {
+            "id": int(r[0]),
+            "event_name": r[1],
+            "event_date": r[2],
+            "format": r[3],
+            "player_count": None,
+        }
+        for r in rows
+    ]
+
+
+async def _load_results(db: AsyncSession, source: str, event_id: int) -> list[dict[str, Any]]:
+    if source == "mtgtop8":
+        rows = (
             await db.execute(
-                text("""
-                    SELECT id, event_name, event_date
-                    FROM analytics.mtgo_events
-                    WHERE id = :id AND INITCAP(format) = :format
-                """),
-                {"id": id, "format": format.title()},
-            )
-        ).one_or_none()
-        if event_row is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail={"error": "event_not_found"},
-            )
-        result_rows = (
-            await db.execute(
-                text("""
-                    SELECT player_name, placement, NULL AS deck_name,
-                           decklist_main, decklist_sideboard
-                    FROM analytics.mtgo_results
-                    WHERE event_id = :event_id
-                    ORDER BY placement NULLS LAST, player_name
-                """),
-                {"event_id": id},
+                text(
+                    "SELECT player_name, placement, deck_name, "
+                    "decklist_main, decklist_sideboard "
+                    "FROM analytics.mtgtop8_results "
+                    "WHERE event_id = :event_id "
+                    "ORDER BY placement NULLS LAST, player_name"
+                ),
+                {"event_id": event_id},
             )
         ).all()
-        return EventDetail(
-            event_id=int(event_row[0]),
-            event_name=event_row[1],
-            event_date=event_row[2],
-            player_count=None,
-            source="mtgo",
-            results=[
-                EventResultEntry(
-                    player_name=r[0],
-                    placement=int(r[1]) if r[1] is not None else None,
-                    deck_name=r[2],
-                    decklist_main=r[3],
-                    decklist_sideboard=r[4],
-                )
-                for r in result_rows
-            ],
+        return [
+            {
+                "player_name": r[0],
+                "placement": int(r[1]) if r[1] is not None else None,
+                "deck_name": r[2],
+                "decklist_main": r[3],
+                "decklist_sideboard": r[4],
+            }
+            for r in rows
+        ]
+    rows = (
+        await db.execute(
+            text(
+                "SELECT player_name, placement, "
+                "decklist_main, decklist_sideboard "
+                "FROM analytics.mtgo_results "
+                "WHERE event_id = :event_id "
+                "ORDER BY placement NULLS LAST, player_name"
+            ),
+            {"event_id": event_id},
         )
+    ).all()
+    return [
+        {
+            "player_name": r[0],
+            "placement": int(r[1]) if r[1] is not None else None,
+            "deck_name": None,
+            "decklist_main": r[2],
+            "decklist_sideboard": r[3],
+        }
+        for r in rows
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/services/analytics/analytics_service/metagame.py
+++ b/services/analytics/analytics_service/metagame.py
@@ -342,7 +342,11 @@ async def event_detail(
     if siblings:
         sources_used.append(other_source)
 
-    merged = merge_results(primary_results, supplement_rows)
+    merged = merge_results(
+        primary_results,
+        supplement_rows,
+        supplement_source=other_source,
+    )
 
     return EventDetail(
         event_id=int(primary_event["id"]),
@@ -428,6 +432,7 @@ async def _load_candidate_events(db: AsyncSession, source: str, fmt: str) -> lis
                 "event_date": r[2],
                 "format": r[3],
                 "player_count": int(r[4]) if r[4] is not None else None,
+                "source": "mtgtop8",
             }
             for r in rows
         ]
@@ -448,6 +453,7 @@ async def _load_candidate_events(db: AsyncSession, source: str, fmt: str) -> lis
             "event_date": r[2],
             "format": r[3],
             "player_count": None,
+            "source": "mtgo",
         }
         for r in rows
     ]

--- a/services/analytics/analytics_service/schemas.py
+++ b/services/analytics/analytics_service/schemas.py
@@ -97,7 +97,15 @@ class MetagameEvent(BaseModel):
     event_name: str
     event_date: date | None = None
     player_count: int | None = None
-    source: str = Field(description="'mtgtop8' or 'mtgo'")
+    source: str = Field(description="primary source — 'mtgtop8' or 'mtgo'")
+    sources: list[str] = Field(
+        default_factory=list,
+        description=(
+            "All scraper feeds that contributed to this canonical event, "
+            "primary first. E.g. ['mtgtop8', 'mtgo'] when the same event "
+            "appears in both."
+        ),
+    )
 
 
 class MetagameEventList(BaseModel):
@@ -125,6 +133,14 @@ class EventDetail(BaseModel):
     event_date: date | None = None
     player_count: int | None = None
     source: str
+    sources: list[str] = Field(
+        default_factory=list,
+        description=(
+            "All scraper feeds that contributed to this event view, "
+            "primary first. When more than one feed contributed, the "
+            "participant list is a union across feeds."
+        ),
+    )
     results: list[EventResultEntry] = Field(default_factory=list)
 
 

--- a/services/analytics/tests/test_event_merger.py
+++ b/services/analytics/tests/test_event_merger.py
@@ -335,6 +335,31 @@ def test_merge_results_top8_plus_top32_union() -> None:
         assert entry["decklist_main"] == {"Card": 4}
 
 
+def test_merge_results_preserves_mtgtop8_supplement_deck_name() -> None:
+    """Regression: when the primary is MTGO and the supplement is
+    mtgtop8, an mtgtop8-only player's archetype label must survive.
+    Previously merge_results unconditionally nulled supplement
+    deck_names, erasing the only archetype source we have."""
+    primary = [_result("Alice", 1, deck_name=None)]  # MTGO primary
+    supplement = [
+        _result("Bob", 2, deck_name="Mono-Red Burn"),  # mtgtop8 sibling
+    ]
+    merged = merge_results(primary, supplement, supplement_source="mtgtop8")
+    bob = next(r for r in merged if r["player_name"] == "Bob")
+    assert bob["deck_name"] == "Mono-Red Burn"
+
+
+def test_merge_results_nulls_mtgo_supplement_deck_name() -> None:
+    """When the supplement source is MTGO, any deck_name on the row
+    is cleared — MTGO doesn't carry archetypes, so a value there is
+    schema noise we don't want to render."""
+    primary = [_result("Alice", 1, deck_name="Burn")]  # mtgtop8 primary
+    supplement = [_result("Bob", 2, deck_name="stale-value")]
+    merged = merge_results(primary, supplement, supplement_source="mtgo")
+    bob = next(r for r in merged if r["player_name"] == "Bob")
+    assert bob["deck_name"] is None
+
+
 def test_merge_results_no_collision_simple_union() -> None:
     primary = [_result("Alice", 1, deck_name="Burn")]
     supplement = [_result("Bob", 2, deck_name=None)]
@@ -388,6 +413,67 @@ def test_find_supplements_for_matches_on_key() -> None:
         _mtgo(7, "Pauper League May212026", event_date=date(2026, 5, 21)),
         _mtgo(8, "Modern Challenge", event_date=date(2026, 5, 21), fmt="Modern"),
         _mtgo(9, "Pauper League", event_date=date(2026, 5, 14)),  # wrong date
+    ]
+    found = find_supplements_for(
+        primary_source="mtgtop8",
+        primary_event=primary,
+        candidate_events=candidates,
+    )
+    assert [c["id"] for c in found] == [7]
+
+
+def test_find_supplements_for_cross_source_id_collision_untagged() -> None:
+    """Regression — original failure shape: candidates loaded without a
+    ``source`` key. Pre-fix the skip logic compared
+    ``candidate.get("source", primary_source) == primary_source`` so an
+    untagged candidate always looked like 'same source as primary',
+    and a sibling from the OTHER feed that happened to share the
+    primary's numeric id got silently dropped. Post-fix the skip
+    requires an explicit source match, so an untagged candidate is
+    never treated as the primary itself."""
+    primary = _mtgtop8(10, "Pauper League", event_date=date(2026, 5, 21))
+    # Candidate has the SAME numeric id as the primary and no source
+    # tag — mirrors the pre-fix _load_candidate_events output.
+    candidates = [_mtgo(10, "Pauper League May212026", event_date=date(2026, 5, 21))]
+    found = find_supplements_for(
+        primary_source="mtgtop8",
+        primary_event=primary,
+        candidate_events=candidates,
+    )
+    assert [c["id"] for c in found] == [10]
+
+
+def test_find_supplements_for_cross_source_id_collision_tagged() -> None:
+    """Same regression in the post-fix data shape: candidates loaded
+    WITH ``source`` set. The (id, source) pair must be compared, not
+    just id — a candidate from the other feed sharing the primary's
+    numeric id is a sibling, not the primary."""
+    primary = _mtgtop8(10, "Pauper League", event_date=date(2026, 5, 21))
+    candidates = [
+        {
+            **_mtgo(10, "Pauper League May212026", event_date=date(2026, 5, 21)),
+            "source": "mtgo",
+        }
+    ]
+    found = find_supplements_for(
+        primary_source="mtgtop8",
+        primary_event=primary,
+        candidate_events=candidates,
+    )
+    assert [c["id"] for c in found] == [10]
+
+
+def test_find_supplements_for_skips_primary_when_mixed_into_pool() -> None:
+    """The skip logic still fires when a candidate has the SAME id and
+    SAME source as the primary — i.e., the caller really did fold the
+    primary into the candidate pool."""
+    primary = _mtgtop8(10, "Pauper League", event_date=date(2026, 5, 21))
+    candidates = [
+        {**_mtgtop8(10, "Pauper League", event_date=date(2026, 5, 21)), "source": "mtgtop8"},
+        {
+            **_mtgo(7, "Pauper League May212026", event_date=date(2026, 5, 21)),
+            "source": "mtgo",
+        },
     ]
     found = find_supplements_for(
         primary_source="mtgtop8",

--- a/services/analytics/tests/test_event_merger.py
+++ b/services/analytics/tests/test_event_merger.py
@@ -1,0 +1,411 @@
+"""Tests for the canonical-event merger (issue #74).
+
+The merger reconciles ``analytics.mtgtop8_events`` and ``analytics.mtgo_events``
+into a single canonical list. mtgtop8 wins on metadata (it carries
+archetype labels); MTGO supplements participants when its decklist
+coverage runs deeper.
+
+These are pure-logic tests — no DB, no HTTP. They feed synthetic event
+dicts through :func:`merge_events` and :func:`merge_results` and check
+the output shape.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from analytics_service.event_merger import (
+    MatchKey,
+    event_signature,
+    find_supplements_for,
+    match_key,
+    merge_events,
+    merge_results,
+    normalize_format,
+)
+
+# --------------------------------------------------------------------------- #
+# Signature + key extraction
+# --------------------------------------------------------------------------- #
+
+
+def test_normalize_format_lowercases() -> None:
+    assert normalize_format("Pauper") == "pauper"
+    assert normalize_format("PAUPER") == "pauper"
+    assert normalize_format("  modern  ") == "modern"
+
+
+def test_normalize_format_handles_blank_and_none() -> None:
+    assert normalize_format(None) is None
+    assert normalize_format("") is None
+    assert normalize_format("   ") is None
+
+
+def test_event_signature_strips_format_words() -> None:
+    assert event_signature("Pauper League") == "league"
+    assert event_signature("Modern Challenge") == "challenge"
+    assert event_signature("Vintage Super Qualifier") == "super qualifier"
+
+
+def test_event_signature_strips_dates_iso() -> None:
+    """YYYY-MM-DD dates inside the name vanish from the signature."""
+    assert event_signature("Modern Challenge 2026-05-08") == "challenge"
+    assert event_signature("Pauper League 2026-05-21") == "league"
+
+
+def test_event_signature_strips_dates_slash() -> None:
+    """mtgtop8-style DD/MM/YY dates vanish too."""
+    assert event_signature("Modern Challenge 08/05/26") == "challenge"
+
+
+def test_event_signature_strips_human_dates() -> None:
+    """Mixed human formats land on the same signature."""
+    assert event_signature("Pauper League May 21, 2026") == "league"
+    assert event_signature("Pauper League May212026") == "league"
+    assert event_signature("Pauper League 21st May 2026") == "league"
+
+
+def test_event_signature_strips_numeric_suffixes() -> None:
+    """Player-count suffixes like 'Challenge 32' shouldn't differentiate."""
+    assert event_signature("Modern Challenge 32") == "challenge"
+    assert event_signature("Modern Challenge 64") == "challenge"
+
+
+def test_event_signature_keeps_showcase_qualifier_tokens() -> None:
+    """Multi-word event types survive — the signature preserves order."""
+    assert event_signature("Modern Showcase Challenge") == "showcase challenge"
+    assert event_signature("Modern Showcase Qualifier") == "showcase qualifier"
+
+
+def test_event_signature_blank_returns_none() -> None:
+    assert event_signature(None) is None
+    assert event_signature("") is None
+    # All format + date — nothing left.
+    assert event_signature("Modern 2026-05-08") is None
+
+
+def test_match_key_full() -> None:
+    key = match_key(
+        {
+            "event_name": "Pauper League — May 21, 2026",
+            "event_date": date(2026, 5, 21),
+            "format": "Pauper",
+        }
+    )
+    assert key == MatchKey(format="pauper", event_date=date(2026, 5, 21), signature="league")
+
+
+def test_match_key_two_names_one_event() -> None:
+    """The MTGO and mtgtop8 names for the same event share a match key."""
+    mtgo_key = match_key(
+        {
+            "event_name": "Pauper League May212026",
+            "event_date": date(2026, 5, 21),
+            "format": "Pauper",
+        }
+    )
+    mtgtop8_key = match_key(
+        {
+            "event_name": "Pauper League",
+            "event_date": date(2026, 5, 21),
+            "format": "Pauper",
+        }
+    )
+    assert mtgo_key is not None
+    assert mtgo_key == mtgtop8_key
+
+
+def test_match_key_missing_pieces_returns_none() -> None:
+    base = {
+        "event_name": "Modern Challenge",
+        "event_date": date(2026, 5, 8),
+        "format": "Modern",
+    }
+    assert match_key(base) is not None
+    assert match_key({**base, "format": None}) is None
+    assert match_key({**base, "event_date": None}) is None
+    assert match_key({**base, "event_name": "Modern 2026-05-08"}) is None  # no type token
+
+
+# --------------------------------------------------------------------------- #
+# merge_events
+# --------------------------------------------------------------------------- #
+
+
+def _mtgtop8(
+    id_: int,
+    name: str,
+    *,
+    event_date: date | None = None,
+    fmt: str | None = "Pauper",
+    player_count: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": id_,
+        "event_name": name,
+        "event_date": event_date,
+        "format": fmt,
+        "player_count": player_count,
+    }
+
+
+def _mtgo(
+    id_: int,
+    name: str,
+    *,
+    event_date: date | None = None,
+    fmt: str | None = "Pauper",
+) -> dict[str, Any]:
+    return {
+        "id": id_,
+        "event_name": name,
+        "event_date": event_date,
+        "format": fmt,
+        "player_count": None,
+    }
+
+
+def test_merge_events_overlap_picks_mtgtop8_primary() -> None:
+    """When both sources have the same logical event, mtgtop8 wins."""
+    mtgtop8 = [
+        _mtgtop8(
+            10,
+            "Pauper League",
+            event_date=date(2026, 5, 21),
+            player_count=128,
+        )
+    ]
+    mtgo = [
+        _mtgo(
+            7,
+            "Pauper League May212026",
+            event_date=date(2026, 5, 21),
+        )
+    ]
+    canonical = merge_events(mtgtop8, mtgo)
+    assert len(canonical) == 1
+    [merged] = canonical
+    assert merged.primary_source == "mtgtop8"
+    assert merged.primary_event_id == 10
+    assert merged.event_name == "Pauper League"
+    assert merged.player_count == 128  # mtgtop8 metadata wins
+    assert merged.sources == ["mtgtop8", "mtgo"]
+    assert merged.supplement_events == [("mtgo", 7)]
+
+
+def test_merge_events_only_mtgtop8_kept_as_is() -> None:
+    mtgtop8 = [_mtgtop8(1, "Vintage Challenge", event_date=date(2026, 5, 8), fmt="Vintage")]
+    canonical = merge_events(mtgtop8, [])
+    assert len(canonical) == 1
+    [c] = canonical
+    assert c.primary_source == "mtgtop8"
+    assert c.sources == ["mtgtop8"]
+    assert c.supplement_events == []
+
+
+def test_merge_events_only_mtgo_kept_as_is() -> None:
+    mtgo = [
+        _mtgo(1, "Modern Showcase Challenge 2026-05-10", event_date=date(2026, 5, 10), fmt="Modern")
+    ]
+    canonical = merge_events([], mtgo)
+    assert len(canonical) == 1
+    [c] = canonical
+    assert c.primary_source == "mtgo"
+    assert c.sources == ["mtgo"]
+    assert c.supplement_events == []
+
+
+def test_merge_events_mixed_overlap_and_unique() -> None:
+    """End-to-end shape check: overlap + mtgtop8-only + MTGO-only.
+
+    Three logical events:
+    - Pauper League on 2026-05-21 appears in both feeds → merged
+    - Modern Challenge on 2026-05-08 appears only in mtgtop8 → kept
+    - Vintage League on 2026-05-15 appears only in MTGO → kept
+    """
+    mtgtop8 = [
+        _mtgtop8(10, "Pauper League", event_date=date(2026, 5, 21), fmt="Pauper"),
+        _mtgtop8(11, "Modern Challenge", event_date=date(2026, 5, 8), fmt="Modern"),
+    ]
+    mtgo = [
+        _mtgo(7, "Pauper League May212026", event_date=date(2026, 5, 21), fmt="Pauper"),
+        _mtgo(8, "Vintage League 2026-05-15", event_date=date(2026, 5, 15), fmt="Vintage"),
+    ]
+    canonical = merge_events(mtgtop8, mtgo)
+    assert len(canonical) == 3
+    by_name = {c.event_name: c for c in canonical}
+    # Overlap merged.
+    assert by_name["Pauper League"].sources == ["mtgtop8", "mtgo"]
+    assert by_name["Pauper League"].supplement_events == [("mtgo", 7)]
+    # mtgtop8-only.
+    assert by_name["Modern Challenge"].sources == ["mtgtop8"]
+    # mtgo-only.
+    assert by_name["Vintage League 2026-05-15"].sources == ["mtgo"]
+    assert by_name["Vintage League 2026-05-15"].primary_source == "mtgo"
+
+
+def test_merge_events_orders_by_date_desc() -> None:
+    """Newer events come first; date-less events come last."""
+    mtgo = [
+        _mtgo(1, "Modern Challenge", event_date=date(2026, 5, 8), fmt="Modern"),
+        _mtgo(2, "Modern Challenge", event_date=date(2026, 5, 15), fmt="Modern"),
+        _mtgo(3, "Modern Challenge", event_date=None, fmt="Modern"),
+    ]
+    canonical = merge_events([], mtgo)
+    dates = [c.event_date for c in canonical]
+    assert dates == [date(2026, 5, 15), date(2026, 5, 8), None]
+
+
+def test_merge_events_no_signature_stands_alone() -> None:
+    """Events the matcher can't key get emitted one-each instead of merged."""
+    mtgo = [_mtgo(1, "Modern 2026-05-08", event_date=date(2026, 5, 8), fmt="Modern")]
+    mtgtop8 = [_mtgtop8(2, "Modern 2026-05-08", event_date=date(2026, 5, 8), fmt="Modern")]
+    canonical = merge_events(mtgtop8, mtgo)
+    # Neither has a signature — both stand alone.
+    assert len(canonical) == 2
+    assert {c.primary_source for c in canonical} == {"mtgtop8", "mtgo"}
+
+
+def test_merge_events_format_case_insensitive() -> None:
+    """Format strings differ in case between feeds but still match."""
+    mtgtop8 = [_mtgtop8(1, "Pauper League", event_date=date(2026, 5, 21), fmt="Pauper")]
+    mtgo = [_mtgo(2, "Pauper League 2026-05-21", event_date=date(2026, 5, 21), fmt="pauper")]
+    canonical = merge_events(mtgtop8, mtgo)
+    assert len(canonical) == 1
+    assert canonical[0].sources == ["mtgtop8", "mtgo"]
+
+
+# --------------------------------------------------------------------------- #
+# merge_results — participant union
+# --------------------------------------------------------------------------- #
+
+
+def _result(
+    name: str,
+    placement: int | None,
+    *,
+    deck_name: str | None = None,
+    main: dict[str, int] | None = None,
+    side: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    return {
+        "player_name": name,
+        "placement": placement,
+        "deck_name": deck_name,
+        "decklist_main": main or {},
+        "decklist_sideboard": side or {},
+    }
+
+
+def test_merge_results_keeps_archetype_labels_on_collision() -> None:
+    """When both sources have the same player, mtgtop8's row wins —
+    so the archetype label survives."""
+    primary = [_result("Alice", 1, deck_name="Boros Energy")]
+    supplement = [_result("Alice", 5, deck_name=None, main={"Mountain": 20})]
+    merged = merge_results(primary, supplement)
+    assert len(merged) == 1
+    assert merged[0]["deck_name"] == "Boros Energy"
+    assert merged[0]["placement"] == 1  # primary's placement wins too
+
+
+def test_merge_results_top8_plus_top32_union() -> None:
+    """The acceptance test from the brief: mtgtop8 publishes the top 8
+    (with archetype labels), MTGO publishes all 32 players. The merge
+    should yield all 32 with archetype labels on the top 8.
+    """
+    # mtgtop8 has the top 8, with archetype labels.
+    primary = [_result(f"Player{i:02d}", i, deck_name=f"Deck{i}") for i in range(1, 9)]
+    # MTGO has all 32 — top 8 with the same names (would collide),
+    # the rest are MTGO-only.
+    supplement = [
+        _result(f"Player{i:02d}", i, deck_name=None, main={"Card": 4}) for i in range(1, 33)
+    ]
+    merged = merge_results(primary, supplement)
+    # All 32 distinct players in the union.
+    assert len(merged) == 32
+    # Top 8 keep their archetype labels.
+    for i in range(1, 9):
+        entry = next(r for r in merged if r["player_name"] == f"Player{i:02d}")
+        assert entry["deck_name"] == f"Deck{i}", f"top-8 #{i} lost its archetype"
+    # Positions 9-32 came from MTGO with deck_name=None.
+    for i in range(9, 33):
+        entry = next(r for r in merged if r["player_name"] == f"Player{i:02d}")
+        assert entry["deck_name"] is None
+        assert entry["decklist_main"] == {"Card": 4}
+
+
+def test_merge_results_no_collision_simple_union() -> None:
+    primary = [_result("Alice", 1, deck_name="Burn")]
+    supplement = [_result("Bob", 2, deck_name=None)]
+    merged = merge_results(primary, supplement)
+    assert len(merged) == 2
+    # Sorted by placement ascending.
+    assert [r["player_name"] for r in merged] == ["Alice", "Bob"]
+
+
+def test_merge_results_player_name_match_is_case_insensitive() -> None:
+    """A player who appears under slightly different casing isn't duplicated."""
+    primary = [_result("Alice", 1, deck_name="Burn")]
+    supplement = [_result("alice", 5)]
+    merged = merge_results(primary, supplement)
+    assert len(merged) == 1
+    assert merged[0]["deck_name"] == "Burn"
+
+
+def test_merge_results_ordering_nulls_last() -> None:
+    """Players with no placement are sorted after ranked ones."""
+    primary = [
+        _result("Bob", None),
+        _result("Alice", 2),
+        _result("Charlie", 1),
+    ]
+    merged = merge_results(primary, [])
+    assert [r["player_name"] for r in merged] == ["Charlie", "Alice", "Bob"]
+
+
+def test_merge_results_input_not_mutated() -> None:
+    """Function must not edit caller's dicts — they often back DB rows
+    cached upstream."""
+    primary = [_result("Alice", 1, deck_name="Burn")]
+    supplement = [_result("Bob", 2, deck_name=None)]
+    snapshot_primary = [dict(r) for r in primary]
+    snapshot_supplement = [dict(r) for r in supplement]
+    merge_results(primary, supplement)
+    assert primary == snapshot_primary
+    assert supplement == snapshot_supplement
+
+
+# --------------------------------------------------------------------------- #
+# find_supplements_for
+# --------------------------------------------------------------------------- #
+
+
+def test_find_supplements_for_matches_on_key() -> None:
+    """Given a primary mtgtop8 event, the function returns the MTGO sibling(s)."""
+    primary = _mtgtop8(10, "Pauper League", event_date=date(2026, 5, 21))
+    candidates = [
+        _mtgo(7, "Pauper League May212026", event_date=date(2026, 5, 21)),
+        _mtgo(8, "Modern Challenge", event_date=date(2026, 5, 21), fmt="Modern"),
+        _mtgo(9, "Pauper League", event_date=date(2026, 5, 14)),  # wrong date
+    ]
+    found = find_supplements_for(
+        primary_source="mtgtop8",
+        primary_event=primary,
+        candidate_events=candidates,
+    )
+    assert [c["id"] for c in found] == [7]
+
+
+def test_find_supplements_for_returns_empty_when_primary_unkeyable() -> None:
+    """If the primary has no signature/date/format, we can't match siblings."""
+    primary = _mtgtop8(10, "Modern 2026-05-08", event_date=date(2026, 5, 8), fmt="Modern")
+    candidates = [_mtgo(7, "Modern Challenge", event_date=date(2026, 5, 8), fmt="Modern")]
+    assert (
+        find_supplements_for(
+            primary_source="mtgtop8",
+            primary_event=primary,
+            candidate_events=candidates,
+        )
+        == []
+    )

--- a/services/web/web_service/templates/metagame.html
+++ b/services/web/web_service/templates/metagame.html
@@ -136,10 +136,18 @@
                     </td>
                     <td class="px-4 py-2.5 text-sm font-mono dark:text-txt-secondary text-txt-secondary-light">{{ ev.event_date or "--" }}</td>
                     <td class="px-4 py-2.5 text-sm dark:text-txt-secondary text-txt-secondary-light">
-                        <span class="text-xs font-medium uppercase tracking-wider px-2 py-0.5 rounded
-                                     {% if ev.source == 'mtgo' %}bg-accent-muted text-accent{% else %}bg-success-muted text-success{% endif %}">
-                            {{ ev.source }}
-                        </span>
+                        {% set source_list = ev.sources if ev.sources else [ev.source] %}
+                        <div class="flex flex-wrap gap-1">
+                            {% for src in source_list %}
+                            <span class="text-xs font-medium uppercase tracking-wider px-2 py-0.5 rounded
+                                         {% if src == 'mtgo' %}bg-accent-muted text-accent{% else %}bg-success-muted text-success{% endif %}">
+                                {{ src }}
+                            </span>
+                            {% endfor %}
+                            {% if source_list|length > 1 %}
+                            <span class="text-xs dark:text-txt-tertiary text-txt-secondary-light" title="Participants are unioned across feeds">merged</span>
+                            {% endif %}
+                        </div>
                     </td>
                     <td class="px-4 py-2.5 text-sm font-mono text-right dark:text-txt-secondary text-txt-secondary-light">{{ ev.player_count or "--" }}</td>
                 </tr>

--- a/services/web/web_service/templates/metagame_event.html
+++ b/services/web/web_service/templates/metagame_event.html
@@ -26,12 +26,18 @@
         <div class="text-sm dark:text-txt-primary text-txt-primary-light">{{ format }}</div>
     </div>
     <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">
-        <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-1">Source</div>
-        <div class="text-sm">
+        <div class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-1">Source{% if event.sources and event.sources|length > 1 %}s{% endif %}</div>
+        <div class="text-sm flex flex-wrap gap-1">
+            {% set source_list = event.sources if event.sources else [event.source] %}
+            {% for src in source_list %}
             <span class="text-xs font-medium uppercase tracking-wider px-2 py-0.5 rounded
-                         {% if event.source == 'mtgo' %}bg-accent-muted text-accent{% else %}bg-success-muted text-success{% endif %}">
-                {{ event.source }}
+                         {% if src == 'mtgo' %}bg-accent-muted text-accent{% else %}bg-success-muted text-success{% endif %}">
+                {{ src }}
             </span>
+            {% endfor %}
+            {% if source_list|length > 1 %}
+            <span class="text-xs dark:text-txt-tertiary text-txt-secondary-light self-center" title="Participants are unioned across feeds">merged</span>
+            {% endif %}
         </div>
     </div>
     <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-4">


### PR DESCRIPTION
Closes #74.

## Summary

- MTGO leagues and other shared events showed up twice in the metagame view because the two scrapers populate independent tables. This PR merges them at query time into a single canonical list.
- **mtgtop8 wins for event metadata** when both feeds have it (it carries `deck_name` archetype labels — gold).
- **Participants are unioned** across feeds keyed by player name. Top-N entries from mtgtop8 keep their archetype labels; MTGO-only players (e.g. positions 9-32 of a league mtgtop8 covered only top-8) land with `deck_name=null`.

## Approach

**Approach A: query-time merge** — chosen over introducing a `canonical_events` table because:

- The two scrapers already tag rows with source in existing queries.
- Data volumes are small (under a few hundred events per format per scrape window).
- The only consumer that wants the merged view is the metagame router.
- A canonical table would have required migration + dual-write changes in both scrapers for no concrete benefit.

The admin scraper UI still uses per-source views for debugging — only the user-facing `/metagame/{format}/events` and `/metagame/{format}/events/{source}/{id}` get the merged view.

## Implementation

- New `services/analytics/analytics_service/event_merger.py`:
  - `match_key(event)` — keys on `(format, event_date, event_signature)` where the signature is the event name with format words, dates (ISO/slash/human), and numeric suffixes stripped. So `"Pauper League May212026"` and `"Pauper League — May 21, 2026"` reduce to `"league"` and match.
  - `merge_events(mtgtop8, mtgo)` — returns `list[CanonicalEvent]` with `primary_source`, `sources`, `supplement_events`.
  - `merge_results(primary, supplement)` — unions player rows; primary wins on collisions.
  - `find_supplements_for()` — used by `event_detail` to look up sibling events by match key.
- `metagame.format_events` loads both tables filtered by format and runs the merger; pagination runs on the merged list.
- `metagame.event_detail` looks up sibling events in the other source and unions participants.
- Schemas gain a `sources: list[str]` field; templates show stacked source badges + a "merged" marker.

If any of (format, date, signature) is missing for an event, it does not merge — it stands alone. This is deliberately conservative: we'd rather miss some genuine duplicates than false-merge unrelated events.

## Test plan

- [x] `services/analytics/tests/test_event_merger.py` — 27 unit tests covering: signature normalization variants, match-key construction, `merge_events` overlap/only-A/only-B/mixed/ordering cases, `merge_results` top-8 + top-32 union (the acceptance test from the brief), input non-mutation, case-insensitive player names.
- [x] All 179 analytics tests pass locally; all 253 web tests pass locally.
- [x] `ruff check` and `mypy` clean on changed files.
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)