### PR TITLE
feat(auth): make version-constant tunables DB-backed and admin-editable

### DIFF
--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -7,6 +7,7 @@ last admin; cannot disable/delete yourself).
 
 from __future__ import annotations
 
+import re
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -596,11 +597,18 @@ _TUNABLE_DEFAULTS: dict[str, int] = {
     "mtgo_scraper_interval_hours": 24,
 }
 
-# Read-only constants surfaced in the tunables view for admin visibility
-# but not persisted to server_settings — they live in code.
-_PARSER_VERSION = "0.9.0"
-_REPARSE_MIN_VERSION = "0.9.0"
-_MIN_AGENT_VERSION = "0.4.14"
+# Defaults for string-valued tunables (version constants surfaced and
+# editable from the admin UI). Same DB-row-or-fallback pattern as
+# _TUNABLE_DEFAULTS; the compiled default applies until an admin saves.
+_STRING_TUNABLE_DEFAULTS: dict[str, str] = {
+    "parser_version": "0.9.0",
+    "reparse_min_version": "0.9.0",
+    "min_agent_version": "0.5.0",
+}
+
+# Loose semver-ish gate: X.Y.Z or vX.Y.Z plus an optional -suffix
+# (e.g. "0.5.0", "v1.2.3", "0.5.0-rc1"). Numeric components only.
+_VERSION_RE = re.compile(r"^v?\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$")
 
 
 async def _read_tunable(db: AsyncSession, key: str) -> int:
@@ -617,15 +625,33 @@ async def _read_tunable(db: AsyncSession, key: str) -> int:
         return _TUNABLE_DEFAULTS[key]
 
 
+async def _read_string_tunable(db: AsyncSession, key: str) -> str:
+    """Read a string-valued tunable from server_settings, falling back
+    to the compiled default. Used for the version constants admins can
+    edit from the settings UI."""
+    row = (
+        await db.execute(select(ServerSetting).where(ServerSetting.key == f"tunable:{key}"))
+    ).scalar_one_or_none()
+    if row is None or not isinstance(row.value, str) or not row.value.strip():
+        return _STRING_TUNABLE_DEFAULTS[key]
+    return row.value
+
+
+async def read_min_agent_version(db: AsyncSession) -> str:
+    """Public accessor for the heartbeat handler. Returns the
+    DB-backed minimum agent version with the compiled fallback."""
+    return await _read_string_tunable(db, "min_agent_version")
+
+
 async def _read_all_tunables(db: AsyncSession) -> TunablesView:
     return TunablesView(
         backfill_batch_size=await _read_tunable(db, "backfill_batch_size"),
         backfill_interval_seconds=await _read_tunable(db, "backfill_interval_seconds"),
         scryfall_sync_interval_days=await _read_tunable(db, "scryfall_sync_interval_days"),
         mtgo_scraper_interval_hours=await _read_tunable(db, "mtgo_scraper_interval_hours"),
-        reparse_min_version=_REPARSE_MIN_VERSION,
-        min_agent_version=_MIN_AGENT_VERSION,
-        parser_version=_PARSER_VERSION,
+        reparse_min_version=await _read_string_tunable(db, "reparse_min_version"),
+        min_agent_version=await _read_string_tunable(db, "min_agent_version"),
+        parser_version=await _read_string_tunable(db, "parser_version"),
     )
 
 
@@ -646,17 +672,30 @@ async def update_tunables(
 ) -> TunablesView:
     """Update one or more mutable tunables. Any admin may write."""
     now = datetime.now(UTC)
-    updates: dict[str, int] = {}
+    int_updates: dict[str, int] = {}
     if body.backfill_batch_size is not None:
-        updates["backfill_batch_size"] = body.backfill_batch_size
+        int_updates["backfill_batch_size"] = body.backfill_batch_size
     if body.backfill_interval_seconds is not None:
-        updates["backfill_interval_seconds"] = body.backfill_interval_seconds
+        int_updates["backfill_interval_seconds"] = body.backfill_interval_seconds
     if body.scryfall_sync_interval_days is not None:
-        updates["scryfall_sync_interval_days"] = body.scryfall_sync_interval_days
+        int_updates["scryfall_sync_interval_days"] = body.scryfall_sync_interval_days
     if body.mtgo_scraper_interval_hours is not None:
-        updates["mtgo_scraper_interval_hours"] = body.mtgo_scraper_interval_hours
+        int_updates["mtgo_scraper_interval_hours"] = body.mtgo_scraper_interval_hours
 
-    for key, value in updates.items():
+    string_updates: dict[str, str] = {}
+    for field in ("parser_version", "reparse_min_version", "min_agent_version"):
+        raw = getattr(body, field)
+        if raw is None:
+            continue
+        candidate = raw.strip()
+        if not _VERSION_RE.match(candidate):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error": "invalid_version", "field": field},
+            )
+        string_updates[field] = candidate
+
+    for key, value in (*int_updates.items(), *string_updates.items()):
         db_key = f"tunable:{key}"
         row = (
             await db.execute(select(ServerSetting).where(ServerSetting.key == db_key))

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -100,6 +100,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(title=f"deep-analysis-{SERVICE_NAME}", lifespan=lifespan)
 mount_metrics(app, SERVICE_NAME)
 
+from auth_service import admin  # noqa: E402
 from auth_service.admin import router as _admin_router  # noqa: E402
 
 # TODO(W7): per-admin-IP rate limit on mutation endpoints — deferred to gateway phase.
@@ -879,11 +880,14 @@ async def agent_heartbeat(
     except Exception:
         upload_count = 0
 
-    settings = get_settings()
+    # min_agent_version is admin-editable via /admin/settings/tunables.
+    # Reads from auth.server_settings with a compiled fallback so a fresh
+    # install with an empty settings table still returns a sane value.
+    min_agent_version = await admin.read_min_agent_version(db)
     return AgentHeartbeatResponse(
         status="ok",
         registered_at=row.created_at,
         revoked=row.revoked_at is not None,
         upload_count=upload_count,
-        min_agent_version=settings.MIN_AGENT_VERSION,
+        min_agent_version=min_agent_version,
     )

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -260,6 +260,12 @@ class UpdateTunablesRequest(BaseModel):
     backfill_interval_seconds: int | None = Field(default=None, ge=60, le=3600)
     scryfall_sync_interval_days: int | None = Field(default=None, ge=1, le=30)
     mtgo_scraper_interval_hours: int | None = Field(default=None, ge=1, le=168)
+    # Version-string tunables. Validated against a loose semver regex
+    # in the admin endpoint so we can return a 400 with a field-level
+    # error rather than letting Pydantic 422 the whole request.
+    parser_version: str | None = Field(default=None, max_length=64)
+    reparse_min_version: str | None = Field(default=None, max_length=64)
+    min_agent_version: str | None = Field(default=None, max_length=64)
 
     @model_validator(mode="after")
     def _at_least_one(self) -> UpdateTunablesRequest:
@@ -270,6 +276,9 @@ class UpdateTunablesRequest(BaseModel):
                 self.backfill_interval_seconds,
                 self.scryfall_sync_interval_days,
                 self.mtgo_scraper_interval_hours,
+                self.parser_version,
+                self.reparse_min_version,
+                self.min_agent_version,
             )
         ):
             raise ValueError("at_least_one_field_required")

--- a/services/auth/auth_service/settings.py
+++ b/services/auth/auth_service/settings.py
@@ -49,12 +49,6 @@ class AuthSettings(BaseServiceSettings):
     )
     initial_admin_secret_path: Path = Path("/data/secrets/initial_admin.txt")
 
-    # Minimum agent version the server considers current.  Returned in
-    # heartbeat responses so the agent can warn or self-update.  This is
-    # a code-level constant, NOT admin-configurable — bump it here when
-    # a new agent release ships a breaking change or required fix.
-    MIN_AGENT_VERSION: str = "0.4.14"
-
 
 _settings: AuthSettings | None = None
 

--- a/services/auth/tests/test_admin_tunables.py
+++ b/services/auth/tests/test_admin_tunables.py
@@ -1,0 +1,277 @@
+"""Admin tunables endpoint + DB-backed string-tunable plumbing.
+
+Covers the version-constant tunables (parser_version, reparse_min_version,
+min_agent_version) that landed when those fields moved from hardcoded
+constants to server_settings rows admins can edit from the UI.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from auth_service.admin import _read_string_tunable, read_min_agent_version
+from auth_service.models import ServerSetting, User
+from auth_service.passwords import hash_password
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _login(client: Any, email: str, password: str) -> str:
+    r = await client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200, r.text
+    return str(r.json()["access_token"])
+
+
+async def _seed_admin(
+    client: Any,
+    db: AsyncSession,
+    email: str = "admin@example.com",
+    password: str = "pw",
+) -> tuple[int, str]:
+    u = User(email=email, password_hash=hash_password(password), role="admin")
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    token = await _login(client, email, password)
+    return u.id, token
+
+
+async def _seed_user(
+    client: Any,
+    db: AsyncSession,
+    email: str = "regular@example.com",
+    password: str = "pw",
+) -> tuple[int, str]:
+    u = User(email=email, password_hash=hash_password(password), role="user")
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    token = await _login(client, email, password)
+    return u.id, token
+
+
+def _h(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# String tunable read/fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_string_tunable_default_when_no_row(db_session: AsyncSession) -> None:
+    # Fresh DB has no tunable:* rows. Compiled defaults apply.
+    assert await _read_string_tunable(db_session, "min_agent_version") == "0.5.0"
+    assert await _read_string_tunable(db_session, "parser_version") == "0.9.0"
+    assert await _read_string_tunable(db_session, "reparse_min_version") == "0.9.0"
+
+
+@pytest.mark.asyncio
+async def test_read_min_agent_version_falls_back(db_session: AsyncSession) -> None:
+    assert await read_min_agent_version(db_session) == "0.5.0"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /admin/settings/tunables — string fields, round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_string_tunables_round_trip(
+    client: Any, db_session: AsyncSession
+) -> None:
+    _admin_id, token = await _seed_admin(client, db_session)
+
+    r = await client.patch(
+        "/admin/settings/tunables",
+        json={
+            "parser_version": "0.10.1",
+            "reparse_min_version": "0.10.0",
+            "min_agent_version": "0.6.0",
+        },
+        headers=_h(token),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["parser_version"] == "0.10.1"
+    assert body["reparse_min_version"] == "0.10.0"
+    assert body["min_agent_version"] == "0.6.0"
+
+    # DB rows landed
+    db_session.expire_all()
+    rows = {
+        row.key: row.value
+        for row in (
+            (
+                await db_session.execute(
+                    select(ServerSetting).where(
+                        ServerSetting.key.in_(
+                            [
+                                "tunable:parser_version",
+                                "tunable:reparse_min_version",
+                                "tunable:min_agent_version",
+                            ]
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    }
+    assert rows == {
+        "tunable:parser_version": "0.10.1",
+        "tunable:reparse_min_version": "0.10.0",
+        "tunable:min_agent_version": "0.6.0",
+    }
+
+    # And read back through the helper
+    assert await _read_string_tunable(db_session, "min_agent_version") == "0.6.0"
+
+
+@pytest.mark.asyncio
+async def test_patch_accepts_v_prefix_and_pre_release(
+    client: Any, db_session: AsyncSession
+) -> None:
+    _admin_id, token = await _seed_admin(client, db_session)
+    r = await client.patch(
+        "/admin/settings/tunables",
+        json={"min_agent_version": "v0.6.0-rc1"},
+        headers=_h(token),
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["min_agent_version"] == "v0.6.0-rc1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value",
+    ["", "   ", "abc", "1.2", "1.2.x", "1.2.3.4", "not-a-version"],
+)
+async def test_patch_rejects_invalid_version_string(
+    client: Any, db_session: AsyncSession, value: str
+) -> None:
+    _admin_id, token = await _seed_admin(client, db_session)
+    r = await client.patch(
+        "/admin/settings/tunables",
+        json={"min_agent_version": value},
+        headers=_h(token),
+    )
+    # Pydantic-level reject (422) or our explicit field-level 400.
+    assert r.status_code in (400, 422), r.text
+    if r.status_code == 400:
+        detail = r.json()["detail"]
+        assert detail["error"] == "invalid_version"
+        assert detail["field"] == "min_agent_version"
+
+
+@pytest.mark.asyncio
+async def test_patch_string_tunable_requires_admin(
+    client: Any, db_session: AsyncSession
+) -> None:
+    _user_id, token = await _seed_user(client, db_session)
+    r = await client.patch(
+        "/admin/settings/tunables",
+        json={"min_agent_version": "0.6.0"},
+        headers=_h(token),
+    )
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/settings/tunables — surfaces DB value or compiled default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_tunables_surfaces_defaults(
+    client: Any, db_session: AsyncSession
+) -> None:
+    _admin_id, token = await _seed_admin(client, db_session)
+    r = await client.get("/admin/settings/tunables", headers=_h(token))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["parser_version"] == "0.9.0"
+    assert body["reparse_min_version"] == "0.9.0"
+    assert body["min_agent_version"] == "0.5.0"
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat gate — reads from DB, falls back to compiled default
+# ---------------------------------------------------------------------------
+
+
+async def _register_agent(
+    client: Any, email: str, password: str
+) -> dict[str, Any]:
+    access = await _login(client, email, password)
+    r = await client.post(
+        "/auth/agent/registration-code",
+        headers=_h(access),
+    )
+    assert r.status_code == 201, r.text
+    code = r.json()["code"]
+    r = await client.post(
+        "/auth/agent/register",
+        json={"code": code, "machine_name": "lab-1", "client_version": "0.5.0"},
+    )
+    assert r.status_code == 201, r.text
+    return dict(r.json())
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_min_agent_version_falls_back_to_default(
+    client: Any, db_session: AsyncSession, seed_user: dict[str, Any]
+) -> None:
+    agent = await _register_agent(client, seed_user["email"], seed_user["password"])
+    r = await client.post(
+        "/auth/agent/heartbeat",
+        headers=_h(agent["api_token"]),
+        json={},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["min_agent_version"] == "0.5.0"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_min_agent_version_reads_db_override(
+    client: Any, db_session: AsyncSession, seed_user: dict[str, Any]
+) -> None:
+    # Save through the admin endpoint so the DB row is written by the
+    # same path production uses.
+    _admin_id, admin_token = await _seed_admin(client, db_session)
+    r = await client.patch(
+        "/admin/settings/tunables",
+        json={"min_agent_version": "0.6.0"},
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 200, r.text
+
+    agent = await _register_agent(client, seed_user["email"], seed_user["password"])
+    r = await client.post(
+        "/auth/agent/heartbeat",
+        headers=_h(agent["api_token"]),
+        json={},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["min_agent_version"] == "0.6.0"
+
+
+@pytest.mark.asyncio
+async def test_patch_no_op_payload_rejected(
+    client: Any, db_session: AsyncSession
+) -> None:
+    _admin_id, token = await _seed_admin(client, db_session)
+    r = await client.patch("/admin/settings/tunables", json={}, headers=_h(token))
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_unauthenticated(client: Any) -> None:
+    r = await client.patch(
+        "/admin/settings/tunables",
+        json={"min_agent_version": "0.6.0"},
+    )
+    assert r.status_code == 401

--- a/services/auth/tests/test_admin_tunables.py
+++ b/services/auth/tests/test_admin_tunables.py
@@ -79,9 +79,7 @@ async def test_read_min_agent_version_falls_back(db_session: AsyncSession) -> No
 
 
 @pytest.mark.asyncio
-async def test_patch_string_tunables_round_trip(
-    client: Any, db_session: AsyncSession
-) -> None:
+async def test_patch_string_tunables_round_trip(client: Any, db_session: AsyncSession) -> None:
     _admin_id, token = await _seed_admin(client, db_session)
 
     r = await client.patch(
@@ -168,9 +166,7 @@ async def test_patch_rejects_invalid_version_string(
 
 
 @pytest.mark.asyncio
-async def test_patch_string_tunable_requires_admin(
-    client: Any, db_session: AsyncSession
-) -> None:
+async def test_patch_string_tunable_requires_admin(client: Any, db_session: AsyncSession) -> None:
     _user_id, token = await _seed_user(client, db_session)
     r = await client.patch(
         "/admin/settings/tunables",
@@ -186,9 +182,7 @@ async def test_patch_string_tunable_requires_admin(
 
 
 @pytest.mark.asyncio
-async def test_get_tunables_surfaces_defaults(
-    client: Any, db_session: AsyncSession
-) -> None:
+async def test_get_tunables_surfaces_defaults(client: Any, db_session: AsyncSession) -> None:
     _admin_id, token = await _seed_admin(client, db_session)
     r = await client.get("/admin/settings/tunables", headers=_h(token))
     assert r.status_code == 200
@@ -203,9 +197,7 @@ async def test_get_tunables_surfaces_defaults(
 # ---------------------------------------------------------------------------
 
 
-async def _register_agent(
-    client: Any, email: str, password: str
-) -> dict[str, Any]:
+async def _register_agent(client: Any, email: str, password: str) -> dict[str, Any]:
     access = await _login(client, email, password)
     r = await client.post(
         "/auth/agent/registration-code",
@@ -260,9 +252,7 @@ async def test_heartbeat_min_agent_version_reads_db_override(
 
 
 @pytest.mark.asyncio
-async def test_patch_no_op_payload_rejected(
-    client: Any, db_session: AsyncSession
-) -> None:
+async def test_patch_no_op_payload_rejected(client: Any, db_session: AsyncSession) -> None:
     _admin_id, token = await _seed_admin(client, db_session)
     r = await client.patch("/admin/settings/tunables", json={}, headers=_h(token))
     assert r.status_code == 422

--- a/services/web/tests/test_admin_settings_routes.py
+++ b/services/web/tests/test_admin_settings_routes.py
@@ -460,3 +460,132 @@ async def test_post_scrape_mtgo_forbidden_for_non_admin(app_client: httpx.AsyncC
     finally:
         _main.app.dependency_overrides.clear()
     assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/settings/tunables — version-string round-trip
+# ---------------------------------------------------------------------------
+
+
+_TUNABLES_FORM = {
+    "backfill_batch_size": "100",
+    "backfill_interval_seconds": "300",
+    "scryfall_sync_interval_days": "7",
+    "mtgo_scraper_interval_hours": "24",
+    "parser_version": "0.10.1",
+    "reparse_min_version": "0.10.0",
+    "min_agent_version": "0.6.0",
+}
+
+
+def _sample_tunables(
+    *,
+    parser_version: str = "0.9.0",
+    reparse_min_version: str = "0.9.0",
+    min_agent_version: str = "0.5.0",
+) -> Any:
+    from web_service import auth_client
+
+    return auth_client.TunablesResult(
+        backfill_batch_size=100,
+        backfill_interval_seconds=300,
+        scryfall_sync_interval_days=7,
+        mtgo_scraper_interval_hours=24,
+        parser_version=parser_version,
+        reparse_min_version=reparse_min_version,
+        min_agent_version=min_agent_version,
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_tunables_forwards_string_fields(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import auth_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_update(
+        _url: str, _token: str, updates: dict[str, int | str]
+    ) -> tuple[auth_client.TunablesResult | None, str | None]:
+        captured["updates"] = updates
+        return _sample_tunables(
+            parser_version=str(updates["parser_version"]),
+            reparse_min_version=str(updates["reparse_min_version"]),
+            min_agent_version=str(updates["min_agent_version"]),
+        ), None
+
+    monkeypatch.setattr(auth_client, "admin_update_tunables", fake_update)
+    dep, _ = _override_admin(user_id=1)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post("/admin/settings/tunables", data=_TUNABLES_FORM)
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 303
+    assert "tunables_saved=1" in r.headers["location"]
+    assert captured["updates"]["parser_version"] == "0.10.1"
+    assert captured["updates"]["reparse_min_version"] == "0.10.0"
+    assert captured["updates"]["min_agent_version"] == "0.6.0"
+
+
+@pytest.mark.asyncio
+async def test_post_tunables_forbidden_for_non_admin(app_client: httpx.AsyncClient) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    dep, _ = _override_non_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post("/admin/settings/tunables", data=_TUNABLES_FORM)
+    finally:
+        _main.app.dependency_overrides.clear()
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_settings_renders_editable_version_fields(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client, auth_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_mode(_url: str, _token: str) -> auth_client.RegistrationMode:
+        return _sample_mode("invite_only")
+
+    async def fake_tunables(_url: str, _token: str) -> auth_client.TunablesResult:
+        return _sample_tunables(min_agent_version="0.6.0")
+
+    async def _empty_cards(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("noop")
+
+    async def _empty_scrapers(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("noop")
+
+    monkeypatch.setattr(auth_client, "admin_get_registration_mode", fake_mode)
+    monkeypatch.setattr(auth_client, "admin_get_tunables", fake_tunables)
+    monkeypatch.setattr(analytics_client, "admin_get_cards_status", _empty_cards)
+    monkeypatch.setattr(analytics_client, "admin_get_all_scraper_health", _empty_scrapers)
+
+    dep, _ = _override_admin(user_id=1)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/admin/settings")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    # The version-constants fieldset is no longer disabled and the
+    # fields are part of the tunables form.
+    assert 'name="min_agent_version"' in r.text
+    assert 'name="parser_version"' in r.text
+    assert 'name="reparse_min_version"' in r.text
+    assert "Agents on older versions will be prompted to upgrade" in r.text
+    # The value rendered is what the (faked) auth service returned.
+    assert 'value="0.6.0"' in r.text

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -1112,12 +1112,12 @@ async def admin_get_tunables(base_url: str, token: str) -> TunablesResult:
 async def admin_update_tunables(
     base_url: str,
     token: str,
-    updates: dict[str, int],
+    updates: dict[str, int | str],
 ) -> tuple[TunablesResult | None, str | None]:
     """Admin-only: patch mutable tunables. Returns (result, error_code).
 
     - 200 -> (TunablesResult, None)
-    - 422 -> (None, "validation_error")
+    - 400/422 -> (None, "validation_error")
     """
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -2472,6 +2472,9 @@ async def admin_settings_tunables(
     backfill_interval_seconds: Annotated[int, Form()],
     scryfall_sync_interval_days: Annotated[int, Form()],
     mtgo_scraper_interval_hours: Annotated[int, Form()],
+    parser_version: Annotated[str, Form()],
+    reparse_min_version: Annotated[str, Form()],
+    min_agent_version: Annotated[str, Form()],
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
 ) -> Response:
@@ -2479,11 +2482,14 @@ async def admin_settings_tunables(
     if blocked is not None:
         return blocked
 
-    updates = {
+    updates: dict[str, int | str] = {
         "backfill_batch_size": backfill_batch_size,
         "backfill_interval_seconds": backfill_interval_seconds,
         "scryfall_sync_interval_days": scryfall_sync_interval_days,
         "mtgo_scraper_interval_hours": mtgo_scraper_interval_hours,
+        "parser_version": parser_version,
+        "reparse_min_version": reparse_min_version,
+        "min_agent_version": min_agent_version,
     }
 
     try:

--- a/services/web/web_service/templates/admin_settings.html
+++ b/services/web/web_service/templates/admin_settings.html
@@ -86,22 +86,25 @@
                 </div>
             </fieldset>
             <fieldset class="border dark:border-border border-border-light rounded-md p-4">
-                <legend class="text-xs font-semibold uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light px-2">Version constants (read-only)</legend>
+                <legend class="text-xs font-semibold uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light px-2">Version constants</legend>
                 <div class="flex flex-wrap gap-4 mt-2">
                     <label class="flex flex-col gap-1">
                         <span class="text-xs font-medium dark:text-txt-secondary text-txt-secondary-light">Parser version</span>
-                        <input type="text" value="{{ tunables.parser_version }}" disabled
-                               class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-secondary text-txt-secondary-light outline-none w-40 opacity-60">
+                        <input type="text" name="parser_version" value="{{ tunables.parser_version }}" required pattern="v?\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?"
+                               class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none w-40">
+                        <small class="text-xs dark:text-txt-tertiary text-txt-secondary-light">Reported parser build (e.g. 0.9.0)</small>
                     </label>
                     <label class="flex flex-col gap-1">
                         <span class="text-xs font-medium dark:text-txt-secondary text-txt-secondary-light">Reparse min version</span>
-                        <input type="text" value="{{ tunables.reparse_min_version }}" disabled
-                               class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-secondary text-txt-secondary-light outline-none w-40 opacity-60">
+                        <input type="text" name="reparse_min_version" value="{{ tunables.reparse_min_version }}" required pattern="v?\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?"
+                               class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none w-40">
+                        <small class="text-xs dark:text-txt-tertiary text-txt-secondary-light">Triggers reparse-on-upgrade below this version</small>
                     </label>
                     <label class="flex flex-col gap-1">
                         <span class="text-xs font-medium dark:text-txt-secondary text-txt-secondary-light">Minimum agent version</span>
-                        <input type="text" value="{{ tunables.min_agent_version }}" disabled
-                               class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-secondary text-txt-secondary-light outline-none w-40 opacity-60">
+                        <input type="text" name="min_agent_version" value="{{ tunables.min_agent_version }}" required pattern="v?\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?"
+                               class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none w-40">
+                        <small class="text-xs dark:text-txt-tertiary text-txt-secondary-light">Agents on older versions will be prompted to upgrade</small>
                     </label>
                 </div>
             </fieldset>


### PR DESCRIPTION
## Summary

- `parser_version`, `reparse_min_version`, and `min_agent_version` move from hardcoded constants in `admin.py` and a `MIN_AGENT_VERSION` env var in `settings.py` to DB-backed rows in `auth.server_settings`, edited through the existing admin tunables form.
- The agent-heartbeat gate at `main.py:888` reads `min_agent_version` from the DB with a compiled fallback, so admins can roll out a new minimum agent version without redeploying.
- Compiled default for `min_agent_version` is bumped to `0.5.0` so the agent v0.5.0 release actually takes effect on fresh installs.

## Approach

- New `_STRING_TUNABLE_DEFAULTS` dict + `_read_string_tunable(db, key)` helper that mirror the existing integer `_TUNABLE_DEFAULTS` / `_read_tunable` pattern (chose a separate helper rather than a combined-type read so each call site stays explicitly typed).
- Save endpoint extended with semver-ish validation (`X.Y.Z` / `vX.Y.Z`, optional `-suffix`) returning a 400 `{"error": "invalid_version", "field": ...}` for bad input.
- Admin template loses the `disabled` attribute on the three fields and the "(read-only)" legend; they're now part of the same `/admin/settings/tunables` POST as the other tunables, with a hint near `min_agent_version` explaining the upgrade prompt.
- Settings env var removed (now redundant — DB row + compiled default is the single source of truth).
- No migration: defaults live in code; DB rows get written on first admin save. Fresh installs with an empty `server_settings` table still get sane heartbeat responses through the fallback.

## Test plan

- [x] `uv run ruff check common/ services/` clean
- [x] `uv run mypy common/ services/` clean
- [x] `services/auth/tests/test_admin_tunables.py` — round-trip, default fallback, validation matrix, heartbeat-from-DB, non-admin block (17 tests)
- [x] `services/web/tests/test_admin_settings_routes.py` — form forwards string fields, GET renders editable inputs with hint, non-admin blocked
- [x] Full auth suite (185 passed) and full web suite (261 passed) locally against live Postgres + Redis
- [ ] CI `test-integration` and `compose-smoke` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)