### PR TITLE
fix(gateway): prevent stale-Caddy-pool after container replacement

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -119,15 +119,6 @@ echo ">> bringing stack up"
 ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
     "docker compose --project-directory $DEPLOY_PATH up -d"
 
-# Drop the gateway's upstream connection pool after the backend
-# containers are replaced. Without this, a long-lived Caddy can keep a
-# keepalive connection pinned to a now-dead container IP — the cause of
-# the empty-body GET / regression in the v0.9.9 deploy. `set -e` above
-# already makes a failed reload abort the deploy.
-echo ">> reloading gateway to refresh upstream pool"
-ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
-    "docker exec deep-analysis-gateway-1 caddy reload --config /etc/caddy/Caddyfile"
-
 echo ">> verifying stack"
 ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
     "docker compose --project-directory $DEPLOY_PATH ps"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -119,6 +119,15 @@ echo ">> bringing stack up"
 ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
     "docker compose --project-directory $DEPLOY_PATH up -d"
 
+# Drop the gateway's upstream connection pool after the backend
+# containers are replaced. Without this, a long-lived Caddy can keep a
+# keepalive connection pinned to a now-dead container IP — the cause of
+# the empty-body GET / regression in the v0.9.9 deploy. `set -e` above
+# already makes a failed reload abort the deploy.
+echo ">> reloading gateway to refresh upstream pool"
+ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
+    "docker exec deep-analysis-gateway-1 caddy reload --config /etc/caddy/Caddyfile"
+
 echo ">> verifying stack"
 ssh "${SSH_OPTS[@]}" "$DEPLOY_HOST" \
     "docker compose --project-directory $DEPLOY_PATH ps"

--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -19,8 +19,7 @@
 
     # Bounded keepalive recycles pooled connections every 30s so a
     # silently-replaced upstream container can't strand a stale pool
-    # entry between deploys. Belt to the post-deploy `caddy reload`
-    # suspenders in deploy/deploy.sh.
+    # entry between deploys.
     handle /auth/* {
         reverse_proxy auth:8000 {
             transport http {

--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -17,20 +17,44 @@
         respond "ok" 200
     }
 
+    # Bounded keepalive recycles pooled connections every 30s so a
+    # silently-replaced upstream container can't strand a stale pool
+    # entry between deploys. Belt to the post-deploy `caddy reload`
+    # suspenders in deploy/deploy.sh.
     handle /auth/* {
-        reverse_proxy auth:8000
+        reverse_proxy auth:8000 {
+            transport http {
+                keepalive 30s
+                keepalive_idle_conns 10
+            }
+        }
     }
 
     handle /ingest/* {
-        reverse_proxy ingest:8000
+        reverse_proxy ingest:8000 {
+            transport http {
+                keepalive 30s
+                keepalive_idle_conns 10
+            }
+        }
     }
 
     handle /analytics/* {
-        reverse_proxy analytics:8000
+        reverse_proxy analytics:8000 {
+            transport http {
+                keepalive 30s
+                keepalive_idle_conns 10
+            }
+        }
     }
 
     handle {
-        reverse_proxy web:8000
+        reverse_proxy web:8000 {
+            transport http {
+                keepalive 30s
+                keepalive_idle_conns 10
+            }
+        }
     }
 
     # NOTE: Rate limiting on auth endpoints (e.g. /auth/login) is


### PR DESCRIPTION
## Summary

Tunes gateway keepalive so the stale-keepalive-pool failure from the v0.9.9 deploy can't recur. After v0.9.9 the gateway Caddy (uptime 9d, never restarted) kept a keepalive connection pinned to the previous `web` container's IP, so `GET /` returned an empty body until lab-admin manually ran `caddy reload`. The `/` route wasn't in monitoring rotation, so the broken pool entry was never refreshed on its own.

- **`gateway/Caddyfile`** — adds `transport http { keepalive 30s; keepalive_idle_conns 10 }` to each of the four `reverse_proxy` directives (auth, ingest, analytics, web). Bounds idle pool entries to 30s so a silently-replaced upstream — between deploys, or any hot-restart — can't strand a stale connection forever. The original failure mode was that the connection was stale FOREVER because nothing ever recycled it; a 30s idle cap makes that impossible.

### Why no post-deploy `caddy reload` step

An earlier revision added `docker exec deep-analysis-gateway-1 caddy reload` to `deploy/deploy.sh`. Codex P1 review caught that this is not allowlisted by edge.int's deploy wrapper — only `docker compose --project-directory $DEPLOY_PATH {pull, up -d, ps}` is permitted; `docker exec`, `compose exec`, `docker run`, and `docker cp` are explicitly disallowed. The step has been dropped. The keepalive cap alone closes the failure mode.

### Monitoring follow-up

A separate request has been filed with lab-admin to add a `GET /` probe to monitoring so any recurrence (or a new stale-pool failure mode we haven't anticipated) is caught immediately. Not in this PR's scope.

## Test plan

- [x] Caddyfile validates locally via `caddy:2-alpine` (`caddy validate --config /etc/caddy/Caddyfile` -> `Valid configuration`).
- [ ] `compose-smoke` E2E green on CI.
- [ ] Next tagged deploy: confirm post-deploy `GET /` returns the landing page; if a stale-pool entry ever appears, confirm it self-heals within ~30s.

> CI gap note: `compose-smoke` exercises gateway -> upstream proxying (the new `transport http` blocks get parsed during the run), but the suite doesn't force-replace a service and re-hit each upstream, so it can't catch a stale-pool regression on its own. Worth filing as a separate test-coverage gap (not expanded in this PR per scope discipline).

Generated with [Claude Code](https://claude.com/claude-code)
