### PR TITLE
feat(dashboard): sortable Card Performance columns

### DIFF
--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -37,6 +37,19 @@ _MAX_PER_PAGE = 100
 # Minimum game count for top-performer standout card
 TOP_PERFORMER_MIN_GAMES = 20
 
+# Allowlist for card-stats sort_by — keep in sync with the dashboard
+# Card Performance table headers.
+_CARD_SORT_COLUMNS = frozenset({"card_name", "games", "win_rate", "avg_cast_turn"})
+_CARD_SORT_DIRS = frozenset({"asc", "desc"})
+# Natural direction for each sortable column. card_name is text → A→Z;
+# numeric columns rank "best first" → descending.
+_CARD_SORT_NATURAL_DIR = {
+    "card_name": "asc",
+    "games": "desc",
+    "win_rate": "desc",
+    "avg_cast_turn": "desc",
+}
+
 
 # ---------------------------------------------------------------------------
 # Response models
@@ -593,7 +606,8 @@ async def get_card_stats(
     db: AsyncSession = Depends(get_session),
     page: Annotated[int, Query(ge=1)] = 1,
     per_page: Annotated[int, Query(ge=1, le=_MAX_PER_PAGE)] = _DEFAULT_PER_PAGE,
-    sort: Annotated[str, Query()] = "cast_count",
+    sort_by: Annotated[str, Query()] = "games",
+    sort_dir: Annotated[str | None, Query()] = None,
     format: Annotated[str | None, Query()] = None,
     opponent: Annotated[str | None, Query()] = None,
     date_from: Annotated[str | None, Query()] = None,
@@ -607,7 +621,26 @@ async def get_card_stats(
     Uses the materialized ``card_game_stats`` table when available,
     falling back to the legacy JSONB extraction path for pre-backfill
     data.
+
+    ``sort_by`` accepts one of ``card_name``, ``games``, ``win_rate``,
+    ``avg_cast_turn``. ``sort_dir`` is ``asc`` or ``desc``; if omitted,
+    defaults to ``asc`` for ``card_name`` and ``desc`` for the numeric
+    columns. Cards with ``avg_cast_turn = NULL`` always rank last when
+    sorting by that column, regardless of direction.
     """
+    if sort_by not in _CARD_SORT_COLUMNS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "invalid_sort_by", "allowed": sorted(_CARD_SORT_COLUMNS)},
+        )
+    if sort_dir is None:
+        sort_dir = _CARD_SORT_NATURAL_DIR[sort_by]
+    elif sort_dir not in _CARD_SORT_DIRS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "invalid_sort_dir", "allowed": sorted(_CARD_SORT_DIRS)},
+        )
+
     use_materialized = await _has_card_game_stats(db, user.user_id)
 
     if use_materialized:
@@ -708,17 +741,46 @@ async def get_card_stats(
                 )
             )
 
-    # Sort
-    if sort == "win_rate":
-        items.sort(key=lambda x: (-x.win_rate, -x.cast_count))
-    else:
-        items.sort(key=lambda x: (-x.cast_count, x.name))
+    _sort_card_items(items, sort_by, sort_dir)
 
     total = len(items)
     offset = (page - 1) * per_page
     page_items = items[offset : offset + per_page]
 
     return CardStatsResponse(cards=page_items, total=total, page=page, per_page=per_page)
+
+
+def _sort_card_items(items: list[CardStatItem], sort_by: str, sort_dir: str) -> None:
+    """Sort ``items`` in place by the chosen column and direction.
+
+    Tie-break order is always ``cast_count`` desc then ``name`` asc, so
+    equally-ranked cards prefer the larger sample size regardless of
+    primary sort direction. ``avg_cast_turn = None`` rows always rank
+    last when sorting by that column.
+    """
+    reverse = sort_dir == "desc"
+
+    # Sort is stable, so apply the tie-breaker first then the primary
+    # key. Items with equal primary values keep tie-breaker order.
+    def tiebreak(x: CardStatItem) -> tuple[int, str]:
+        return (-x.cast_count, x.name.lower())
+
+    if sort_by == "avg_cast_turn":
+        non_null = [x for x in items if x.avg_cast_turn is not None]
+        nulls = [x for x in items if x.avg_cast_turn is None]
+        non_null.sort(key=tiebreak)
+        non_null.sort(key=lambda x: x.avg_cast_turn or 0.0, reverse=reverse)
+        nulls.sort(key=tiebreak)
+        items[:] = non_null + nulls
+        return
+
+    items.sort(key=tiebreak)
+    if sort_by == "card_name":
+        items.sort(key=lambda x: x.name.lower(), reverse=reverse)
+    elif sort_by == "win_rate":
+        items.sort(key=lambda x: x.win_rate, reverse=reverse)
+    else:  # "games"
+        items.sort(key=lambda x: x.cast_count, reverse=reverse)
 
 
 @router.get("/cards/{card_name}", response_model=CardDetailResponse)

--- a/services/analytics/tests/test_card_stats.py
+++ b/services/analytics/tests/test_card_stats.py
@@ -294,6 +294,232 @@ async def test_card_stats_aggregates(
     assert mountain["win_rate"] == 100.0
 
 
+def _three_card_fixture() -> list[dict[str, Any]]:
+    """Three cards with distinct values on every sortable column.
+
+    Win-rate when cast: Counterspell 100%, Brainstorm 50%, Ancestral 0%.
+    Cast count:         Brainstorm 2,    Counterspell 1, Ancestral 1.
+    avg_cast_turn:      Brainstorm 4,    Counterspell 2, Ancestral 1.
+    Card name asc:      Ancestral Recall, Brainstorm, Counterspell.
+    """
+    g1, g2 = uuid.uuid4(), uuid.uuid4()
+    return [
+        {
+            "game_id": g1,
+            "winner": "alice",
+            "players": ["alice", "bob"],
+            "format": "Modern",
+            "card_name": "Brainstorm",
+            "first_turn": 3,
+            "hero": "alice",
+        },
+        {
+            "game_id": g2,
+            "winner": "bob",
+            "players": ["alice", "bob"],
+            "format": "Modern",
+            "card_name": "Brainstorm",
+            "first_turn": 5,
+            "hero": "alice",
+        },
+        {
+            "game_id": g1,
+            "winner": "alice",
+            "players": ["alice", "bob"],
+            "format": "Modern",
+            "card_name": "Counterspell",
+            "first_turn": 2,
+            "hero": "alice",
+        },
+        {
+            "game_id": g2,
+            "winner": "bob",
+            "players": ["alice", "bob"],
+            "format": "Modern",
+            "card_name": "Ancestral Recall",
+            "first_turn": 1,
+            "hero": "alice",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sort_by", "expected_first"),
+    [
+        ("card_name", "Ancestral Recall"),
+        ("games", "Brainstorm"),
+        ("win_rate", "Counterspell"),
+        ("avg_cast_turn", "Brainstorm"),
+    ],
+)
+async def test_card_stats_sort_desc(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    sort_by: str,
+    expected_first: str,
+) -> None:
+    """Each allowed sort_by ranks the expected card first under desc/default."""
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    _patch_has_card_game_stats(monkeypatch, False)
+    _patch_hero_name(monkeypatch, "alice")
+    _patch_card_loader(monkeypatch, _three_card_fixture())
+
+    # card_name asc is the natural default for card_name, so use asc there;
+    # desc for the numeric columns.
+    sort_dir = "asc" if sort_by == "card_name" else "desc"
+
+    session = _FakeSession(queue=[[]])  # catalog.cards lookup, empty meta
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get(
+            "/analytics/stats/cards",
+            params={"sort_by": sort_by, "sort_dir": sort_dir},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["cards"][0]["name"] == expected_first, (
+        f"sort_by={sort_by} {sort_dir} → got {[c['name'] for c in body['cards']]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_card_stats_sort_direction_flips(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """asc and desc on the same column return reversed orderings."""
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    _patch_has_card_game_stats(monkeypatch, False)
+    _patch_hero_name(monkeypatch, "alice")
+    _patch_card_loader(monkeypatch, _three_card_fixture())
+
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+
+    session_desc = _FakeSession(queue=[[]])
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session_desc)
+    r_desc = await app_client.get(
+        "/analytics/stats/cards",
+        params={"sort_by": "win_rate", "sort_dir": "desc"},
+    )
+
+    session_asc = _FakeSession(queue=[[]])
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session_asc)
+    r_asc = await app_client.get(
+        "/analytics/stats/cards",
+        params={"sort_by": "win_rate", "sort_dir": "asc"},
+    )
+    _main.app.dependency_overrides.clear()
+
+    desc_names = [c["name"] for c in r_desc.json()["cards"]]
+    asc_names = [c["name"] for c in r_asc.json()["cards"]]
+    assert desc_names[0] == "Counterspell"  # 100% wr
+    assert asc_names[0] == "Ancestral Recall"  # 0% wr
+    assert desc_names == list(reversed(asc_names))
+
+
+@pytest.mark.asyncio
+async def test_card_stats_sort_avg_cast_turn_nulls_last(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cards with no avg_cast_turn rank last under both asc and desc."""
+    from analytics_service import card_stats as _cs
+
+    items = [
+        _cs.CardStatItem(name="HasTurn", cast_count=5, win_rate=50.0, avg_cast_turn=3.0),
+        _cs.CardStatItem(name="NullTurn", cast_count=10, win_rate=90.0, avg_cast_turn=None),
+    ]
+    _cs._sort_card_items(items, "avg_cast_turn", "desc")
+    assert [x.name for x in items] == ["HasTurn", "NullTurn"]
+
+    items = [
+        _cs.CardStatItem(name="HasTurn", cast_count=5, win_rate=50.0, avg_cast_turn=3.0),
+        _cs.CardStatItem(name="NullTurn", cast_count=10, win_rate=90.0, avg_cast_turn=None),
+    ]
+    _cs._sort_card_items(items, "avg_cast_turn", "asc")
+    assert [x.name for x in items] == ["HasTurn", "NullTurn"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("params", "expected_error"),
+    [
+        ({"sort_by": "DROP TABLE users"}, "invalid_sort_by"),
+        ({"sort_by": "wins"}, "invalid_sort_by"),  # not in allowlist
+        ({"sort_by": "games", "sort_dir": "sideways"}, "invalid_sort_dir"),
+    ],
+)
+async def test_card_stats_rejects_invalid_sort(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, str],
+    expected_error: str,
+) -> None:
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    _patch_has_card_game_stats(monkeypatch, False)
+    _patch_hero_name(monkeypatch, "alice")
+    _patch_card_loader(monkeypatch, [])
+
+    session = _FakeSession(queue=[])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    _main.app.dependency_overrides[_db.get_session] = _override_session(session)
+    try:
+        r = await app_client.get("/analytics/stats/cards", params=params)
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"] == expected_error
+
+
+@pytest.mark.asyncio
+async def test_card_stats_sort_dir_defaults_per_column(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting sort_dir → asc for card_name, desc for numeric columns."""
+    from analytics_service import db as _db
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    _patch_has_card_game_stats(monkeypatch, False)
+    _patch_hero_name(monkeypatch, "alice")
+    _patch_card_loader(monkeypatch, _three_card_fixture())
+
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        _main.app.dependency_overrides[_db.get_session] = _override_session(
+            _FakeSession(queue=[[]])
+        )
+        r_name = await app_client.get("/analytics/stats/cards", params={"sort_by": "card_name"})
+
+        _main.app.dependency_overrides[_db.get_session] = _override_session(
+            _FakeSession(queue=[[]])
+        )
+        r_games = await app_client.get("/analytics/stats/cards", params={"sort_by": "games"})
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    # card_name default is asc → "Ancestral Recall" comes first.
+    assert r_name.json()["cards"][0]["name"] == "Ancestral Recall"
+    # games default is desc → "Brainstorm" (2 casts) comes first.
+    assert r_games.json()["cards"][0]["name"] == "Brainstorm"
+
+
 @pytest.mark.asyncio
 async def test_card_stats_pagination(
     app_client: httpx.AsyncClient,

--- a/services/web/tests/test_card_performance_partial.py
+++ b/services/web/tests/test_card_performance_partial.py
@@ -1,0 +1,355 @@
+"""Tests for the sortable Card Performance HTMX partial.
+
+Covers the route-level query-param validation, the analytics_client
+sort_dir round-trip, and the template's clickable headers + indicator
+arrows + pagination URL preservation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _override_user(user_id: int = 42, token: str = "user-tok") -> Any:
+    from web_service import deps as _deps
+
+    fake_user = _deps.BrowserUser(
+        user_id=user_id,
+        email="alice@example.com",
+        role="user",
+        must_change_password=False,
+        scope=None,
+        token=token,
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_user
+
+    return _dep
+
+
+def _sample_card_stats() -> Any:
+    from web_service import analytics_client
+
+    return analytics_client.CardStatsResponse(
+        cards=[
+            analytics_client.CardStatItem(
+                card_name="Lightning Bolt",
+                games=10,
+                wins=6,
+                win_rate=60.0,
+                avg_cast_turn=2.5,
+            ),
+            analytics_client.CardStatItem(
+                card_name="Mountain",
+                games=20,
+                wins=12,
+                win_rate=60.0,
+                avg_cast_turn=None,
+            ),
+        ],
+        total=22,
+        page=1,
+        per_page=10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Query-param round-trip + validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_passes_sort_and_dir_through_to_analytics_client(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_card_stats(_url: str, _token: str, **kw: Any) -> Any:
+        captured.update(kw)
+        return _sample_card_stats()
+
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_card_stats)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(
+            "/dashboard/partials/card-performance",
+            params={"sort": "win_rate", "dir": "asc", "format": "Modern", "page": 2},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert captured["sort_by"] == "win_rate"
+    assert captured["sort_dir"] == "asc"
+    assert captured["format_filter"] == "Modern"
+    assert captured["page"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("params", "expected_sort", "expected_dir"),
+    [
+        # Invalid sort → games. Valid dir is preserved.
+        ({"sort": "wins", "dir": "asc"}, "games", "asc"),
+        # Invalid dir → desc. Valid sort is preserved.
+        ({"sort": "win_rate", "dir": "sideways"}, "win_rate", "desc"),
+        # Both invalid → both defaults.
+        ({"sort": "DROP TABLE", "dir": "down"}, "games", "desc"),
+        # No params at all → defaults.
+        ({}, "games", "desc"),
+    ],
+)
+async def test_partial_invalid_sort_or_dir_falls_back_to_defaults(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, str],
+    expected_sort: str,
+    expected_dir: str,
+) -> None:
+    """User clicked something we don't recognize → render with defaults, not 400."""
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_card_stats(_url: str, _token: str, **kw: Any) -> Any:
+        captured.update(kw)
+        return _sample_card_stats()
+
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_card_stats)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get("/dashboard/partials/card-performance", params=params)
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert captured["sort_by"] == expected_sort
+    assert captured["sort_dir"] == expected_dir
+
+
+# ---------------------------------------------------------------------------
+# Template rendering — header URLs, indicators, pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_renders_clickable_headers_with_correct_urls(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each header issues an hx-get that flips/sets sort state correctly."""
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_card_stats(_url: str, _token: str, **_kw: Any) -> Any:
+        return _sample_card_stats()
+
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_card_stats)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        # Currently sorted by games desc.
+        r = await app_client.get(
+            "/dashboard/partials/card-performance",
+            params={"sort": "games", "dir": "desc"},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    html = r.text
+    # Inactive headers point at their natural default direction.
+    assert "sort=card_name&amp;dir=asc" in html
+    assert "sort=win_rate&amp;dir=desc" in html
+    assert "sort=avg_cast_turn&amp;dir=desc" in html
+    # The active header (games) toggles to asc.
+    assert "sort=games&amp;dir=asc" in html
+    # Toggling sort always resets to page 1.
+    assert "page=1&amp;sort=games" in html
+
+
+@pytest.mark.asyncio
+async def test_partial_shows_indicator_only_on_active_column(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_card_stats(_url: str, _token: str, **_kw: Any) -> Any:
+        return _sample_card_stats()
+
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_card_stats)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r_desc = await app_client.get(
+            "/dashboard/partials/card-performance",
+            params={"sort": "win_rate", "dir": "desc"},
+        )
+        r_asc = await app_client.get(
+            "/dashboard/partials/card-performance",
+            params={"sort": "win_rate", "dir": "asc"},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    # desc → ↓, asc → ↑. Only one arrow each.
+    assert r_desc.text.count("&darr;") == 1
+    assert "&uarr;" not in r_desc.text
+    assert r_asc.text.count("&uarr;") == 1
+    assert "&darr;" not in r_asc.text
+    # aria-sort marks the active column.
+    assert 'aria-sort="descending"' in r_desc.text
+    assert 'aria-sort="ascending"' in r_asc.text
+
+
+@pytest.mark.asyncio
+async def test_partial_pagination_preserves_sort_and_dir(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import analytics_client
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_card_stats(_url: str, _token: str, **_kw: Any) -> Any:
+        # Force a second page to exist by claiming total > per_page.
+        return analytics_client.CardStatsResponse(
+            cards=[
+                analytics_client.CardStatItem(
+                    card_name="Bolt",
+                    games=1,
+                    wins=1,
+                    win_rate=100.0,
+                    avg_cast_turn=1.0,
+                ),
+            ],
+            total=30,
+            page=2,
+            per_page=10,
+        )
+
+    monkeypatch.setattr(analytics_client, "get_card_stats", fake_card_stats)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = _override_user()
+    try:
+        r = await app_client.get(
+            "/dashboard/partials/card-performance",
+            params={"sort": "win_rate", "dir": "asc", "page": 2},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    html = r.text
+    # Both Prev and Next URLs carry the active sort/dir.
+    assert "sort=win_rate&amp;dir=asc&amp;page=1" in html
+    assert "sort=win_rate&amp;dir=asc&amp;page=3" in html
+
+
+# ---------------------------------------------------------------------------
+# analytics_client wire-level sort_dir round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_analytics_client_get_card_stats_sends_sort_dir() -> None:
+    from web_service import analytics_client
+
+    captured_urls: list[httpx.URL] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_urls.append(request.url)
+        return httpx.Response(200, json={"cards": [], "total": 0, "page": 1, "per_page": 10})
+
+    transport = httpx.MockTransport(handler)
+
+    # Patch httpx.AsyncClient inside the client module to use our transport.
+    import httpx as _httpx_mod
+
+    original = _httpx_mod.AsyncClient
+
+    class _PatchedClient(_httpx_mod.AsyncClient):
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            kw["transport"] = transport
+            super().__init__(*a, **kw)
+
+    _httpx_mod.AsyncClient = _PatchedClient  # type: ignore[misc]
+    try:
+        await analytics_client.get_card_stats(
+            "http://analytics:8000",
+            "tok",
+            sort_by="win_rate",
+            sort_dir="asc",
+            format_filter="Modern",
+        )
+    finally:
+        _httpx_mod.AsyncClient = original  # type: ignore[misc]
+
+    assert len(captured_urls) == 1
+    url = captured_urls[0]
+    params = dict(url.params)
+    assert params["sort_by"] == "win_rate"
+    assert params["sort_dir"] == "asc"
+    assert params["format"] == "Modern"
+
+
+@pytest.mark.asyncio
+async def test_analytics_client_omits_sort_dir_when_none() -> None:
+    """``sort_dir=None`` lets the analytics service apply its column-default."""
+    from web_service import analytics_client
+
+    captured_urls: list[httpx.URL] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_urls.append(request.url)
+        return httpx.Response(200, json={"cards": [], "total": 0, "page": 1, "per_page": 10})
+
+    transport = httpx.MockTransport(handler)
+    import httpx as _httpx_mod
+
+    original = _httpx_mod.AsyncClient
+
+    class _PatchedClient(_httpx_mod.AsyncClient):
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            kw["transport"] = transport
+            super().__init__(*a, **kw)
+
+    _httpx_mod.AsyncClient = _PatchedClient  # type: ignore[misc]
+    try:
+        await analytics_client.get_card_stats(
+            "http://analytics:8000",
+            "tok",
+            sort_by="card_name",
+        )
+    finally:
+        _httpx_mod.AsyncClient = original  # type: ignore[misc]
+
+    params = dict(captured_urls[0].params)
+    assert params["sort_by"] == "card_name"
+    assert "sort_dir" not in params

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -1153,12 +1153,15 @@ async def get_card_stats(
     page: int = 1,
     per_page: int = 20,
     sort_by: str = "games",
+    sort_dir: str | None = None,
     format_filter: str | None = None,
     opponent: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
 ) -> CardStatsResponse:
     params: dict[str, Any] = {"page": page, "per_page": per_page, "sort_by": sort_by}
+    if sort_dir:
+        params["sort_dir"] = sort_dir
     if format_filter:
         params["format"] = format_filter
     if opponent:

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -470,6 +470,14 @@ async def dashboard_partial_mulligans(
 
 _CARD_PERF_PER_PAGE = 10
 
+# Mirrors the analytics-side allowlist; kept here so we can validate
+# user-supplied query params before passing them to analytics, and fall
+# back to defaults rather than 400ing the dashboard.
+_CARD_SORT_COLUMNS = frozenset({"card_name", "games", "win_rate", "avg_cast_turn"})
+_CARD_SORT_DIRS = frozenset({"asc", "desc"})
+_CARD_SORT_DEFAULT = "games"
+_CARD_DIR_DEFAULT = "desc"
+
 
 @app.get("/dashboard/partials/card-performance", response_class=HTMLResponse)
 async def dashboard_partial_card_performance(
@@ -478,8 +486,21 @@ async def dashboard_partial_card_performance(
     settings: WebSettings = Depends(get_settings),
     format: Annotated[str, Query(alias="format")] = "",
     page: Annotated[int, Query(ge=1)] = 1,
+    sort: Annotated[str, Query()] = _CARD_SORT_DEFAULT,
+    dir: Annotated[str, Query()] = _CARD_DIR_DEFAULT,
 ) -> Response:
-    """HTMX partial: card performance filtered by format, paginated."""
+    """HTMX partial: card performance filtered by format, paginated.
+
+    ``sort`` + ``dir`` come from header clicks in the partial. Invalid
+    values fall back to the defaults (``games`` desc) rather than 400 —
+    the user clicked something we don't recognize, not a hand-crafted
+    payload.
+    """
+    if sort not in _CARD_SORT_COLUMNS:
+        sort = _CARD_SORT_DEFAULT
+    if dir not in _CARD_SORT_DIRS:
+        dir = _CARD_DIR_DEFAULT
+
     card_stats: Any = None
     try:
         card_stats = await analytics_client.get_card_stats(
@@ -487,7 +508,8 @@ async def dashboard_partial_card_performance(
             user.token,
             page=page,
             per_page=_CARD_PERF_PER_PAGE,
-            sort_by="games",
+            sort_by=sort,
+            sort_dir=dir,
             format_filter=format or None,
         )
     except analytics_client.AnalyticsForbidden:
@@ -497,7 +519,12 @@ async def dashboard_partial_card_performance(
     return templates.TemplateResponse(
         request,
         "_partials_card_performance.html",
-        {"card_stats": card_stats, "format_filter": format},
+        {
+            "card_stats": card_stats,
+            "format_filter": format,
+            "current_sort": sort,
+            "current_dir": dir,
+        },
     )
 
 

--- a/services/web/web_service/templates/_partials_card_performance.html
+++ b/services/web/web_service/templates/_partials_card_performance.html
@@ -1,4 +1,17 @@
-{# HTMX partial: Card performance table filtered by format, paginated #}
+{# HTMX partial: Card performance table filtered by format, paginated, sortable.
+
+   `current_sort` / `current_dir` default here so the partial renders
+   correctly when first {% include %}d from dashboard.html (no route
+   handler has bound those names yet). The handler always overrides
+   them via the TemplateResponse context. #}
+{% set current_sort = current_sort|default('games') %}
+{% set current_dir = current_dir|default('desc') %}
+{% set columns = [
+    {'key': 'card_name',     'label': 'Card',          'natural': 'asc',  'align': 'left'},
+    {'key': 'games',         'label': 'Games',         'natural': 'desc', 'align': 'right'},
+    {'key': 'win_rate',      'label': 'Win Rate',      'natural': 'desc', 'align': 'right'},
+    {'key': 'avg_cast_turn', 'label': 'Avg Cast Turn', 'natural': 'desc', 'align': 'right'},
+] %}
 {% if card_stats and card_stats.cards %}
 <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md overflow-hidden">
     <div class="px-4 py-3 border-b dark:border-border border-border-light">
@@ -8,10 +21,23 @@
         <table class="w-full">
             <thead>
                 <tr class="border-b dark:border-border border-border-light">
-                    <th class="text-xs uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light font-medium text-left px-4 py-2.5">Card</th>
-                    <th class="text-xs uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light font-medium text-right px-4 py-2.5">Games</th>
-                    <th class="text-xs uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light font-medium text-right px-4 py-2.5">Win Rate</th>
-                    <th class="text-xs uppercase tracking-wider dark:text-txt-secondary text-txt-secondary-light font-medium text-right px-4 py-2.5">Avg Cast Turn</th>
+                    {% for col in columns %}
+                    {% set is_active = (col.key == current_sort) %}
+                    {% set next_dir = ('asc' if current_dir == 'desc' else 'desc') if is_active else col.natural %}
+                    {% set aria_sort = ('ascending' if current_dir == 'asc' else 'descending') if is_active else 'none' %}
+                    {# Toggling sort always returns the user to page 1 — the row that was on page 3 under the
+                       previous sort almost never maps to the same page under the new sort. #}
+                    {% set href = "/dashboard/partials/card-performance?format=" + (format_filter|urlencode) + "&page=1&sort=" + col.key + "&dir=" + next_dir %}
+                    <th aria-sort="{{ aria_sort }}"
+                        class="text-xs uppercase tracking-wider font-medium text-{{ col.align }} px-0 py-0 dark:text-txt-secondary text-txt-secondary-light">
+                        <button hx-get="{{ href }}"
+                                hx-target="#card-performance-panel"
+                                hx-swap="innerHTML"
+                                class="w-full text-{{ col.align }} px-4 py-2.5 cursor-pointer bg-transparent border-0 uppercase tracking-wider text-xs font-medium {% if is_active %}dark:text-txt-primary text-txt-primary-light{% else %}dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light{% endif %} transition-colors">
+                            {{ col.label }}{% if is_active %}<span aria-hidden="true" class="ml-1">{% if current_dir == 'asc' %}&uarr;{% else %}&darr;{% endif %}</span>{% endif %}
+                        </button>
+                    </th>
+                    {% endfor %}
                 </tr>
             </thead>
             <tbody>
@@ -27,11 +53,14 @@
         </table>
     </div>
 
-    {# Pagination #}
+    {# Pagination — preserves the active sort + direction. #}
     {% set first_idx = (card_stats.page - 1) * card_stats.per_page + 1 %}
     {% set last_idx = first_idx + card_stats.cards|length - 1 %}
     {% set has_prev = card_stats.page > 1 %}
     {% set has_next = last_idx < card_stats.total %}
+    {% set base_qs = "format=" + (format_filter|urlencode) + "&sort=" + current_sort + "&dir=" + current_dir %}
+    {% set prev_url = "/dashboard/partials/card-performance?" + base_qs + "&page=" + (card_stats.page - 1)|string %}
+    {% set next_url = "/dashboard/partials/card-performance?" + base_qs + "&page=" + (card_stats.page + 1)|string %}
     <div class="px-4 py-3 border-t dark:border-border border-border-light">
         <nav class="flex items-center justify-between" aria-label="Card stats pagination">
             <p class="text-xs dark:text-txt-secondary text-txt-secondary-light">
@@ -41,14 +70,14 @@
             {% if has_prev or has_next %}
             <div class="flex items-center gap-2 text-sm">
                 {% if has_prev %}
-                <button hx-get="/dashboard/partials/card-performance?format={{ format_filter|urlencode }}&page={{ card_stats.page - 1 }}"
+                <button hx-get="{{ prev_url }}"
                         hx-target="#card-performance-panel"
                         hx-swap="innerHTML"
                         class="border dark:border-border border-border-light dark:text-txt-primary text-txt-primary-light hover:dark:bg-surface-2 hover:bg-surface-light-3 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer bg-transparent">&larr; Prev</button>
                 {% endif %}
                 <span class="font-mono text-xs dark:text-txt-secondary text-txt-secondary-light">{{ card_stats.page }}</span>
                 {% if has_next %}
-                <button hx-get="/dashboard/partials/card-performance?format={{ format_filter|urlencode }}&page={{ card_stats.page + 1 }}"
+                <button hx-get="{{ next_url }}"
                         hx-target="#card-performance-panel"
                         hx-swap="innerHTML"
                         class="border dark:border-border border-border-light dark:text-txt-primary text-txt-primary-light hover:dark:bg-surface-2 hover:bg-surface-light-3 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer bg-transparent">Next &rarr;</button>


### PR DESCRIPTION
## Summary
- Every column header of the dashboard Card Performance table is now a clickable button that fetches the partial via HTMX with updated sort state. Clicking the active column toggles direction; clicking an inactive column switches to that column's natural default (asc for `card_name`, desc for `games` / `win_rate` / `avg_cast_turn`). The active column shows `↑` or `↓` and an `aria-sort` attribute for screen readers.
- Sort happens at the analytics-query layer (`sort_by` + `sort_dir`) so pagination spans the whole correctly-sorted dataset rather than just the visible page. The analytics service enforces an allowlist (`card_name`, `games`, `win_rate`, `avg_cast_turn` × `asc`/`desc`) and rejects anything else with 400; the web route validates against the same allowlist and silently falls back to defaults on invalid input rather than 400ing the dashboard (a stray click shouldn't break the page).
- Pagination buttons preserve `sort` + `dir`; toggling sort always returns the user to page 1.
- Null `avg_cast_turn` rows always rank last when sorting by that column, regardless of direction — cards with no cast-turn data should never head the view.
- Format-filter chip clicks reset sort/dir back to `games desc` via the dashboard's normal full-page reload (the chips are plain `<a href>` links on the parent page, not HTMX). Documented inline in the partial.

## Out of scope
Other dashboard tables (Play/Draw, Pre-board vs Post-board, Mulligans) are intentionally **not** made sortable in this PR — Scott specifically pointed at Card Performance. Separate work if it comes up.

## Pre-existing things noticed while wiring this up
- `analytics_client.get_card_stats` was sending `?sort_by=games` while the analytics endpoint accepted `?sort=` — the param name mismatched, so the old "sort by games" call was silently using the analytics default. Unified on `sort_by` in this PR.
- The materialized `analytics.card_game_stats` table doesn't store cast-turn data, so `avg_cast_turn` is always `None` for users on the materialized path. The "Avg Cast Turn" column already shows `—` for those users; sorting by it on the materialized path is therefore essentially a no-op (everything tied, NULLS LAST). The JSONB-fallback path computes real values. Capturing cast-turn in the materialized table is separate work.
- `services/analytics/tests/` is not run in CI (`.github/workflows/ci.yml` runs auth + ingest + web only). The 8 new analytics-side tests pass locally but won't be exercised by the gate.

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy common/ services/` — Success, no issues
- [x] `uv run pytest tests/common/ tests/test_route_prefix_convention.py services/web/tests/` — 294 passed
- [x] `cd services/analytics && uv run --project . pytest tests/` — 201 passed (incl. 8 new card-stats sort tests)
- [ ] CI (12 checks) green
- [ ] Eyeball the dashboard once deployed: each header clicks correctly, indicators show, pagination preserves sort, format chip resets sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)