### PR TITLE
feat(dashboard): add date range filter to Overview tab

### DIFF
--- a/services/analytics/analytics_service/stats.py
+++ b/services/analytics/analytics_service/stats.py
@@ -123,7 +123,13 @@ def _classify_match(
     return "D", opponent, user_wins, opp_wins
 
 
-async def _load_user_matches(db: AsyncSession, user_id: int) -> list[dict[str, Any]]:
+async def _load_user_matches(
+    db: AsyncSession,
+    user_id: int,
+    *,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> list[dict[str, Any]]:
     """Fetch a user's matches plus per-match game-winner counts.
 
     Kept for callers that need the full match list with game-win
@@ -132,21 +138,32 @@ async def _load_user_matches(db: AsyncSession, user_id: int) -> list[dict[str, A
 
     v0.9.6: Now also returns ``hero_player_name`` from the match row,
     eliminating the need for a separate ``auth.users`` lookup.
+
+    v0.9.8: Optional ``date_from`` / ``date_to`` params push date
+    filtering to SQL (same pattern as ``game_stats._load_games_with_context``).
     """
+    where = "WHERE user_id = :user_id AND review_status IS NULL"
+    params: dict[str, Any] = {"user_id": user_id}
+    if date_from:
+        where += " AND COALESCE(played_at, parsed_at)::date >= :date_from"
+        params["date_from"] = date_from
+    if date_to:
+        where += " AND COALESCE(played_at, parsed_at)::date <= :date_to"
+        params["date_to"] = date_to
+
     rows = (
         await db.execute(
             text(
-                """
+                f"""
                 SELECT id, format, players,
                        COALESCE(played_at, parsed_at) AS played_at,
                        hero_player_name
                 FROM parser.matches
-                WHERE user_id = :user_id
-                  AND review_status IS NULL
+                {where}
                 ORDER BY COALESCE(played_at, parsed_at) DESC
                 """
             ),
-            {"user_id": user_id},
+            params,
         )
     ).all()
     if not rows:
@@ -231,14 +248,16 @@ def _summarize(
 async def get_summary(
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
+    date_from: Annotated[str | None, Query()] = None,
+    date_to: Annotated[str | None, Query()] = None,
 ) -> StatsSummary:
     redis_client = await _get_redis_or_none()
-    ck = cache_key(user.user_id, "summary")
+    ck = cache_key(user.user_id, "summary", date_from=date_from, date_to=date_to)
     if redis_client:
         cached = await get_cached(redis_client, ck, endpoint="summary")
         if isinstance(cached, dict):
             return StatsSummary(**cached)
-    matches = await _load_user_matches(db, user.user_id)
+    matches = await _load_user_matches(db, user.user_id, date_from=date_from, date_to=date_to)
     result = _summarize(matches)
     if redis_client:
         await set_cached(redis_client, ck, result.model_dump(mode="json", by_alias=True))
@@ -249,14 +268,16 @@ async def get_summary(
 async def get_by_format(
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
+    date_from: Annotated[str | None, Query()] = None,
+    date_to: Annotated[str | None, Query()] = None,
 ) -> list[FormatStat]:
     redis_client = await _get_redis_or_none()
-    ck = cache_key(user.user_id, "by-format")
+    ck = cache_key(user.user_id, "by-format", date_from=date_from, date_to=date_to)
     if redis_client:
         cached = await get_cached(redis_client, ck, endpoint="by-format")
         if isinstance(cached, list):
             return [FormatStat(**item) for item in cached]
-    matches = await _load_user_matches(db, user.user_id)
+    matches = await _load_user_matches(db, user.user_id, date_from=date_from, date_to=date_to)
     if not matches:
         return []
     buckets: dict[str, dict[str, int]] = {}

--- a/services/analytics/tests/test_review_status_filter.py
+++ b/services/analytics/tests/test_review_status_filter.py
@@ -127,7 +127,13 @@ async def test_summary_loader_filtering_contract(
         }
     ]
 
-    async def fake_loader(_db: Any, _user_id: int) -> list[dict[str, Any]]:
+    async def fake_loader(
+        _db: Any,
+        _user_id: int,
+        *,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> list[dict[str, Any]]:
         return matches
 
     monkeypatch.setattr(_stats, "_load_user_matches", fake_loader)

--- a/services/analytics/tests/test_stats.py
+++ b/services/analytics/tests/test_stats.py
@@ -63,7 +63,13 @@ def _override_user(user_id: int = 7) -> Any:
 def _patch_loader(monkeypatch: pytest.MonkeyPatch, matches: list[dict[str, Any]]) -> None:
     from analytics_service import stats as _stats
 
-    async def fake_loader(_db: Any, _user_id: int) -> list[dict[str, Any]]:
+    async def fake_loader(
+        _db: Any,
+        _user_id: int,
+        *,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> list[dict[str, Any]]:
         return matches
 
     monkeypatch.setattr(_stats, "_load_user_matches", fake_loader)
@@ -73,6 +79,37 @@ def _patch_loader(monkeypatch: pytest.MonkeyPatch, matches: list[dict[str, Any]]
         return None
 
     monkeypatch.setattr(_stats, "_get_redis_or_none", _no_redis)
+
+
+def _patch_loader_date_aware(
+    monkeypatch: pytest.MonkeyPatch,
+    matches: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Like _patch_loader but records date_from/date_to calls.
+
+    Returns a mutable list that the fake appends call records to.
+    """
+    from analytics_service import stats as _stats
+
+    calls: list[dict[str, Any]] = []
+
+    async def fake_loader(
+        _db: Any,
+        _user_id: int,
+        *,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> list[dict[str, Any]]:
+        calls.append({"date_from": date_from, "date_to": date_to})
+        return matches
+
+    monkeypatch.setattr(_stats, "_load_user_matches", fake_loader)
+
+    async def _no_redis() -> None:
+        return None
+
+    monkeypatch.setattr(_stats, "_get_redis_or_none", _no_redis)
+    return calls
 
 
 def _match_dict(
@@ -328,3 +365,100 @@ async def test_by_opponent_buckets_by_opponent(
     assert by_opp["carol"]["matches"] == 1
     assert by_opp["carol"]["wins"] == 1
     assert by_opp["carol"]["win_rate"] == 100.0
+
+
+# ---------------------------------------------------------------------------
+# /summary and /by-format with date_from / date_to
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summary_threads_date_params(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """date_from and date_to query params are forwarded to _load_user_matches."""
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    calls = _patch_loader_date_aware(monkeypatch, [])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get(
+            "/analytics/stats/summary",
+            params={"date_from": "2026-05-01", "date_to": "2026-05-10"},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert len(calls) == 1
+    assert calls[0]["date_from"] == "2026-05-01"
+    assert calls[0]["date_to"] == "2026-05-10"
+
+
+@pytest.mark.asyncio
+async def test_summary_no_date_params_passes_none(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without date params, _load_user_matches receives None."""
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    calls = _patch_loader_date_aware(monkeypatch, [])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get("/analytics/stats/summary")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert len(calls) == 1
+    assert calls[0]["date_from"] is None
+    assert calls[0]["date_to"] is None
+
+
+@pytest.mark.asyncio
+async def test_by_format_threads_date_params(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """date_from and date_to query params are forwarded through by-format."""
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    calls = _patch_loader_date_aware(monkeypatch, [])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get(
+            "/analytics/stats/by-format",
+            params={"date_from": "2026-05-01", "date_to": "2026-05-15"},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert len(calls) == 1
+    assert calls[0]["date_from"] == "2026-05-01"
+    assert calls[0]["date_to"] == "2026-05-15"
+
+
+# ---------------------------------------------------------------------------
+# Cache key differentiation with date params
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_differs_with_date_params() -> None:
+    """Cache keys for date-filtered vs unfiltered requests must differ."""
+    from common.cache import cache_key as ck
+
+    key_no_date = ck(7, "summary")
+    key_with_date = ck(7, "summary", date_from="2026-05-01", date_to="2026-05-10")
+    key_different_date = ck(7, "summary", date_from="2026-04-01", date_to="2026-04-30")
+
+    assert key_no_date != key_with_date
+    assert key_with_date != key_different_date
+    # None values should not affect the key (stripped by cache_key)
+    key_none = ck(7, "summary", date_from=None, date_to=None)
+    assert key_none == key_no_date

--- a/services/web/tests/test_dashboard_stats.py
+++ b/services/web/tests/test_dashboard_stats.py
@@ -123,10 +123,10 @@ async def test_dashboard_renders_with_stats(
     from web_service import deps as _deps
     from web_service import main as _main
 
-    async def fake_summary(_url: str, _token: str) -> Any:
+    async def fake_summary(_url: str, _token: str, **_kw: Any) -> Any:
         return _sample_summary(total=7)
 
-    async def fake_format(_url: str, _token: str) -> Any:
+    async def fake_format(_url: str, _token: str, **_kw: Any) -> Any:
         return _sample_format_stats()
 
     async def fake_opponent(_url: str, _token: str) -> Any:
@@ -235,10 +235,10 @@ async def test_dashboard_empty_state_no_matches(
     from web_service import deps as _deps
     from web_service import main as _main
 
-    async def fake_summary(_url: str, _token: str) -> Any:
+    async def fake_summary(_url: str, _token: str, **_kw: Any) -> Any:
         return _sample_summary(total=0)
 
-    async def fake_format(_url: str, _token: str) -> Any:
+    async def fake_format(_url: str, _token: str, **_kw: Any) -> Any:
         return []
 
     async def fake_opponent(_url: str, _token: str) -> Any:
@@ -360,10 +360,10 @@ async def test_dashboard_format_filter_threads_through(
 
     captured: dict[str, Any] = {}
 
-    async def fake_summary(_url: str, _token: str) -> Any:
+    async def fake_summary(_url: str, _token: str, **_kw: Any) -> Any:
         return _sample_summary(total=7)
 
-    async def fake_format(_url: str, _token: str) -> Any:
+    async def fake_format(_url: str, _token: str, **_kw: Any) -> Any:
         return _sample_format_stats()
 
     async def fake_play_draw(_url: str, _token: str, **kw: Any) -> Any:
@@ -430,11 +430,11 @@ async def test_dashboard_format_filter_overrides_headline_numbers(
     from web_service import deps as _deps
     from web_service import main as _main
 
-    async def fake_summary(_url: str, _token: str) -> Any:
+    async def fake_summary(_url: str, _token: str, **_kw: Any) -> Any:
         # Overall: 7 matches, 4-2-1, win rate 66.7%.
         return _sample_summary(total=7)
 
-    async def fake_format(_url: str, _token: str) -> Any:
+    async def fake_format(_url: str, _token: str, **_kw: Any) -> Any:
         return [
             analytics_client.FormatStatItem(
                 format_="Modern",
@@ -497,10 +497,10 @@ async def test_dashboard_unfiltered_has_no_clear_link(
     from web_service import deps as _deps
     from web_service import main as _main
 
-    async def fake_summary(_url: str, _token: str) -> Any:
+    async def fake_summary(_url: str, _token: str, **_kw: Any) -> Any:
         return _sample_summary(total=7)
 
-    async def fake_format(_url: str, _token: str) -> Any:
+    async def fake_format(_url: str, _token: str, **_kw: Any) -> Any:
         return _sample_format_stats()
 
     async def fake_play_draw(_url: str, _token: str, **_kw: Any) -> Any:

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -296,11 +296,23 @@ def _to_opponent_stat(payload: dict[str, Any]) -> OpponentStatItem:
     )
 
 
-async def get_stats_summary(base_url: str, token: str) -> StatsSummary:
+async def get_stats_summary(
+    base_url: str,
+    token: str,
+    *,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> StatsSummary:
+    params: dict[str, str] = {}
+    if date_from:
+        params["date_from"] = date_from
+    if date_to:
+        params["date_to"] = date_to
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(
                 f"{base_url}/analytics/stats/summary",
+                params=params,
                 headers={"Authorization": f"Bearer {token}"},
             )
     except httpx.HTTPError as exc:
@@ -314,11 +326,23 @@ async def get_stats_summary(base_url: str, token: str) -> StatsSummary:
     return _to_summary(resp.json())
 
 
-async def get_stats_by_format(base_url: str, token: str) -> list[FormatStatItem]:
+async def get_stats_by_format(
+    base_url: str,
+    token: str,
+    *,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> list[FormatStatItem]:
+    params: dict[str, str] = {}
+    if date_from:
+        params["date_from"] = date_from
+    if date_to:
+        params["date_to"] = date_to
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(
                 f"{base_url}/analytics/stats/by-format",
+                params=params,
                 headers={"Authorization": f"Bearer {token}"},
             )
     except httpx.HTTPError as exc:

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -225,11 +225,15 @@ async def dashboard(
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
     format: Annotated[str, Query(alias="format")] = "",
+    date_from: Annotated[str, Query()] = "",
+    date_to: Annotated[str, Query()] = "",
 ) -> Response:
     if user.role == "admin":
         return RedirectResponse(url=_ADMIN_LANDING_PATH, status_code=status.HTTP_302_FOUND)
 
     format_filter = format or None
+    df = date_from or None
+    dt = date_to or None
 
     stats_summary: Any = None
     format_stats: list[Any] = []
@@ -240,10 +244,10 @@ async def dashboard(
     card_stats: Any = None
     try:
         stats_summary = await analytics_client.get_stats_summary(
-            settings.analytics_service_url, user.token
+            settings.analytics_service_url, user.token, date_from=df, date_to=dt
         )
         format_stats = await analytics_client.get_stats_by_format(
-            settings.analytics_service_url, user.token
+            settings.analytics_service_url, user.token, date_from=df, date_to=dt
         )
     except analytics_client.AnalyticsForbidden:
         # Treat as logged-out: bounce to /login so the user can re-auth.
@@ -254,21 +258,33 @@ async def dashboard(
 
     try:
         play_draw_stats = await analytics_client.get_play_draw_stats(
-            settings.analytics_service_url, user.token, format_filter=format_filter
+            settings.analytics_service_url,
+            user.token,
+            format_filter=format_filter,
+            date_from=df,
+            date_to=dt,
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("play/draw stats unavailable")
 
     try:
         preboard_postboard_stats = await analytics_client.get_preboard_postboard_stats(
-            settings.analytics_service_url, user.token, format_filter=format_filter
+            settings.analytics_service_url,
+            user.token,
+            format_filter=format_filter,
+            date_from=df,
+            date_to=dt,
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("preboard/postboard stats unavailable")
 
     try:
         mulligan_stats = await analytics_client.get_mulligan_stats(
-            settings.analytics_service_url, user.token, format_filter=format_filter
+            settings.analytics_service_url,
+            user.token,
+            format_filter=format_filter,
+            date_from=df,
+            date_to=dt,
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("mulligan stats unavailable")
@@ -281,6 +297,8 @@ async def dashboard(
             user.token,
             per_page=_CARD_PERF_PER_PAGE,
             format_filter=format_filter,
+            date_from=df,
+            date_to=dt,
         )
     except (analytics_client.AnalyticsForbidden, analytics_client.AnalyticsClientError):
         _log.debug("card stats unavailable")
@@ -309,6 +327,8 @@ async def dashboard(
             "card_stats": card_stats,
             "format_filter": format,
             "filtered_summary": filtered_summary,
+            "date_from": date_from,
+            "date_to": date_to,
         },
     )
 
@@ -402,12 +422,18 @@ async def dashboard_partial_play_draw(
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
     format: Annotated[str, Query(alias="format")] = "",
+    date_from: Annotated[str, Query()] = "",
+    date_to: Annotated[str, Query()] = "",
 ) -> Response:
-    """HTMX partial: play/draw stats filtered by format."""
+    """HTMX partial: play/draw stats filtered by format and date range."""
     play_draw_stats: Any = None
     try:
         play_draw_stats = await analytics_client.get_play_draw_stats(
-            settings.analytics_service_url, user.token, format_filter=format or None
+            settings.analytics_service_url,
+            user.token,
+            format_filter=format or None,
+            date_from=date_from or None,
+            date_to=date_to or None,
         )
     except analytics_client.AnalyticsForbidden:
         return HTMLResponse("<p>Session expired. Please reload the page.</p>", status_code=401)
@@ -426,12 +452,18 @@ async def dashboard_partial_preboard_postboard(
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
     format: Annotated[str, Query(alias="format")] = "",
+    date_from: Annotated[str, Query()] = "",
+    date_to: Annotated[str, Query()] = "",
 ) -> Response:
-    """HTMX partial: pre-board vs post-board stats filtered by format."""
+    """HTMX partial: pre-board vs post-board stats filtered by format and date range."""
     preboard_postboard_stats: Any = None
     try:
         preboard_postboard_stats = await analytics_client.get_preboard_postboard_stats(
-            settings.analytics_service_url, user.token, format_filter=format or None
+            settings.analytics_service_url,
+            user.token,
+            format_filter=format or None,
+            date_from=date_from or None,
+            date_to=date_to or None,
         )
     except analytics_client.AnalyticsForbidden:
         return HTMLResponse("<p>Session expired. Please reload the page.</p>", status_code=401)
@@ -450,12 +482,18 @@ async def dashboard_partial_mulligans(
     user: BrowserUser = Depends(get_current_browser_user),
     settings: WebSettings = Depends(get_settings),
     format: Annotated[str, Query(alias="format")] = "",
+    date_from: Annotated[str, Query()] = "",
+    date_to: Annotated[str, Query()] = "",
 ) -> Response:
-    """HTMX partial: mulligan analysis filtered by format."""
+    """HTMX partial: mulligan analysis filtered by format and date range."""
     mulligan_stats: Any = None
     try:
         mulligan_stats = await analytics_client.get_mulligan_stats(
-            settings.analytics_service_url, user.token, format_filter=format or None
+            settings.analytics_service_url,
+            user.token,
+            format_filter=format or None,
+            date_from=date_from or None,
+            date_to=date_to or None,
         )
     except analytics_client.AnalyticsForbidden:
         return HTMLResponse("<p>Session expired. Please reload the page.</p>", status_code=401)
@@ -488,8 +526,10 @@ async def dashboard_partial_card_performance(
     page: Annotated[int, Query(ge=1)] = 1,
     sort: Annotated[str, Query()] = _CARD_SORT_DEFAULT,
     dir: Annotated[str, Query()] = _CARD_DIR_DEFAULT,
+    date_from: Annotated[str, Query()] = "",
+    date_to: Annotated[str, Query()] = "",
 ) -> Response:
-    """HTMX partial: card performance filtered by format, paginated.
+    """HTMX partial: card performance filtered by format and date range, paginated.
 
     ``sort`` + ``dir`` come from header clicks in the partial. Invalid
     values fall back to the defaults (``games`` desc) rather than 400 —
@@ -511,6 +551,8 @@ async def dashboard_partial_card_performance(
             sort_by=sort,
             sort_dir=dir,
             format_filter=format or None,
+            date_from=date_from or None,
+            date_to=date_to or None,
         )
     except analytics_client.AnalyticsForbidden:
         return HTMLResponse("<p>Session expired. Please reload the page.</p>", status_code=401)
@@ -524,6 +566,8 @@ async def dashboard_partial_card_performance(
             "format_filter": format,
             "current_sort": sort,
             "current_dir": dir,
+            "date_from": date_from,
+            "date_to": date_to,
         },
     )
 

--- a/services/web/web_service/templates/_partials_card_performance.html
+++ b/services/web/web_service/templates/_partials_card_performance.html
@@ -27,7 +27,7 @@
                     {% set aria_sort = ('ascending' if current_dir == 'asc' else 'descending') if is_active else 'none' %}
                     {# Toggling sort always returns the user to page 1 — the row that was on page 3 under the
                        previous sort almost never maps to the same page under the new sort. #}
-                    {% set href = "/dashboard/partials/card-performance?format=" + (format_filter|urlencode) + "&page=1&sort=" + col.key + "&dir=" + next_dir %}
+                    {% set href = "/dashboard/partials/card-performance?format=" + (format_filter|urlencode) + "&date_from=" + (date_from|default('')|urlencode) + "&date_to=" + (date_to|default('')|urlencode) + "&page=1&sort=" + col.key + "&dir=" + next_dir %}
                     <th aria-sort="{{ aria_sort }}"
                         class="text-xs uppercase tracking-wider font-medium text-{{ col.align }} px-0 py-0 dark:text-txt-secondary text-txt-secondary-light">
                         <button hx-get="{{ href }}"
@@ -58,7 +58,7 @@
     {% set last_idx = first_idx + card_stats.cards|length - 1 %}
     {% set has_prev = card_stats.page > 1 %}
     {% set has_next = last_idx < card_stats.total %}
-    {% set base_qs = "format=" + (format_filter|urlencode) + "&sort=" + current_sort + "&dir=" + current_dir %}
+    {% set base_qs = "format=" + (format_filter|urlencode) + "&date_from=" + (date_from|default('')|urlencode) + "&date_to=" + (date_to|default('')|urlencode) + "&sort=" + current_sort + "&dir=" + current_dir %}
     {% set prev_url = "/dashboard/partials/card-performance?" + base_qs + "&page=" + (card_stats.page - 1)|string %}
     {% set next_url = "/dashboard/partials/card-performance?" + base_qs + "&page=" + (card_stats.page + 1)|string %}
     <div class="px-4 py-3 border-t dark:border-border border-border-light">

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -16,6 +16,12 @@
     preset: '{{ 'custom' if date_active else 'all' }}',
     dateFrom: '{{ date_from|default('') }}',
     dateTo: '{{ date_to|default('') }}',
+    localDate(d) {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return y + '-' + m + '-' + day;
+    },
     selectPreset(days) {
         if (days === 0) {
             this.dateFrom = '';
@@ -24,8 +30,8 @@
             const to = new Date();
             const from = new Date();
             from.setDate(from.getDate() - days + 1);
-            this.dateFrom = from.toISOString().slice(0, 10);
-            this.dateTo = to.toISOString().slice(0, 10);
+            this.dateFrom = this.localDate(from);
+            this.dateTo = this.localDate(to);
         }
         this.navigate();
     },

--- a/services/web/web_service/templates/dashboard.html
+++ b/services/web/web_service/templates/dashboard.html
@@ -10,6 +10,67 @@
     </p>
 </div>
 
+{# ── Date Range Filter ── #}
+{% set date_active = (date_from|default('') or date_to|default('')) %}
+<div x-data="{
+    preset: '{{ 'custom' if date_active else 'all' }}',
+    dateFrom: '{{ date_from|default('') }}',
+    dateTo: '{{ date_to|default('') }}',
+    selectPreset(days) {
+        if (days === 0) {
+            this.dateFrom = '';
+            this.dateTo = '';
+        } else {
+            const to = new Date();
+            const from = new Date();
+            from.setDate(from.getDate() - days + 1);
+            this.dateFrom = from.toISOString().slice(0, 10);
+            this.dateTo = to.toISOString().slice(0, 10);
+        }
+        this.navigate();
+    },
+    navigate() {
+        const params = new URLSearchParams(window.location.search);
+        if (this.dateFrom) params.set('date_from', this.dateFrom);
+        else params.delete('date_from');
+        if (this.dateTo) params.set('date_to', this.dateTo);
+        else params.delete('date_to');
+        window.location.href = '/dashboard' + (params.toString() ? '?' + params.toString() : '');
+    }
+}" class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md px-4 py-3 mb-6 flex flex-wrap items-center gap-3">
+    <label class="text-xs dark:text-txt-secondary text-txt-secondary-light font-medium">Date range</label>
+    <select x-model="preset"
+            @change="if (preset !== 'custom') selectPreset(preset === 'all' ? 0 : parseInt(preset))"
+            class="text-sm dark:bg-surface-2 bg-surface-light-2 border dark:border-border border-border-light dark:text-txt-primary text-txt-primary-light rounded-md px-2 py-1">
+        <option value="all">All time</option>
+        <option value="7">Last 7 days</option>
+        <option value="14">Last 14 days</option>
+        <option value="30">Last 30 days</option>
+        <option value="custom" x-show="preset === 'custom'">Custom</option>
+    </select>
+    <div class="flex items-center gap-2">
+        <input type="date" x-model="dateFrom"
+               @change="preset = 'custom'"
+               class="text-sm dark:bg-surface-2 bg-surface-light-2 border dark:border-border border-border-light dark:text-txt-primary text-txt-primary-light rounded-md px-2 py-1"
+               placeholder="From">
+        <span class="text-xs dark:text-txt-tertiary text-txt-secondary-light">&ndash;</span>
+        <input type="date" x-model="dateTo"
+               @change="preset = 'custom'"
+               class="text-sm dark:bg-surface-2 bg-surface-light-2 border dark:border-border border-border-light dark:text-txt-primary text-txt-primary-light rounded-md px-2 py-1"
+               placeholder="To">
+    </div>
+    <button @click="navigate()"
+            class="text-xs font-medium dark:text-txt-primary text-txt-primary-light border dark:border-border border-border-light rounded-md px-3 py-1 hover:dark:bg-surface-2 hover:bg-surface-light-2 transition-colors cursor-pointer bg-transparent">
+        Apply
+    </button>
+    {% if date_active %}
+    <a href="/dashboard{% if format_filter %}?format={{ format_filter|urlencode }}{% endif %}"
+       class="text-xs dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light transition-colors no-underline">
+        Clear dates
+    </a>
+    {% endif %}
+</div>
+
 {% if stats_error|default(false) or stats_summary is not defined or stats_summary is none %}
 {% if stats_summary is defined %}
 <div class="bg-danger-muted border border-danger/20 text-danger rounded-md p-3 text-sm mb-6" role="alert">
@@ -21,7 +82,7 @@
 {# ── Stat Cards Row ── #}
 {% if stats_summary.total_matches == 0 %}
 <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-6 mb-6">
-    <p class="dark:text-txt-secondary text-txt-secondary-light">No matches yet. Upload a game log to get started.</p>
+    <p class="dark:text-txt-secondary text-txt-secondary-light">{% if date_active %}No matches in this date range.{% else %}No matches yet. Upload a game log to get started.{% endif %}</p>
 </div>
 {% else %}
 {# When a format filter is active and we have a matching row, use it
@@ -72,7 +133,10 @@
             <p class="text-xs dark:text-txt-secondary text-txt-secondary-light mt-0.5">Click a format to filter stats below.</p>
         </div>
         {% if format_filter %}
-        <a href="/dashboard"
+        {% set clear_format_qs = [] %}
+        {% if date_from|default('') %}{% set _ = clear_format_qs.append("date_from=" + (date_from|urlencode)) %}{% endif %}
+        {% if date_to|default('') %}{% set _ = clear_format_qs.append("date_to=" + (date_to|urlencode)) %}{% endif %}
+        <a href="/dashboard{% if clear_format_qs %}?{{ clear_format_qs|join('&') }}{% endif %}"
            class="text-xs dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light border dark:border-border border-border-light rounded-md px-2 py-1 transition-colors no-underline">
             Clear filter
         </a>
@@ -93,7 +157,11 @@
             <tbody>
                 {% for row in format_stats %}
                 {% set is_selected = (format_filter == row.format_) %}
-                {% set row_href = "/dashboard" if is_selected else "/dashboard?format=" + (row.format_|urlencode) %}
+                {% set date_qs_parts = [] %}
+                {% if date_from|default('') %}{% set _ = date_qs_parts.append("date_from=" + (date_from|urlencode)) %}{% endif %}
+                {% if date_to|default('') %}{% set _ = date_qs_parts.append("date_to=" + (date_to|urlencode)) %}{% endif %}
+                {% set date_qs = "&" + date_qs_parts|join("&") if date_qs_parts else "" %}
+                {% set row_href = ("/dashboard" + ("?" + date_qs_parts|join("&") if date_qs_parts else "")) if is_selected else "/dashboard?format=" + (row.format_|urlencode) + date_qs %}
                 <tr data-format="{{ row.format_ }}"
                     data-href="{{ row_href }}"
                     role="button"


### PR DESCRIPTION
## Summary

- Adds a date range filter bar to the dashboard Overview tab, between the welcome text and stat cards
- Preset dropdown (All time, Last 7/14/30 days), custom From/To date inputs with Apply button, Clear link when dates are active
- URL is source of truth (`?date_from=&date_to=`); date and format filters compose independently
- Threads `date_from`/`date_to` through the full stack: analytics `_load_user_matches` + summary/by-format endpoints, analytics client, web dashboard route + all 4 HTMX partials, dashboard template, and card performance pagination URLs

## Changes

| File | What |
|------|------|
| `services/analytics/analytics_service/stats.py` | `_load_user_matches()` accepts `date_from`/`date_to` kwargs, adds WHERE clauses; `get_summary` and `get_by_format` accept and thread date query params, include in cache key |
| `services/web/web_service/analytics_client.py` | `get_stats_summary()` and `get_stats_by_format()` accept and forward `date_from`/`date_to` |
| `services/web/web_service/main.py` | Dashboard route + all 4 HTMX partials accept `date_from`/`date_to` query params, pass to all analytics client calls, include in template context |
| `services/web/web_service/templates/dashboard.html` | Date filter bar (Alpine.js), date-aware format row hrefs, date-preserving Clear filter link, date-aware empty state text |
| `services/web/web_service/templates/_partials_card_performance.html` | Pagination and sort header URLs include `date_from`/`date_to` |
| `services/analytics/tests/test_stats.py` | Tests for date param threading (summary + by-format), cache key differentiation |

## Test plan

- [x] `services/analytics/tests/` -- 208 passed
- [x] `services/web/tests/` -- 279 passed
- [x] `ruff check` + `ruff format --check` -- clean
- [ ] CI smoke gate