### PR TITLE
UI polish: password hints and sidebar aria-label

### DIFF
--- a/services/web/web_service/templates/base.html
+++ b/services/web/web_service/templates/base.html
@@ -70,6 +70,7 @@
                 {% if user %}
                 {# Mobile hamburger #}
                 <button @click="$store.sidebar.toggle()"
+                        aria-label="Toggle sidebar"
                         class="lg:hidden dark:text-txt-secondary text-txt-secondary-light hover:dark:text-txt-primary hover:text-txt-primary-light">
                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>

--- a/services/web/web_service/templates/password.html
+++ b/services/web/web_service/templates/password.html
@@ -24,6 +24,7 @@
                 <span class="text-xs font-medium dark:text-txt-secondary text-txt-secondary-light">New password</span>
                 <input type="password" name="new_password" autocomplete="new-password" required
                        class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-2 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none">
+                <p class="text-xs dark:text-txt-tertiary text-txt-secondary-light mt-1">12 characters minimum</p>
             </label>
             <label class="flex flex-col gap-1">
                 <span class="text-xs font-medium dark:text-txt-secondary text-txt-secondary-light">Confirm new password</span>

--- a/services/web/web_service/templates/register.html
+++ b/services/web/web_service/templates/register.html
@@ -38,6 +38,7 @@
                     <input type="password" name="password" autocomplete="new-password" required
                            minlength="12"
                            class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-2 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none">
+                    <p class="text-xs dark:text-txt-tertiary text-txt-secondary-light mt-1">12 characters minimum</p>
                 </label>
                 <label class="flex flex-col gap-1">
                     <span class="text-xs font-medium dark:text-txt-secondary text-txt-secondary-light">Confirm password</span>


### PR DESCRIPTION
## Summary
- Add "12 characters minimum" helper text below password fields on the register and change-password forms (the `minlength="12"` constraint was enforced but not visible to users)
- Add `aria-label="Toggle sidebar"` to the hamburger menu button for screen reader accessibility

Note: the theme toggle hover state (item 1 in the original task) was already present on `main`, so no change was needed there.

## Test plan
- [ ] Load `/register` -- confirm "12 characters minimum" hint appears below the password field
- [ ] Load `/settings/password` -- confirm the same hint appears below the "New password" field
- [ ] Inspect the hamburger button in dev tools on a narrow viewport -- confirm `aria-label="Toggle sidebar"` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)