### PR TITLE
fix(analytics): cast date bind params to ::date in SQL

### DIFF
--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -185,10 +185,10 @@ def _build_match_where(
         clauses.append("m.players::text ILIKE :opp_pattern ESCAPE '\\'")
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        clauses.append("COALESCE(m.played_at, m.parsed_at)::date >= :date_from")
+        clauses.append("COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date")
         params["date_from"] = date_from
     if date_to:
-        clauses.append("COALESCE(m.played_at, m.parsed_at)::date <= :date_to")
+        clauses.append("COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date")
         params["date_to"] = date_to
     if opponent_archetype_id:
         clauses.append(
@@ -380,10 +380,10 @@ async def _load_card_appearances(
         where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date"
         params["date_from"] = date_from
     if date_to:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date"
         params["date_to"] = date_to
 
     if not hero_name:
@@ -458,10 +458,10 @@ async def _load_card_appearances_fallback(
         where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date"
         params["date_from"] = date_from
     if date_to:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date"
         params["date_to"] = date_to
 
     rows = (

--- a/services/analytics/analytics_service/game_stats.py
+++ b/services/analytics/analytics_service/game_stats.py
@@ -113,10 +113,10 @@ async def _load_games_with_context(
         where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date"
         params["date_from"] = date_from
     if date_to:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date"
         params["date_to"] = date_to
 
     rows = (
@@ -320,10 +320,10 @@ async def get_game_length(
         where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date"
         params["date_from"] = date_from
     if date_to:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date"
         params["date_to"] = date_to
 
     rows = (

--- a/services/analytics/analytics_service/stats.py
+++ b/services/analytics/analytics_service/stats.py
@@ -145,10 +145,10 @@ async def _load_user_matches(
     where = "WHERE user_id = :user_id AND review_status IS NULL"
     params: dict[str, Any] = {"user_id": user_id}
     if date_from:
-        where += " AND COALESCE(played_at, parsed_at)::date >= :date_from"
+        where += " AND COALESCE(played_at, parsed_at)::date >= :date_from::date"
         params["date_from"] = date_from
     if date_to:
-        where += " AND COALESCE(played_at, parsed_at)::date <= :date_to"
+        where += " AND COALESCE(played_at, parsed_at)::date <= :date_to::date"
         params["date_to"] = date_to
 
     rows = (


### PR DESCRIPTION
## Summary

- Fixes dashboard date filter showing "Stats unavailable" when any date range is selected
- asyncpg sends Python `str` values as PostgreSQL `text` type — comparing `date >= text` fails because PostgreSQL has no implicit `text→date` cast
- Adding explicit `::date` cast to bind params (`:date_from::date`) resolves the type mismatch
- Applied to all three analytics files: `stats.py`, `game_stats.py`, `card_stats.py`

## Test plan

- [ ] Select "Last 7 days" on dashboard — stats should load
- [ ] Select custom date range — stats should load
- [ ] "All time" still works (no regression)
- [ ] Match history date filter still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)