### PR TITLE
fix(analytics): pass datetime.date objects for SQL date bind params

### DIFF
--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -13,6 +13,7 @@ cards, G1/G2/G3 split, opponent archetype and on_play filters.
 from __future__ import annotations
 
 import uuid
+from datetime import date
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -185,11 +186,11 @@ def _build_match_where(
         clauses.append("m.players::text ILIKE :opp_pattern ESCAPE '\\'")
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        clauses.append("COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date")
-        params["date_from"] = date_from
+        clauses.append("COALESCE(m.played_at, m.parsed_at)::date >= :date_from")
+        params["date_from"] = date.fromisoformat(date_from)
     if date_to:
-        clauses.append("COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date")
-        params["date_to"] = date_to
+        clauses.append("COALESCE(m.played_at, m.parsed_at)::date <= :date_to")
+        params["date_to"] = date.fromisoformat(date_to)
     if opponent_archetype_id:
         clauses.append(
             "EXISTS (SELECT 1 FROM parser.match_archetypes opp_ma "

--- a/services/analytics/analytics_service/game_stats.py
+++ b/services/analytics/analytics_service/game_stats.py
@@ -12,6 +12,7 @@ replaced with a JOIN to ``parser.game_players``.
 
 from __future__ import annotations
 
+from datetime import date
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
@@ -113,11 +114,11 @@ async def _load_games_with_context(
         where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date"
-        params["date_from"] = date_from
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
+        params["date_from"] = date.fromisoformat(date_from)
     if date_to:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date"
-        params["date_to"] = date_to
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
+        params["date_to"] = date.fromisoformat(date_to)
 
     rows = (
         await db.execute(
@@ -320,11 +321,11 @@ async def get_game_length(
         where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date"
-        params["date_from"] = date_from
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
+        params["date_from"] = date.fromisoformat(date_from)
     if date_to:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date"
-        params["date_to"] = date_to
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
+        params["date_to"] = date.fromisoformat(date_to)
 
     rows = (
         await db.execute(

--- a/services/analytics/analytics_service/stats.py
+++ b/services/analytics/analytics_service/stats.py
@@ -145,11 +145,11 @@ async def _load_user_matches(
     where = "WHERE user_id = :user_id AND review_status IS NULL"
     params: dict[str, Any] = {"user_id": user_id}
     if date_from:
-        where += " AND COALESCE(played_at, parsed_at)::date >= :date_from::date"
-        params["date_from"] = date_from
+        where += " AND COALESCE(played_at, parsed_at)::date >= :date_from"
+        params["date_from"] = date.fromisoformat(date_from)
     if date_to:
-        where += " AND COALESCE(played_at, parsed_at)::date <= :date_to::date"
-        params["date_to"] = date_to
+        where += " AND COALESCE(played_at, parsed_at)::date <= :date_to"
+        params["date_to"] = date.fromisoformat(date_to)
 
     rows = (
         await db.execute(


### PR DESCRIPTION
## Summary

Fixes dashboard date filter "Stats unavailable" error (broken since v0.9.13).

**Root cause:** Two compounding issues:
1. **v0.9.13**: Raw string date params sent via asyncpg as PostgreSQL `text` type → `date >= text` operator doesn't exist
2. **v0.9.14 attempted fix**: Added `::date` cast to bind params (`:date_from::date`) but SQLAlchemy `text()` mis-parses this — `::` is consumed as a param delimiter, truncating `date_from` → `date_fro`

**Fix:** Convert string dates to `datetime.date` objects via `fromisoformat()` before binding. asyncpg maps Python `date` to PostgreSQL `date` type natively. Same approach used by the working `list_matches` endpoint.

Applied to all three analytics files: `stats.py`, `game_stats.py`, `card_stats.py`.

## Test plan

- [ ] Select "Last 7 days" on dashboard — stats load
- [ ] Select custom date range — stats load  
- [ ] "All time" still works
- [ ] Card performance pagination preserves date filter
- [ ] Format + date filter compose correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)