### PR TITLE
Fix admin match detail 'Match not found' bug

### DIFF
--- a/services/analytics/analytics_service/matches.py
+++ b/services/analytics/analytics_service/matches.py
@@ -17,7 +17,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from analytics_service.db import get_session
-from analytics_service.deps import AuthenticatedUser, require_user
+from analytics_service.deps import AuthenticatedUser, require_admin, require_user
 
 router = APIRouter(prefix="/analytics/matches", tags=["matches"])
 
@@ -56,6 +56,7 @@ class MatchDetail(BaseModel):
     hero_player_name: str | None = None
     played_at: datetime | None = None
     games: list[GameDetail] = Field(default_factory=list)
+    review_status: str | None = None
 
 
 class FormatUpdate(BaseModel):
@@ -74,7 +75,7 @@ async def get_match(
                 """
                 SELECT id, format, format_source, players,
                        COALESCE(played_at, parsed_at) AS played_at,
-                       hero_player_name
+                       hero_player_name, review_status
                 FROM parser.matches
                 WHERE id = :match_id AND user_id = :user_id
                   AND review_status IS NULL
@@ -88,7 +89,7 @@ async def get_match(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"error": "match_not_found"},
         )
-    row_id, fmt, fmt_source, players, played_at, hero_name = match_row
+    row_id, fmt, fmt_source, players, played_at, hero_name, review_st = match_row
     game_rows = (
         await db.execute(
             text(
@@ -122,6 +123,71 @@ async def get_match(
         hero_player_name=hero_name,
         played_at=played_at,
         games=games,
+        review_status=review_st,
+    )
+
+
+@router.get("/admin/{match_id}", response_model=MatchDetail)
+async def get_match_admin(
+    match_id: uuid.UUID,
+    user: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> MatchDetail:
+    """Admin match detail — no user_id or review_status filter."""
+    match_row = (
+        await db.execute(
+            text(
+                """
+                SELECT id, format, format_source, players,
+                       COALESCE(played_at, parsed_at) AS played_at,
+                       hero_player_name, review_status
+                FROM parser.matches
+                WHERE id = :match_id
+                """
+            ),
+            {"match_id": match_id},
+        )
+    ).one_or_none()
+    if match_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "match_not_found"},
+        )
+    row_id, fmt, fmt_source, players, played_at, hero_name, review_st = match_row
+    game_rows = (
+        await db.execute(
+            text(
+                """
+                SELECT g.id, g.game_number, g.winner,
+                       (SELECT MAX(s.turn_number)
+                          FROM parser.game_states s
+                         WHERE s.game_id = g.id) AS turns
+                FROM parser.games g
+                WHERE g.match_id = :match_id
+                ORDER BY g.game_number
+                """
+            ),
+            {"match_id": row_id},
+        )
+    ).all()
+    games = [
+        GameDetail(
+            game_number=int(game_number),
+            winner=winner,
+            turns=int(turns) if turns is not None else None,
+        )
+        for (_game_id, game_number, winner, turns) in game_rows
+    ]
+    raw_players: list[Any] = list(players or [])
+    return MatchDetail(
+        match_id=str(row_id),
+        format=fmt,
+        format_source=fmt_source,
+        players=[str(p) for p in raw_players],
+        hero_player_name=hero_name,
+        played_at=played_at,
+        games=games,
+        review_status=review_st,
     )
 
 

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -606,6 +606,7 @@ class MatchDetail:
     played_at: datetime | None
     hero_player_name: str | None = None
     games: list[GameItem] = field(default_factory=list)
+    review_status: str | None = None
 
 
 def _to_game(payload: dict[str, Any]) -> GameItem:
@@ -629,6 +630,7 @@ def _to_match_detail(payload: dict[str, Any]) -> MatchDetail:
         played_at=_parse_dt(payload.get("played_at")),
         hero_player_name=payload.get("hero_player_name"),
         games=[_to_game(g) for g in (payload.get("games") or [])],
+        review_status=payload.get("review_status"),
     )
 
 
@@ -649,6 +651,29 @@ async def get_match_detail(base_url: str, token: str, match_id: str) -> MatchDet
     if resp.status_code >= 400:
         raise AnalyticsClientError(
             f"analytics GET /matches/{{id}} returned {resp.status_code}: {resp.text}"
+        )
+    return _to_match_detail(resp.json())
+
+
+async def admin_get_match_detail(base_url: str, token: str, match_id: str) -> MatchDetail | None:
+    """Admin: fetch any match regardless of owner/review status. Returns None on 404."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/analytics/matches/admin/{match_id}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AnalyticsClientError(
+            f"analytics GET /matches/admin/{{id}} transport error: {exc}"
+        ) from exc
+    if resp.status_code == 404:
+        return None
+    if resp.status_code in (401, 403):
+        raise AnalyticsForbidden(f"analytics GET /matches/admin/{{id}} returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AnalyticsClientError(
+            f"analytics GET /matches/admin/{{id}} returned {resp.status_code}: {resp.text}"
         )
     return _to_match_detail(resp.json())
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -3477,6 +3477,7 @@ async def admin_match_detail_page(
             "overall_result": overall_result,
             "review_status": match.review_status,
             "format_options": _MATCH_FORMAT_OPTIONS,
+            "admin_view": True,
         },
     )
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -1151,6 +1151,7 @@ async def match_detail_page(
             "user": user,
             "match": match,
             "overall_result": overall_result,
+            "review_status": match.review_status,
             "format_options": [
                 "Standard",
                 "Pioneer",
@@ -3425,6 +3426,57 @@ async def admin_matches_list(
             "format_options": _MATCH_FORMAT_OPTIONS,
             "error": None,
             "msg": msg,
+        },
+    )
+
+
+@app.get("/admin/matches/{match_id}", response_class=HTMLResponse)
+async def admin_match_detail_page(
+    match_id: uuid.UUID,
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    """Admin match detail — can view any user's match regardless of review status."""
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+    try:
+        match = await analytics_client.admin_get_match_detail(
+            settings.analytics_service_url, user.token, str(match_id)
+        )
+    except analytics_client.AnalyticsForbidden:
+        _log.info("admin.matches.detail.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except analytics_client.AnalyticsClientError:
+        _log.exception("analytics GET /matches/admin/%s call failed", match_id)
+        return Response(
+            content="Analytics service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    if match is None:
+        return Response(content="Match not found.", status_code=status.HTTP_404_NOT_FOUND)
+
+    overall_result = ""
+    if match.players and match.games:
+        hero = match.hero_player_name or match.players[0]
+        user_wins = sum(1 for g in match.games if g.winner == hero)
+        opp_wins = sum(1 for g in match.games if g.winner is not None and g.winner != hero)
+        if user_wins > opp_wins:
+            overall_result = "W"
+        elif user_wins < opp_wins:
+            overall_result = "L"
+        elif user_wins or opp_wins:
+            overall_result = "D"
+    return templates.TemplateResponse(
+        request,
+        "match_detail.html",
+        {
+            "user": user,
+            "match": match,
+            "overall_result": overall_result,
+            "review_status": match.review_status,
+            "format_options": _MATCH_FORMAT_OPTIONS,
         },
     )
 

--- a/services/web/web_service/templates/admin_matches.html
+++ b/services/web/web_service/templates/admin_matches.html
@@ -133,7 +133,7 @@
                     <td class="px-4 py-2.5 text-sm font-mono text-right dark:text-txt-primary text-txt-primary-light">{{ m.game_count }}</td>
                     <td class="px-4 py-2.5 text-sm">
                         {% if m.played_at %}
-                            <a href="/matches/{{ m.match_id }}" class="text-accent hover:text-accent-hover font-mono text-xs">{{ m.played_at.strftime("%Y-%m-%d %H:%M") }}</a>
+                            <a href="/admin/matches/{{ m.match_id }}" class="text-accent hover:text-accent-hover font-mono text-xs">{{ m.played_at.strftime("%Y-%m-%d %H:%M") }}</a>
                         {% else %}
                             —
                         {% endif %}

--- a/services/web/web_service/templates/match_detail.html
+++ b/services/web/web_service/templates/match_detail.html
@@ -4,7 +4,11 @@
 
 {% block content %}
 <div class="mb-6">
+    {% if admin_view|default(false) %}
+    <a href="/admin/matches" class="text-xs text-accent hover:text-accent-hover">&larr; Back to match list</a>
+    {% else %}
     <a href="/dashboard" class="text-xs text-accent hover:text-accent-hover">&larr; Back to dashboard</a>
+    {% endif %}
 </div>
 
 {% if review_status %}
@@ -35,6 +39,9 @@
             </div>
             <div>
                 <span class="text-xs dark:text-txt-secondary text-txt-secondary-light">Format</span>
+                {% if admin_view|default(false) %}
+                <p class="text-sm dark:text-txt-primary text-txt-primary-light">{{ match.format_ or "—" }}</p>
+                {% else %}
                 <form method="post" action="/matches/{{ match.match_id }}/format" class="inline">
                     <select name="format" onchange="this.form.submit()"
                             class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-2 py-1 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none">
@@ -49,6 +56,7 @@
                         {% endfor %}
                     </select>
                 </form>
+                {% endif %}
             </div>
             <div>
                 <span class="text-xs dark:text-txt-secondary text-txt-secondary-light">Players</span>
@@ -112,12 +120,14 @@
                         {% endif %}
                     </td>
                     <td class="px-4 py-2.5 text-right">
+                        {% if not admin_view|default(false) %}
                         <button class="border dark:border-border border-border-light dark:text-txt-primary text-txt-primary-light hover:dark:bg-surface-2 hover:bg-surface-light-3 rounded-md px-2 py-1 text-xs transition-colors"
                             hx-get="/matches/{{ match.match_id }}/games/{{ game.game_number }}/turns"
                             hx-target="#turns-{{ game.game_number }}"
                             hx-swap="innerHTML">
                             Show turns
                         </button>
+                        {% endif %}
                     </td>
                 </tr>
                 <tr>

--- a/services/web/web_service/templates/match_detail.html
+++ b/services/web/web_service/templates/match_detail.html
@@ -7,6 +7,18 @@
     <a href="/dashboard" class="text-xs text-accent hover:text-accent-hover">&larr; Back to dashboard</a>
 </div>
 
+{% if review_status %}
+{% if review_status == "rejected" %}
+<div class="bg-danger-muted border border-danger/20 text-danger rounded-md p-3 text-sm mb-4">
+    Held for review: {{ review_status | replace('_', ' ') }}
+</div>
+{% else %}
+<div class="bg-warning/10 border border-warning/20 text-warning rounded-md p-3 text-sm mb-4">
+    Held for review: {{ review_status | replace('_', ' ') }}
+</div>
+{% endif %}
+{% endif %}
+
 <div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md mb-6 overflow-hidden">
     {# Match header info bar #}
     <div class="px-4 py-4 border-b dark:border-border border-border-light">


### PR DESCRIPTION
## Summary

- Adds admin-only match detail endpoint (`GET /analytics/matches/admin/{match_id}`) that skips the `user_id` and `review_status IS NULL` filters, so admins can view any user's match including held ones
- Adds `review_status` field to the `MatchDetail` response model and surfaces it as a warning/danger banner on the match detail page
- Fixes the admin matches list to link to `/admin/matches/{id}` instead of `/matches/{id}`

## What was broken

Clicking a match on the admin match review page (`/admin/matches`) navigated to `/matches/{match_id}`, the user-facing endpoint. That endpoint filters by `WHERE user_id = :user_id AND review_status IS NULL`, so an admin viewing another user's match or a held match always got "Match not found."

## Changes

| File | Change |
|------|--------|
| `services/analytics/analytics_service/matches.py` | New `GET /admin/{match_id}` endpoint (admin-only, no user/review filters); added `review_status` to `MatchDetail` model and existing query |
| `services/web/web_service/analytics_client.py` | New `admin_get_match_detail()` client function; added `review_status` to `MatchDetail` dataclass and `_to_match_detail` |
| `services/web/web_service/main.py` | New `GET /admin/matches/{match_id}` web route with admin auth; passes `review_status` to template context |
| `services/web/web_service/templates/admin_matches.html` | Match detail link changed from `/matches/` to `/admin/matches/` |
| `services/web/web_service/templates/match_detail.html` | Added review status banner (warning for pending, danger for rejected) |

## Test plan

- [x] Ruff lint and format pass on all changed files
- [x] Web service tests pass (279/279)
- [ ] Verify admin can click a match on `/admin/matches` and see the detail page
- [ ] Verify held matches show the review status banner (pending review / rejected)
- [ ] Verify regular users still see their own matches normally via `/matches/{id}`

Generated with [Claude Code](https://claude.com/claude-code)