### PR TITLE
Fix parser backfill bugs: DetachedInstanceError + CardinalityViolationError

### DIFF
--- a/services/parser/parser_service/consumer.py
+++ b/services/parser/parser_service/consumer.py
@@ -332,8 +332,12 @@ class ParserConsumer:
             except Exception:  # noqa: BLE001
                 _log.debug("deck-to-match link failed sha=%s", sha256)
 
+            # Capture ORM attributes before leaving the session scope —
+            # accessing them after close raises DetachedInstanceError.
+            match_id_str = str(match.id)
+
         out: MatchParsedPayload = {
-            "match_id": str(match.id),
+            "match_id": match_id_str,
             "user_id": str(user_id),
             "game_count": parsed.game_count,
             "parsed_at": datetime.now(UTC).isoformat(),
@@ -341,11 +345,11 @@ class ParserConsumer:
         try:
             await self._publisher.publish(MATCH_PARSED, dict(out))
         except Exception:  # noqa: BLE001 — best-effort
-            _log.exception("match.parsed publish failed match_id=%s", match.id)
+            _log.exception("match.parsed publish failed match_id=%s", match_id_str)
 
         _log.info(
             "match parsed match_id=%s sha=%s user_id=%s games=%s",
-            match.id,
+            match_id_str,
             sha256,
             user_id,
             parsed.game_count,

--- a/services/parser/parser_service/persistence.py
+++ b/services/parser/parser_service/persistence.py
@@ -367,8 +367,13 @@ async def persist_match(
         await session.flush()  # populate game.id
 
         if parsed_game.turns:
-            turn_values = [
-                {
+            # Deduplicate by turn_number — duplicate (game_id, turn_number)
+            # pairs in a single INSERT ... ON CONFLICT DO UPDATE cause
+            # CardinalityViolationError. Keep the last occurrence so later
+            # snapshots of the same turn override earlier ones.
+            seen_turns: dict[int, dict] = {}
+            for turn in parsed_game.turns:
+                seen_turns[turn.turn_number] = {
                     "game_id": game.id,
                     "turn_number": turn.turn_number,
                     "active_player": turn.active_player,
@@ -377,8 +382,7 @@ async def persist_match(
                     },
                     "stack": [entry.model_dump() for entry in turn.stack],
                 }
-                for turn in parsed_game.turns
-            ]
+            turn_values = list(seen_turns.values())
             gs_stmt = pg_insert(GameState).values(turn_values)
             gs_stmt = gs_stmt.on_conflict_do_update(
                 constraint="uq_game_states_game_turn",


### PR DESCRIPTION
## Summary

Two parser bugs causing ~80% of match parses to fail, blocking the backfill scanner.

- **Bug A — DetachedInstanceError in consumer.py:** `match.id` (a SQLAlchemy ORM attribute) was accessed after the `async with session` block closed at line 334, raising `DetachedInstanceError`. Fixed by capturing `match.id` into a local variable (`match_id_str`) before the session block exits.

- **Bug B — CardinalityViolationError in persistence.py:** When `parsed_game.turns` contains duplicate `(game_id, turn_number)` pairs, the bulk `INSERT ... ON CONFLICT DO UPDATE` fails because PostgreSQL cannot affect the same row twice in one statement. Fixed by deduplicating `turn_values` by `turn_number` before the insert, keeping the last occurrence.

The events section (also using `INSERT ... ON CONFLICT DO UPDATE`) was verified safe — `seq` is generated from `enumerate()` so duplicates are not possible there.

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] 186 parser unit tests pass (20 DB-dependent tests skipped as expected)
- [ ] CI compose-smoke E2E gate
- [ ] Verify backfill scanner completes without DetachedInstanceError or CardinalityViolationError in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)