### PR TITLE
Add postgres and redis Prometheus exporter sidecars

### DIFF
--- a/ci/smoke_e2e.sh
+++ b/ci/smoke_e2e.sh
@@ -61,6 +61,12 @@ echo "--- Infrastructure probes ---"
 status=$(http_status "$BASE_URL/metrics")
 check "GET /metrics → 200" "200" "$status"
 
+status=$(http_status "$BASE_URL/postgres/metrics")
+check "GET /postgres/metrics → 200" "200" "$status"
+
+status=$(http_status "$BASE_URL/redis/metrics")
+check "GET /redis/metrics → 200" "200" "$status"
+
 # --------------------------------------------------------------------------
 # 1. Auth gate checks (no credentials)
 # --------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     networks:
       - backend
     environment:
-      DATA_SOURCE_NAME: "postgresql://deep_analysis:${POSTGRES_PASSWORD}@postgres:5432/deep_analysis?sslmode=disable"
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/deep_analysis?sslmode=disable"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,27 @@ services:
       timeout: 5s
       retries: 5
 
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.16.0
+    restart: unless-stopped
+    networks:
+      - backend
+    environment:
+      DATA_SOURCE_NAME: "postgresql://deep_analysis:${POSTGRES_PASSWORD}@postgres:5432/deep_analysis?sslmode=disable"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.67.0
+    restart: unless-stopped
+    networks:
+      - backend
+    environment:
+      REDIS_ADDR: "redis://redis:6379"
+    depends_on:
+      - redis
+
   # One-shot jobs: apply alembic migrations on `compose up` and exit 0. The
   # deploy wrapper on docker.int rejects `compose exec`, so migrations have
   # to run as part of `compose up`. Ordering is enforced by depends_on with

--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -66,6 +66,16 @@
         }
     }
 
+    handle /postgres/metrics {
+        rewrite * /metrics
+        reverse_proxy postgres-exporter:9187
+    }
+
+    handle /redis/metrics {
+        rewrite * /metrics
+        reverse_proxy redis-exporter:9121
+    }
+
     # Bounded keepalive recycles pooled connections every 30s so a
     # silently-replaced upstream container can't strand a stale pool
     # entry between deploys.


### PR DESCRIPTION
## Summary

- Adds `postgres-exporter` (prometheuscommunity/postgres-exporter:v0.16.0) and `redis-exporter` (oliver006/redis_exporter:v1.67.0) as sidecar services in docker-compose.yml
- Routes `/postgres/metrics` and `/redis/metrics` through the gateway Caddyfile to the new exporters
- Adds E2E smoke probes for both new metrics endpoints
- No deploy script changes needed — the rewriter already skips services with only `image:` (no `build:` key)

## Files changed

- `docker-compose.yml` — two new services after `redis`
- `gateway/Caddyfile` — two new handle blocks for exporter metrics
- `ci/smoke_e2e.sh` — two new infrastructure probe checks

## Test plan

- [ ] CI compose-smoke gate passes (includes new `/postgres/metrics` and `/redis/metrics` probes)
- [ ] Verify `docker compose up -d` starts both exporters with healthy dependencies
- [ ] Confirm `/postgres/metrics` returns Prometheus text format with `pg_` prefixed metrics
- [ ] Confirm `/redis/metrics` returns Prometheus text format with `redis_` prefixed metrics
- [ ] Verify deploy rewriter produces correct prod compose (exporters keep their `image:` refs, no GHCR rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)