### PR TITLE
fix(parser): capture match.id immediately after persist to avoid MissingGreenlet

### DIFF
--- a/services/parser/parser_service/consumer.py
+++ b/services/parser/parser_service/consumer.py
@@ -229,6 +229,9 @@ class ParserConsumer:
                 await session.rollback()
                 return parsed
 
+            match_id = match.id
+            match_id_str = str(match_id)
+
             # Skip format inference when an admin has manually set the
             # format — format_source='manual' is authoritative and must
             # survive both reparsing and inference.
@@ -283,7 +286,7 @@ class ParserConsumer:
                     if hero_player_name and hero_result:
                         ma_values.append(
                             {
-                                "match_id": match.id,
+                                "match_id": match_id,
                                 "player_name": hero_player_name,
                                 "archetype_id": hero_result.archetype_id,
                                 "confidence": hero_result.confidence,
@@ -294,7 +297,7 @@ class ParserConsumer:
                     if opponent_name and opp_result:
                         ma_values.append(
                             {
-                                "match_id": match.id,
+                                "match_id": match_id,
                                 "player_name": opponent_name,
                                 "archetype_id": opp_result.archetype_id,
                                 "confidence": opp_result.confidence,
@@ -328,13 +331,9 @@ class ParserConsumer:
 
             # Deck-to-match linking — best-effort.
             try:
-                await link_deck_to_match(session, match.id, user_id, match.format)
+                await link_deck_to_match(session, match_id, user_id, match.format)
             except Exception:  # noqa: BLE001
                 _log.debug("deck-to-match link failed sha=%s", sha256)
-
-            # Capture ORM attributes before leaving the session scope —
-            # accessing them after close raises DetachedInstanceError.
-            match_id_str = str(match.id)
 
         out: MatchParsedPayload = {
             "match_id": match_id_str,


### PR DESCRIPTION
## Summary

- Fixes `MissingGreenlet` errors still occurring after PR #94's DetachedInstanceError fix
- Root cause: `match_id_str = str(match.id)` was at the end of the session block, after multiple `session.commit()` and `session.rollback()` calls had expired the ORM attributes
- Fix: capture `match.id` immediately after `persist_match()` returns (before any commits), use the captured UUID for all downstream references

Confirmed via Loki logs that the error was still happening at 05:12 UTC on v0.9.16 (post PR #94 deploy).

## Test plan

- [ ] Deploy and monitor Loki: `{compose_project="deep-analysis", compose_service="parser"} |~ "MissingGreenlet"` should go silent
- [ ] Backfill scanner progresses (parsed count climbs on /profile/agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)