### PR TITLE
Fix: backfill processes newest uploads first

### DIFF
--- a/services/parser/parser_service/backfill.py
+++ b/services/parser/parser_service/backfill.py
@@ -30,7 +30,7 @@ _log = logging.getLogger("parser.backfill")
 
 _UNPARSED_SQL = text(
     """
-    SELECT DISTINCT u.sha256, u.user_id
+    SELECT u.sha256, u.user_id
       FROM ingest.user_uploads u
       JOIN ingest.game_log_files g ON g.sha256 = u.sha256
       LEFT JOIN parser.matches m
@@ -41,6 +41,8 @@ _UNPARSED_SQL = text(
            OR m.parsed_with_version IS NULL
            OR m.parsed_with_version < :min_version
        )
+     GROUP BY u.sha256, u.user_id
+     ORDER BY MAX(u.uploaded_at) DESC
      LIMIT :batch_size
     """
 )

--- a/services/parser/tests/test_backfill.py
+++ b/services/parser/tests/test_backfill.py
@@ -1,0 +1,29 @@
+"""Tests for the backfill scanner (``parser_service.backfill``).
+
+Verifies that the unparsed-files query processes newest uploads first so
+that when the same logical match has multiple snapshots (partial
+mid-match + complete post-match), the complete one is parsed first and
+the quality gate correctly discards the partials.
+"""
+
+from __future__ import annotations
+
+
+def test_unparsed_sql_orders_newest_first() -> None:
+    """The backfill SQL must ORDER BY upload timestamp descending so that
+    the newest snapshot of a match is processed before older partials."""
+    from parser_service.backfill import _UNPARSED_SQL
+
+    sql = _UNPARSED_SQL.text.lower()
+    assert "order by" in sql, "_UNPARSED_SQL is missing ORDER BY clause"
+    # Verify it orders by the most recent upload time, descending.
+    assert "max(u.uploaded_at)" in sql, "_UNPARSED_SQL should order by MAX(u.uploaded_at)"
+    assert "desc" in sql.split("order by")[1], "_UNPARSED_SQL ORDER BY must be DESC (newest first)"
+
+
+def test_unparsed_sql_uses_group_by() -> None:
+    """GROUP BY is required for the aggregate ORDER BY to work."""
+    from parser_service.backfill import _UNPARSED_SQL
+
+    sql = _UNPARSED_SQL.text.lower()
+    assert "group by u.sha256, u.user_id" in sql, "_UNPARSED_SQL must GROUP BY u.sha256, u.user_id"


### PR DESCRIPTION
## Summary

- Adds `ORDER BY MAX(u.uploaded_at) DESC` to the backfill scanner's unparsed-files query so newest uploads are processed first
- Converts `SELECT DISTINCT` to `GROUP BY` to support the aggregate ordering
- When the same logical match has multiple uploaded snapshots (partial mid-match + complete post-match), processing the complete one first means the quality comparison gate correctly discards the partials

## Test plan

- [x] New unit tests verify the SQL contains `ORDER BY ... DESC` and `GROUP BY` clauses
- [x] Full parser test suite passes (195 passed, 20 skipped for DB-gated tests)
- [x] ruff lint + format clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)