### PR TITLE
Fix: retry archetype classification on transient connection errors

### DIFF
--- a/services/parser/parser_service/analytics_client.py
+++ b/services/parser/parser_service/analytics_client.py
@@ -7,10 +7,16 @@ utility and the parser holds no JWT of its own.
 
 Failures (transport, HTTP non-2xx, malformed payload) are caller-
 swallowed: classification is best-effort and must never fail the parse.
+
+Transient connection errors (container restarts, brief network blips)
+are retried up to ``_MAX_RETRIES`` times with a fixed delay between
+attempts so that a momentary analytics-service outage does not
+permanently lose the classification for affected matches.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from collections.abc import Iterable
@@ -19,6 +25,10 @@ from dataclasses import dataclass
 import httpx
 
 _log = logging.getLogger("parser.analytics_client")
+
+# Retry parameters for transient connection errors.
+_MAX_RETRIES: int = 2
+_RETRY_DELAY_SECONDS: float = 2.0
 
 
 @dataclass
@@ -55,18 +65,17 @@ async def classify_with_confidence(
     """Call analytics' classify endpoint, return id + confidence.
 
     Returns ``None`` under the same conditions as :func:`classify`.
+
+    Transient connection errors (:class:`httpx.ConnectError`,
+    :class:`httpx.TimeoutException`) are retried up to
+    ``_MAX_RETRIES`` times with a fixed delay.  Non-transient failures
+    (HTTP 4xx/5xx, malformed response) are **not** retried.
     """
     if not base_url:
         return None
     payload = {"card_names": list(card_names)}
-    try:
-        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
-            resp = await client.post(
-                f"{base_url}/analytics/archetypes/classify",
-                json=payload,
-            )
-    except httpx.HTTPError:
-        _log.exception("analytics classify transport error url=%s", base_url)
+    resp = await _post_with_retry(base_url, payload, timeout_seconds=timeout_seconds)
+    if resp is None:
         return None
     if resp.status_code >= 400:
         _log.warning(
@@ -90,3 +99,49 @@ async def classify_with_confidence(
         return None
     confidence = float(data.get("confidence", 0.0))
     return ClassifyResult(archetype_id=aid, confidence=confidence)
+
+
+async def _post_with_retry(
+    base_url: str,
+    payload: dict[str, list[str]],
+    *,
+    timeout_seconds: float = 5.0,
+) -> httpx.Response | None:
+    """POST to the classify endpoint, retrying on transient errors.
+
+    Retries only on :class:`httpx.ConnectError` and
+    :class:`httpx.TimeoutException` — the kind of failures caused by a
+    container restart or momentary network hiccup.  All other
+    ``HTTPError`` subclasses bubble up immediately (the caller will
+    still swallow them, but they won't delay the parse with pointless
+    retries).
+    """
+    url = f"{base_url}/analytics/archetypes/classify"
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES + 1):  # 0, 1, 2 → three total attempts
+        try:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+                return await client.post(url, json=payload)
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            last_exc = exc
+            if attempt < _MAX_RETRIES:
+                _log.warning(
+                    "analytics classify transient error (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1,
+                    _MAX_RETRIES + 1,
+                    _RETRY_DELAY_SECONDS,
+                    exc,
+                )
+                await asyncio.sleep(_RETRY_DELAY_SECONDS)
+            else:
+                _log.exception(
+                    "analytics classify failed after %d attempts url=%s",
+                    _MAX_RETRIES + 1,
+                    base_url,
+                )
+        except httpx.HTTPError:
+            _log.exception("analytics classify transport error url=%s", base_url)
+            return None
+    # All retries exhausted — log was already emitted above.
+    assert last_exc is not None  # guaranteed by the loop logic
+    return None

--- a/services/parser/tests/test_analytics_client_retry.py
+++ b/services/parser/tests/test_analytics_client_retry.py
@@ -1,0 +1,225 @@
+"""Tests for analytics_client retry behaviour on transient errors.
+
+Verifies that ``classify_with_confidence`` retries on
+:class:`httpx.ConnectError` and :class:`httpx.TimeoutException` but
+does **not** retry on HTTP 4xx responses or other transport errors.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from parser_service.analytics_client import _MAX_RETRIES, classify_with_confidence
+
+_ASYNC_CLIENT = "parser_service.analytics_client.httpx.AsyncClient"
+_ASYNC_SLEEP = "parser_service.analytics_client.asyncio.sleep"
+
+
+def _ok_response(
+    archetype_id: uuid.UUID | None = None,
+    confidence: float = 0.85,
+) -> httpx.Response:
+    """Build a synthetic 200 response with a valid classify payload."""
+    aid = archetype_id or uuid.uuid4()
+    return httpx.Response(
+        200,
+        json={"archetype_id": str(aid), "confidence": confidence},
+        request=httpx.Request(
+            "POST",
+            "http://analytics:8000/analytics/archetypes/classify",
+        ),
+    )
+
+
+def _400_response() -> httpx.Response:
+    return httpx.Response(
+        400,
+        text="bad request",
+        request=httpx.Request(
+            "POST",
+            "http://analytics:8000/analytics/archetypes/classify",
+        ),
+    )
+
+
+# ---- Retry on ConnectError then succeed ----
+
+
+@pytest.mark.asyncio
+async def test_retries_on_connect_error_then_succeeds() -> None:
+    """First attempt raises ConnectError, second succeeds."""
+    expected_id = uuid.uuid4()
+    ok = _ok_response(archetype_id=expected_id)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        side_effect=[httpx.ConnectError("connection refused"), ok],
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch(_ASYNC_CLIENT, return_value=mock_client),
+        patch(_ASYNC_SLEEP, new_callable=AsyncMock) as mock_sleep,
+    ):
+        result = await classify_with_confidence(
+            "http://analytics:8000",
+            ["Lightning Bolt", "Mountain"],
+        )
+
+    assert result is not None
+    assert result.archetype_id == expected_id
+    assert mock_client.post.call_count == 2
+    mock_sleep.assert_awaited_once()
+
+
+# ---- Retry on TimeoutException then succeed ----
+
+
+@pytest.mark.asyncio
+async def test_retries_on_timeout_then_succeeds() -> None:
+    """First attempt times out, second succeeds."""
+    expected_id = uuid.uuid4()
+    ok = _ok_response(archetype_id=expected_id)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        side_effect=[httpx.TimeoutException("read timed out"), ok],
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch(_ASYNC_CLIENT, return_value=mock_client),
+        patch(_ASYNC_SLEEP, new_callable=AsyncMock),
+    ):
+        result = await classify_with_confidence(
+            "http://analytics:8000",
+            ["Counterspell"],
+        )
+
+    assert result is not None
+    assert mock_client.post.call_count == 2
+
+
+# ---- All retries exhausted ----
+
+
+@pytest.mark.asyncio
+async def test_returns_none_after_all_retries_exhausted() -> None:
+    """Every attempt fails with ConnectError — returns None."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        side_effect=httpx.ConnectError("connection refused"),
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch(_ASYNC_CLIENT, return_value=mock_client),
+        patch(_ASYNC_SLEEP, new_callable=AsyncMock) as mock_sleep,
+    ):
+        result = await classify_with_confidence(
+            "http://analytics:8000",
+            ["Bolt"],
+        )
+
+    assert result is None
+    assert mock_client.post.call_count == _MAX_RETRIES + 1
+    assert mock_sleep.await_count == _MAX_RETRIES
+
+
+# ---- No retry on 4xx ----
+
+
+@pytest.mark.asyncio
+async def test_no_retry_on_4xx() -> None:
+    """HTTP 400 is not retried — returns None immediately."""
+    bad = _400_response()
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=bad)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch(_ASYNC_CLIENT, return_value=mock_client),
+        patch(_ASYNC_SLEEP, new_callable=AsyncMock) as mock_sleep,
+    ):
+        result = await classify_with_confidence(
+            "http://analytics:8000",
+            ["Bolt"],
+        )
+
+    assert result is None
+    assert mock_client.post.call_count == 1
+    mock_sleep.assert_not_awaited()
+
+
+# ---- No retry on non-transient HTTPError ----
+
+
+@pytest.mark.asyncio
+async def test_no_retry_on_generic_http_error() -> None:
+    """A non-transient HTTPError is not retried."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        side_effect=httpx.DecodingError("bad encoding"),
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch(_ASYNC_CLIENT, return_value=mock_client),
+        patch(_ASYNC_SLEEP, new_callable=AsyncMock) as mock_sleep,
+    ):
+        result = await classify_with_confidence(
+            "http://analytics:8000",
+            ["Bolt"],
+        )
+
+    assert result is None
+    assert mock_client.post.call_count == 1
+    mock_sleep.assert_not_awaited()
+
+
+# ---- Empty base_url skips everything ----
+
+
+@pytest.mark.asyncio
+async def test_empty_base_url_returns_none() -> None:
+    """An empty base_url short-circuits without any HTTP call."""
+    result = await classify_with_confidence("", ["Bolt"])
+    assert result is None
+
+
+# ---- Success on first attempt ----
+
+
+@pytest.mark.asyncio
+async def test_no_retry_on_immediate_success() -> None:
+    """When the first call succeeds, no retry delay occurs."""
+    expected_id = uuid.uuid4()
+    ok = _ok_response(archetype_id=expected_id)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=ok)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch(_ASYNC_CLIENT, return_value=mock_client),
+        patch(_ASYNC_SLEEP, new_callable=AsyncMock) as mock_sleep,
+    ):
+        result = await classify_with_confidence(
+            "http://analytics:8000",
+            ["Bolt"],
+        )
+
+    assert result is not None
+    assert result.archetype_id == expected_id
+    assert mock_client.post.call_count == 1
+    mock_sleep.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Adds retry-with-backoff to the parser's analytics client (`classify_with_confidence`) for transient connection errors (`ConnectError`, `TimeoutException`) — the kind caused by analytics container restarts
- Retries up to 2 times with 2-second delays between attempts; non-transient failures (4xx, decoding errors) are not retried
- Previously these errors were silently swallowed by the bare `except` in `consumer.py`, permanently losing archetype classification for affected matches

## Changed files

- `services/parser/parser_service/analytics_client.py` — extracted HTTP POST into `_post_with_retry()` with a simple retry loop; added module-level `_MAX_RETRIES` and `_RETRY_DELAY_SECONDS` constants
- `services/parser/tests/test_analytics_client_retry.py` — 7 new tests covering: retry on ConnectError, retry on TimeoutException, exhausted retries, no retry on 4xx, no retry on generic HTTPError, empty base_url, immediate success

## Test plan

- [x] All 7 new retry tests pass
- [x] Full parser test suite green (195 passed, 20 skipped DB-backed)
- [x] ruff lint clean
- [x] ruff format clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)