### PR TITLE
Fix: coerce date query params to datetime.date in analytics stats

### DIFF
--- a/services/analytics/analytics_service/card_stats.py
+++ b/services/analytics/analytics_service/card_stats.py
@@ -169,8 +169,8 @@ def _build_match_where(
     params: dict[str, Any],
     format_filter: str | None = None,
     opponent: str | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     opponent_archetype_id: str | None = None,
 ) -> str:
     """Build WHERE fragments that filter on parser.matches columns.
@@ -187,10 +187,10 @@ def _build_match_where(
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
         clauses.append("COALESCE(m.played_at, m.parsed_at)::date >= :date_from")
-        params["date_from"] = date.fromisoformat(date_from)
+        params["date_from"] = date_from
     if date_to:
         clauses.append("COALESCE(m.played_at, m.parsed_at)::date <= :date_to")
-        params["date_to"] = date.fromisoformat(date_to)
+        params["date_to"] = date_to
     if opponent_archetype_id:
         clauses.append(
             "EXISTS (SELECT 1 FROM parser.match_archetypes opp_ma "
@@ -253,8 +253,8 @@ async def _card_stats_from_materialized(
     card_name: str | None = None,
     format_filter: str | None = None,
     opponent: str | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     opponent_archetype_id: str | None = None,
     on_play: bool | None = None,
     is_postboard: bool | None = None,
@@ -368,8 +368,8 @@ async def _load_card_appearances(
     card_name: str | None = None,
     format_filter: str | None = None,
     opponent: str | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
 ) -> list[dict[str, Any]]:
     """Load per-game card appearance data using SQL-level JSONB extraction."""
     where = "WHERE m.user_id = :user_id AND m.review_status IS NULL"
@@ -381,10 +381,10 @@ async def _load_card_appearances(
         where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from
     if date_to:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
         params["date_to"] = date_to
 
     if not hero_name:
@@ -446,8 +446,8 @@ async def _load_card_appearances_fallback(
     card_name: str | None = None,
     format_filter: str | None = None,
     opponent: str | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
 ) -> list[dict[str, Any]]:
     """Fallback loader for battlefield entries stored as plain strings."""
     where = "WHERE m.user_id = :user_id AND m.review_status IS NULL"
@@ -459,10 +459,10 @@ async def _load_card_appearances_fallback(
         where += " AND m.players::text ILIKE :opp_pattern ESCAPE '\\'"
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from::date"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
         params["date_from"] = date_from
     if date_to:
-        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to::date"
+        where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
         params["date_to"] = date_to
 
     rows = (
@@ -546,8 +546,8 @@ async def _load_card_appearances_auto(
     card_name: str | None = None,
     format_filter: str | None = None,
     opponent: str | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
 ) -> list[dict[str, Any]]:
     """Try the fast SQL path first; fall back to Python extraction."""
     results = await _load_card_appearances(
@@ -615,8 +615,8 @@ async def get_card_stats(
     sort_dir: Annotated[str | None, Query()] = None,
     format: Annotated[str | None, Query()] = None,
     opponent: Annotated[str | None, Query()] = None,
-    date_from: Annotated[str | None, Query()] = None,
-    date_to: Annotated[str | None, Query()] = None,
+    date_from: Annotated[date | None, Query()] = None,
+    date_to: Annotated[date | None, Query()] = None,
     opponent_archetype_id: Annotated[uuid.UUID | None, Query()] = None,
     on_play: Annotated[bool | None, Query()] = None,
     is_postboard: Annotated[bool | None, Query()] = None,

--- a/services/analytics/analytics_service/game_stats.py
+++ b/services/analytics/analytics_service/game_stats.py
@@ -92,8 +92,8 @@ async def _load_games_with_context(
     user_id: int,
     format_filter: str | None = None,
     opponent: str | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
 ) -> list[dict[str, Any]]:
     """Load all games with match context for a user.
 
@@ -115,10 +115,10 @@ async def _load_games_with_context(
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
-        params["date_from"] = date.fromisoformat(date_from)
+        params["date_from"] = date_from
     if date_to:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
-        params["date_to"] = date.fromisoformat(date_to)
+        params["date_to"] = date_to
 
     rows = (
         await db.execute(
@@ -169,8 +169,8 @@ async def get_play_draw(
     db: AsyncSession = Depends(get_session),
     format: Annotated[str | None, Query()] = None,
     opponent: Annotated[str | None, Query()] = None,
-    date_from: Annotated[str | None, Query()] = None,
-    date_to: Annotated[str | None, Query()] = None,
+    date_from: Annotated[date | None, Query()] = None,
+    date_to: Annotated[date | None, Query()] = None,
 ) -> PlayDrawResponse:
     """Win rate on the play vs on the draw."""
     games = await _load_games_with_context(
@@ -212,8 +212,8 @@ async def get_preboard_postboard(
     db: AsyncSession = Depends(get_session),
     format: Annotated[str | None, Query()] = None,
     opponent: Annotated[str | None, Query()] = None,
-    date_from: Annotated[str | None, Query()] = None,
-    date_to: Annotated[str | None, Query()] = None,
+    date_from: Annotated[date | None, Query()] = None,
+    date_to: Annotated[date | None, Query()] = None,
 ) -> PrePostBoardResponse:
     """Win rate in game 1 (pre-board) vs games 2-3 (post-board)."""
     games = await _load_games_with_context(
@@ -251,8 +251,8 @@ async def get_mulligans(
     db: AsyncSession = Depends(get_session),
     format: Annotated[str | None, Query()] = None,
     opponent: Annotated[str | None, Query()] = None,
-    date_from: Annotated[str | None, Query()] = None,
-    date_to: Annotated[str | None, Query()] = None,
+    date_from: Annotated[date | None, Query()] = None,
+    date_to: Annotated[date | None, Query()] = None,
 ) -> list[MulliganBucket]:
     """Frequency and win rate by opening hand size."""
     games = await _load_games_with_context(
@@ -304,8 +304,8 @@ async def get_game_length(
     db: AsyncSession = Depends(get_session),
     format: Annotated[str | None, Query()] = None,
     opponent: Annotated[str | None, Query()] = None,
-    date_from: Annotated[str | None, Query()] = None,
-    date_to: Annotated[str | None, Query()] = None,
+    date_from: Annotated[date | None, Query()] = None,
+    date_to: Annotated[date | None, Query()] = None,
 ) -> list[GameLengthBucket]:
     """Turns distribution bucketed into ranges.
 
@@ -322,10 +322,10 @@ async def get_game_length(
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
-        params["date_from"] = date.fromisoformat(date_from)
+        params["date_from"] = date_from
     if date_to:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
-        params["date_to"] = date.fromisoformat(date_to)
+        params["date_to"] = date_to
 
     rows = (
         await db.execute(

--- a/services/analytics/analytics_service/stats.py
+++ b/services/analytics/analytics_service/stats.py
@@ -127,8 +127,8 @@ async def _load_user_matches(
     db: AsyncSession,
     user_id: int,
     *,
-    date_from: str | None = None,
-    date_to: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch a user's matches plus per-match game-winner counts.
 
@@ -146,10 +146,10 @@ async def _load_user_matches(
     params: dict[str, Any] = {"user_id": user_id}
     if date_from:
         where += " AND COALESCE(played_at, parsed_at)::date >= :date_from"
-        params["date_from"] = date.fromisoformat(date_from)
+        params["date_from"] = date_from
     if date_to:
         where += " AND COALESCE(played_at, parsed_at)::date <= :date_to"
-        params["date_to"] = date.fromisoformat(date_to)
+        params["date_to"] = date_to
 
     rows = (
         await db.execute(
@@ -248,8 +248,8 @@ def _summarize(
 async def get_summary(
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
-    date_from: Annotated[str | None, Query()] = None,
-    date_to: Annotated[str | None, Query()] = None,
+    date_from: Annotated[date | None, Query()] = None,
+    date_to: Annotated[date | None, Query()] = None,
 ) -> StatsSummary:
     redis_client = await _get_redis_or_none()
     ck = cache_key(user.user_id, "summary", date_from=date_from, date_to=date_to)
@@ -268,8 +268,8 @@ async def get_summary(
 async def get_by_format(
     user: AuthenticatedUser = Depends(require_user),
     db: AsyncSession = Depends(get_session),
-    date_from: Annotated[str | None, Query()] = None,
-    date_to: Annotated[str | None, Query()] = None,
+    date_from: Annotated[date | None, Query()] = None,
+    date_to: Annotated[date | None, Query()] = None,
 ) -> list[FormatStat]:
     redis_client = await _get_redis_or_none()
     ck = cache_key(user.user_id, "by-format", date_from=date_from, date_to=date_to)
@@ -468,10 +468,10 @@ async def list_matches(
         params["opp_pattern"] = f"%{_escape_like(opponent)}%"
     if date_from:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date >= :date_from"
-        params["date_from"] = str(date_from)
+        params["date_from"] = date_from
     if date_to:
         where += " AND COALESCE(m.played_at, m.parsed_at)::date <= :date_to"
-        params["date_to"] = str(date_to)
+        params["date_to"] = date_to
 
     # When there's no result filter, we can paginate in SQL
     has_result_filter = result is not None and result.lower() != "all"

--- a/services/analytics/tests/test_card_stats.py
+++ b/services/analytics/tests/test_card_stats.py
@@ -144,8 +144,8 @@ def _patch_card_loader(
         card_name: str | None = None,
         format_filter: str | None = None,
         opponent: str | None = None,
-        date_from: str | None = None,
-        date_to: str | None = None,
+        date_from: Any = None,
+        date_to: Any = None,
     ) -> list[dict[str, Any]]:
         result = appearances
         if card_name:

--- a/services/analytics/tests/test_review_status_filter.py
+++ b/services/analytics/tests/test_review_status_filter.py
@@ -131,8 +131,8 @@ async def test_summary_loader_filtering_contract(
         _db: Any,
         _user_id: int,
         *,
-        date_from: str | None = None,
-        date_to: str | None = None,
+        date_from: Any = None,
+        date_to: Any = None,
     ) -> list[dict[str, Any]]:
         return matches
 

--- a/services/analytics/tests/test_stats.py
+++ b/services/analytics/tests/test_stats.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 import uuid
 from collections.abc import AsyncIterator, Iterator
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -67,8 +67,8 @@ def _patch_loader(monkeypatch: pytest.MonkeyPatch, matches: list[dict[str, Any]]
         _db: Any,
         _user_id: int,
         *,
-        date_from: str | None = None,
-        date_to: str | None = None,
+        date_from: date | None = None,
+        date_to: date | None = None,
     ) -> list[dict[str, Any]]:
         return matches
 
@@ -97,8 +97,8 @@ def _patch_loader_date_aware(
         _db: Any,
         _user_id: int,
         *,
-        date_from: str | None = None,
-        date_to: str | None = None,
+        date_from: date | None = None,
+        date_to: date | None = None,
     ) -> list[dict[str, Any]]:
         calls.append({"date_from": date_from, "date_to": date_to})
         return matches
@@ -393,8 +393,8 @@ async def test_summary_threads_date_params(
 
     assert r.status_code == 200
     assert len(calls) == 1
-    assert calls[0]["date_from"] == "2026-05-01"
-    assert calls[0]["date_to"] == "2026-05-10"
+    assert calls[0]["date_from"] == date(2026, 5, 1)
+    assert calls[0]["date_to"] == date(2026, 5, 10)
 
 
 @pytest.mark.asyncio
@@ -440,8 +440,45 @@ async def test_by_format_threads_date_params(
 
     assert r.status_code == 200
     assert len(calls) == 1
-    assert calls[0]["date_from"] == "2026-05-01"
-    assert calls[0]["date_to"] == "2026-05-15"
+    assert calls[0]["date_from"] == date(2026, 5, 1)
+    assert calls[0]["date_to"] == date(2026, 5, 15)
+
+
+# ---------------------------------------------------------------------------
+# date_from / date_to coercion — regression for asyncpg DataError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_user_matches_receives_date_objects(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """date_from/date_to must arrive as datetime.date, not str.
+
+    Regression: asyncpg raises DataError when a str is passed where a
+    date is expected ('str' object has no attribute 'toordinal').
+    """
+    from analytics_service import deps as _deps
+    from analytics_service import main as _main
+
+    calls = _patch_loader_date_aware(monkeypatch, [])
+    _main.app.dependency_overrides[_deps.require_user] = _override_user()
+    try:
+        r = await app_client.get(
+            "/analytics/stats/summary",
+            params={"date_from": "2023-12-01", "date_to": "2023-12-26"},
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert len(calls) == 1
+    # The key assertion: values must be date objects, not strings
+    assert isinstance(calls[0]["date_from"], date)
+    assert isinstance(calls[0]["date_to"], date)
+    assert calls[0]["date_from"] == date(2023, 12, 1)
+    assert calls[0]["date_to"] == date(2023, 12, 26)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Bug**: `date_from`/`date_to` query params were passed as strings to asyncpg, which expects `datetime.date` objects. This caused `DataError: invalid input for query argument $2: '2023-12-26' ('str' object has no attribute 'toordinal')` when the dashboard used date filters.
- **Fix**: Changed all `date_from`/`date_to` FastAPI parameter annotations from `str | None` to `date | None` across `stats.py`, `game_stats.py`, and `card_stats.py`. Removed manual `date.fromisoformat()` calls and `str()` wrapping that were papering over or reintroducing the type mismatch. FastAPI/Pydantic now handles the string-to-date coercion at the endpoint boundary.
- Added a regression test (`test_load_user_matches_receives_date_objects`) that verifies date params arrive as `datetime.date` objects, not strings.

## Test plan
- [x] `test_stats.py` — 12 tests pass (including new regression test)
- [x] `test_game_stats.py` — 8 tests pass
- [x] `test_card_stats.py` — 27 tests pass
- [x] `test_review_status_filter.py` — 5 tests pass
- [x] ruff clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)