### PR TITLE
Feature: show review reason in admin match detail

### DIFF
--- a/alembic/versions/029_match_review_reason.py
+++ b/alembic/versions/029_match_review_reason.py
@@ -1,0 +1,40 @@
+"""parser.matches.review_reason: human-readable explanation for review holds.
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-05-26
+
+Adds a nullable ``review_reason`` TEXT column to ``parser.matches``.
+When the consumer sets ``review_status = 'pending_review'``, it also
+writes a concise reason string (e.g. "No game winners resolved
+(3 games observed)") so admins can see WHY a match was held, not just
+that it was.
+
+Existing rows get NULL — the column is informational and existing
+``pending_review`` rows work fine without a reason.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "029"
+down_revision: str | None = "028"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "matches",
+        sa.Column("review_reason", sa.Text(), nullable=True),
+        schema="parser",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("matches", "review_reason", schema="parser")

--- a/services/analytics/analytics_service/matches.py
+++ b/services/analytics/analytics_service/matches.py
@@ -57,6 +57,7 @@ class MatchDetail(BaseModel):
     played_at: datetime | None = None
     games: list[GameDetail] = Field(default_factory=list)
     review_status: str | None = None
+    review_reason: str | None = None
 
 
 class FormatUpdate(BaseModel):
@@ -75,7 +76,7 @@ async def get_match(
                 """
                 SELECT id, format, format_source, players,
                        COALESCE(played_at, parsed_at) AS played_at,
-                       hero_player_name, review_status
+                       hero_player_name, review_status, review_reason
                 FROM parser.matches
                 WHERE id = :match_id AND user_id = :user_id
                   AND review_status IS NULL
@@ -89,7 +90,7 @@ async def get_match(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"error": "match_not_found"},
         )
-    row_id, fmt, fmt_source, players, played_at, hero_name, review_st = match_row
+    row_id, fmt, fmt_source, players, played_at, hero_name, review_st, review_rsn = match_row
     game_rows = (
         await db.execute(
             text(
@@ -124,6 +125,7 @@ async def get_match(
         played_at=played_at,
         games=games,
         review_status=review_st,
+        review_reason=review_rsn,
     )
 
 
@@ -140,7 +142,7 @@ async def get_match_admin(
                 """
                 SELECT id, format, format_source, players,
                        COALESCE(played_at, parsed_at) AS played_at,
-                       hero_player_name, review_status
+                       hero_player_name, review_status, review_reason
                 FROM parser.matches
                 WHERE id = :match_id
                 """
@@ -153,7 +155,7 @@ async def get_match_admin(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"error": "match_not_found"},
         )
-    row_id, fmt, fmt_source, players, played_at, hero_name, review_st = match_row
+    row_id, fmt, fmt_source, players, played_at, hero_name, review_st, review_rsn = match_row
     game_rows = (
         await db.execute(
             text(
@@ -188,6 +190,7 @@ async def get_match_admin(
         played_at=played_at,
         games=games,
         review_status=review_st,
+        review_reason=review_rsn,
     )
 
 

--- a/services/analytics/tests/test_matches.py
+++ b/services/analytics/tests/test_matches.py
@@ -121,7 +121,7 @@ async def test_match_detail_returns_match_with_games(app_client: httpx.AsyncClie
     session = _FakeSession(
         queue=[
             # match row
-            [(match_id, "Modern", "inferred", ["alice", "bob"], played_at, "alice")],
+            [(match_id, "Modern", "inferred", ["alice", "bob"], played_at, "alice", None, None)],
             # games rows: (game_id, game_number, winner, turns)
             [
                 (game_1_id, 1, "alice", 8),
@@ -193,7 +193,7 @@ async def test_match_detail_handles_missing_turns_gracefully(
     game_id = uuid.uuid4()
     session = _FakeSession(
         queue=[
-            [(match_id, None, None, ["alice", "bob"], None, None)],
+            [(match_id, None, None, ["alice", "bob"], None, None, None, None)],
             # turns column is NULL when the parser didn't store game states
             [(game_id, 1, "alice", None)],
         ]

--- a/services/parser/parser_service/consumer.py
+++ b/services/parser/parser_service/consumer.py
@@ -489,10 +489,7 @@ def _build_review_reason(parsed: ParsedMatch) -> str:
 
     # Safety net -- theoretically unreachable when _is_partial_parse is
     # True (it requires *no* game winners).
-    return (
-        f"Partial: {games_with_winners} of {game_count} "
-        f"game{plural} have winners"
-    )
+    return f"Partial: {games_with_winners} of {game_count} game{plural} have winners"
 
 
 def _collect_cards_by_side(

--- a/services/parser/parser_service/consumer.py
+++ b/services/parser/parser_service/consumer.py
@@ -194,6 +194,7 @@ class ParserConsumer:
             return parsed
 
         review_status: str | None = None
+        review_reason: str | None = None
         if _is_partial_parse(parsed):
             # Games observed but no resolved winners anywhere — could
             # be an in-progress MTGO snapshot the agent caught during
@@ -210,6 +211,7 @@ class ParserConsumer:
                 parsed.winner,
             )
             review_status = "pending_review"
+            review_reason = _build_review_reason(parsed)
 
         # Resolve the hero player name from auth.users.mtgo_usernames.
         hero_player_name = await self._resolve_hero(user_id, parsed.players)
@@ -223,6 +225,7 @@ class ParserConsumer:
                     user_id,
                     hero_player_name=hero_player_name,
                     review_status=review_status,
+                    review_reason=review_reason,
                 )
             except Exception:
                 _log.exception("persist failed sha=%s user_id=%s", sha256, user_id)
@@ -469,6 +472,27 @@ def _is_partial_parse(parsed: ParsedMatch) -> bool:
     if parsed.winner:
         return False
     return not any(g.winner for g in parsed.games)
+
+
+def _build_review_reason(parsed: ParsedMatch) -> str:
+    """Build a concise, human-readable reason for why a parse is partial.
+
+    Called only when ``_is_partial_parse(parsed)`` is True -- i.e., games
+    exist but no match-level or per-game winner was resolved.
+    """
+    game_count = len(parsed.games)
+    games_with_winners = sum(1 for g in parsed.games if g.winner)
+    plural = "s" if game_count != 1 else ""
+
+    if games_with_winners == 0:
+        return f"No game winners resolved ({game_count} game{plural} observed)"
+
+    # Safety net -- theoretically unreachable when _is_partial_parse is
+    # True (it requires *no* game winners).
+    return (
+        f"Partial: {games_with_winners} of {game_count} "
+        f"game{plural} have winners"
+    )
 
 
 def _collect_cards_by_side(

--- a/services/parser/parser_service/models.py
+++ b/services/parser/parser_service/models.py
@@ -84,6 +84,7 @@ class Match(Base):
     # ``'rejected'`` = admin discarded; permanently hidden. The DB
     # CHECK constraint (alembic 025) enforces the allowed values.
     review_status: Mapped[str | None] = mapped_column(Text, nullable=True)
+    review_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     deck_composition_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("parser.deck_compositions.id", ondelete="SET NULL"),

--- a/services/parser/parser_service/persistence.py
+++ b/services/parser/parser_service/persistence.py
@@ -129,6 +129,7 @@ async def _insert_new_match(
     raw_match_id: str | None,
     hero_player_name: str | None,
     review_status: str | None,
+    review_reason: str | None,
     now: datetime,
 ) -> uuid.UUID:
     """Insert a fresh ``matches`` row and return its id."""
@@ -148,6 +149,7 @@ async def _insert_new_match(
         parsed_with_version=PARSER_VERSION,
         hero_player_name=hero_player_name,
         review_status=review_status,
+        review_reason=review_reason,
     )
     session.add(match)
     # Flush surfaces unique-violation collisions to the caller without
@@ -165,6 +167,7 @@ async def _update_match_row(
     parsed: ParsedMatch,
     hero_player_name: str | None,
     review_status: str | None,
+    review_reason: str | None,
     existing_review_status: str | None,
     now: datetime,
     preserve_manual_format: bool,
@@ -202,8 +205,10 @@ async def _update_match_row(
     if existing_review_status == "rejected":
         # Preserve admin's rejection — a later snapshot must not undo it.
         values["review_status"] = "rejected"
+        # Keep the original review_reason on rejected rows.
     else:
         values["review_status"] = review_status
+        values["review_reason"] = review_reason
     if not preserve_manual_format:
         values["format"] = parsed.format
         values["format_source"] = None
@@ -217,6 +222,7 @@ async def persist_match(
     user_id: int,
     hero_player_name: str | None = None,
     review_status: str | None = None,
+    review_reason: str | None = None,
 ) -> Match:
     """Insert or update a parsed match (plus games and per-turn states).
 
@@ -307,6 +313,7 @@ async def persist_match(
             parsed=parsed,
             hero_player_name=hero_player_name,
             review_status=review_status,
+            review_reason=review_reason,
             existing_review_status=existing.review_status,
             now=now,
             preserve_manual_format=existing.format_source == "manual",
@@ -321,6 +328,7 @@ async def persist_match(
                 raw_match_id=raw_match_id,
                 hero_player_name=hero_player_name,
                 review_status=review_status,
+                review_reason=review_reason,
                 now=now,
             )
         except IntegrityError:
@@ -341,6 +349,7 @@ async def persist_match(
                 parsed=parsed,
                 hero_player_name=hero_player_name,
                 review_status=review_status,
+                review_reason=review_reason,
                 existing_review_status=existing.review_status,
                 now=now,
                 preserve_manual_format=existing.format_source == "manual",

--- a/services/parser/tests/test_review_reason.py
+++ b/services/parser/tests/test_review_reason.py
@@ -1,0 +1,299 @@
+"""Tests for the review_reason feature.
+
+When a parse is held for review (``review_status='pending_review'``),
+the consumer sets a human-readable ``review_reason`` string explaining
+why. These tests cover:
+
+* ``_build_review_reason`` produces the expected strings.
+* Consumer-level: partial parses land with both ``review_status`` and
+  ``review_reason`` set.
+* Consumer-level: conclusive parses have ``review_reason=NULL``.
+* Persistence-level: a conclusive reparse clears ``review_reason``
+  alongside ``review_status``.
+* Persistence-level: an admin-rejected row keeps its ``review_reason``
+  across reparses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from parser_service.consumer import (
+    ParserConsumer,
+    _build_review_reason,
+)
+from parser_service.models import Match
+from parser_service.parsing.models import ParsedGame, ParsedMatch
+from parser_service.persistence import persist_match
+from sqlalchemy import select
+
+# ---------------------------------------------------------------------------
+# Pure unit tests — _build_review_reason
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReviewReason:
+    def test_single_game_no_winners(self) -> None:
+        parsed = ParsedMatch(
+            players=["alice", "bob"],
+            games=[ParsedGame(game_number=1, winner=None)],
+        )
+        reason = _build_review_reason(parsed)
+        assert "No game winners resolved" in reason
+        assert "1 game observed" in reason
+
+    def test_multiple_games_no_winners(self) -> None:
+        parsed = ParsedMatch(
+            players=["alice", "bob"],
+            games=[
+                ParsedGame(game_number=1, winner=None),
+                ParsedGame(game_number=2, winner=None),
+                ParsedGame(game_number=3, winner=None),
+            ],
+        )
+        reason = _build_review_reason(parsed)
+        assert "No game winners resolved" in reason
+        assert "3 games observed" in reason
+
+    def test_plural_vs_singular(self) -> None:
+        one_game = ParsedMatch(
+            games=[ParsedGame(game_number=1, winner=None)],
+        )
+        two_games = ParsedMatch(
+            games=[
+                ParsedGame(game_number=1, winner=None),
+                ParsedGame(game_number=2, winner=None),
+            ],
+        )
+        assert "1 game observed" in _build_review_reason(one_game)
+        assert "2 games observed" in _build_review_reason(two_games)
+
+
+# ---------------------------------------------------------------------------
+# Consumer-level: review_reason set on partial, absent on conclusive
+# ---------------------------------------------------------------------------
+
+
+class _StubParser:
+    def __init__(self, parsed: ParsedMatch) -> None:
+        self._parsed = parsed
+
+    def parse(self, content: bytes) -> ParsedMatch:
+        return self._parsed
+
+
+class _NoopPublisher:
+    async def publish(self, channel: str, payload: dict[str, Any]) -> None:
+        return None
+
+
+def _session_maker_returning(session: Any) -> Any:
+    class _Wrapper:
+        def __call__(self) -> Any:
+            return _Ctx(session)
+
+    class _Ctx:
+        def __init__(self, s: Any) -> None:
+            self._s = s
+
+        async def __aenter__(self) -> Any:
+            return self._s
+
+        async def __aexit__(self, *exc: Any) -> bool:
+            return False
+
+    return _Wrapper()
+
+
+def _write_raw(raw_root: Path, sha: str) -> None:
+    shard = raw_root / sha[0:2] / sha[2:4]
+    shard.mkdir(parents=True, exist_ok=True)
+    (shard / f"{sha}.dat").write_bytes(b"unused-by-stub-parser")
+
+
+def _consumer_with(parsed: ParsedMatch, sm: Any, raw_root: Path) -> ParserConsumer:
+    class _DummyRedis:
+        def pubsub(self) -> Any:
+            raise NotImplementedError
+
+    consumer = ParserConsumer(
+        redis_client=_DummyRedis(),
+        sessionmaker=sm,
+        raw_root=raw_root,
+        parser=_StubParser(parsed),
+        publisher=_NoopPublisher(),
+    )
+
+    async def _stub_resolve_hero(_user_id: int, players: list[str]) -> str | None:
+        return str(players[0]) if players else None
+
+    consumer._resolve_hero = _stub_resolve_hero
+    return consumer
+
+
+@pytest.mark.asyncio
+async def test_consumer_sets_review_reason_on_partial(parser_session: Any, tmp_path: Path) -> None:
+    sha = "d" * 64
+    _write_raw(tmp_path, sha)
+    partial = ParsedMatch(
+        raw_match_id="reason-uuid-1",
+        players=["alice", "bob"],
+        games=[
+            ParsedGame(game_number=1, winner=None),
+            ParsedGame(game_number=2, winner=None),
+        ],
+    )
+    sm = _session_maker_returning(parser_session)
+    consumer = _consumer_with(partial, sm, tmp_path)
+
+    await consumer.handle_event(sha, user_id=1)
+    parser_session.expire_all()
+
+    row = (await parser_session.execute(select(Match))).scalar_one()
+    assert row.review_status == "pending_review"
+    assert row.review_reason is not None
+    assert "No game winners resolved" in row.review_reason
+    assert "2 games observed" in row.review_reason
+
+
+@pytest.mark.asyncio
+async def test_consumer_no_review_reason_on_conclusive(
+    parser_session: Any, tmp_path: Path
+) -> None:
+    sha = "c" * 64
+    _write_raw(tmp_path, sha)
+    conclusive = ParsedMatch(
+        raw_match_id="reason-uuid-2",
+        players=["alice", "bob"],
+        winner="alice",
+        match_result="2-0",
+        games=[
+            ParsedGame(game_number=1, winner="alice"),
+            ParsedGame(game_number=2, winner="alice"),
+        ],
+    )
+    sm = _session_maker_returning(parser_session)
+    consumer = _consumer_with(conclusive, sm, tmp_path)
+
+    await consumer.handle_event(sha, user_id=1)
+    parser_session.expire_all()
+
+    row = (await parser_session.execute(select(Match))).scalar_one()
+    assert row.review_status is None
+    assert row.review_reason is None
+
+
+# ---------------------------------------------------------------------------
+# Persistence-level: review_reason cleared on conclusive reparse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_reason_cleared_on_conclusive_reparse(parser_session: Any) -> None:
+    raw_id = "reason-logical-1"
+    sha_partial = "e1" + "0" * 62
+    sha_conclusive = "e2" + "0" * 62
+
+    partial = ParsedMatch(
+        raw_match_id=raw_id,
+        players=["alice", "bob"],
+        games=[ParsedGame(game_number=1, winner=None)],
+    )
+    await persist_match(
+        parser_session,
+        partial,
+        sha256=sha_partial,
+        user_id=1,
+        review_status="pending_review",
+        review_reason="No game winners resolved (1 game observed)",
+    )
+
+    parser_session.expire_all()
+    after_partial = (await parser_session.execute(select(Match))).scalar_one()
+    assert after_partial.review_status == "pending_review"
+    assert after_partial.review_reason == "No game winners resolved (1 game observed)"
+
+    conclusive = ParsedMatch(
+        raw_match_id=raw_id,
+        players=["alice", "bob"],
+        winner="alice",
+        match_result="2-0",
+        games=[
+            ParsedGame(game_number=1, winner="alice"),
+            ParsedGame(game_number=2, winner="alice"),
+        ],
+    )
+    await persist_match(
+        parser_session,
+        conclusive,
+        sha256=sha_conclusive,
+        user_id=1,
+        review_status=None,
+        review_reason=None,
+    )
+
+    parser_session.expire_all()
+    after_conclusive = (await parser_session.execute(select(Match))).scalar_one()
+    assert after_conclusive.review_status is None
+    assert after_conclusive.review_reason is None
+
+
+# ---------------------------------------------------------------------------
+# Persistence-level: rejected row preserves review_reason
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rejected_row_preserves_review_reason(parser_session: Any) -> None:
+    raw_id = "reason-logical-2"
+    sha_a = "f1" + "0" * 62
+    sha_b = "f2" + "0" * 62
+
+    rejected = Match(
+        id=uuid.uuid4(),
+        sha256=sha_a,
+        user_id=1,
+        raw_match_id=raw_id,
+        players=["alice", "bob"],
+        winner=None,
+        game_count=1,
+        review_status="rejected",
+        review_reason="No game winners resolved (1 game observed)",
+    )
+    parser_session.add(rejected)
+    await parser_session.commit()
+
+    conclusive = ParsedMatch(
+        raw_match_id=raw_id,
+        players=["alice", "bob"],
+        winner="alice",
+        match_result="2-0",
+        games=[
+            ParsedGame(game_number=1, winner="alice"),
+            ParsedGame(game_number=2, winner="alice"),
+        ],
+    )
+    await persist_match(
+        parser_session,
+        conclusive,
+        sha256=sha_b,
+        user_id=1,
+        review_status=None,
+        review_reason=None,
+    )
+
+    parser_session.expire_all()
+    survivor = (await parser_session.execute(select(Match))).scalar_one()
+    assert survivor.review_status == "rejected"
+    # The reason from the original rejected row is preserved (the update
+    # path skips setting review_reason on rejected rows).
+    assert survivor.review_reason == "No game winners resolved (1 game observed)"
+
+
+@pytest.fixture(autouse=True)
+def _ensure_loop_policy() -> None:
+    asyncio.get_event_loop_policy()

--- a/services/parser/tests/test_review_reason.py
+++ b/services/parser/tests/test_review_reason.py
@@ -161,9 +161,7 @@ async def test_consumer_sets_review_reason_on_partial(parser_session: Any, tmp_p
 
 
 @pytest.mark.asyncio
-async def test_consumer_no_review_reason_on_conclusive(
-    parser_session: Any, tmp_path: Path
-) -> None:
+async def test_consumer_no_review_reason_on_conclusive(parser_session: Any, tmp_path: Path) -> None:
     sha = "c" * 64
     _write_raw(tmp_path, sha)
     conclusive = ParsedMatch(

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -850,6 +850,7 @@ class AdminMatchItem:
     played_at: datetime | None
     is_draw: bool = False
     review_status: str | None = None
+    review_reason: str | None = None
 
 
 @dataclass

--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -607,6 +607,7 @@ class MatchDetail:
     hero_player_name: str | None = None
     games: list[GameItem] = field(default_factory=list)
     review_status: str | None = None
+    review_reason: str | None = None
 
 
 def _to_game(payload: dict[str, Any]) -> GameItem:
@@ -631,6 +632,7 @@ def _to_match_detail(payload: dict[str, Any]) -> MatchDetail:
         hero_player_name=payload.get("hero_player_name"),
         games=[_to_game(g) for g in (payload.get("games") or [])],
         review_status=payload.get("review_status"),
+        review_reason=payload.get("review_reason"),
     )
 
 
@@ -871,6 +873,7 @@ def _to_admin_match(payload: dict[str, Any]) -> AdminMatchItem:
         played_at=_parse_dt(payload.get("played_at")),
         is_draw=bool(payload.get("is_draw") or False),
         review_status=payload.get("review_status"),
+        review_reason=payload.get("review_reason"),
     )
 
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -1163,6 +1163,7 @@ async def match_detail_page(
             "match": match,
             "overall_result": overall_result,
             "review_status": match.review_status,
+            "review_reason": match.review_reason,
             "format_options": [
                 "Standard",
                 "Pioneer",
@@ -3487,6 +3488,7 @@ async def admin_match_detail_page(
             "match": match,
             "overall_result": overall_result,
             "review_status": match.review_status,
+            "review_reason": match.review_reason,
             "format_options": _MATCH_FORMAT_OPTIONS,
             "admin_view": True,
         },

--- a/services/web/web_service/templates/match_detail.html
+++ b/services/web/web_service/templates/match_detail.html
@@ -14,11 +14,17 @@
 {% if review_status %}
 {% if review_status == "rejected" %}
 <div class="bg-danger-muted border border-danger/20 text-danger rounded-md p-3 text-sm mb-4">
-    Held for review: {{ review_status | replace('_', ' ') }}
+    <span class="font-medium">Held for review: {{ review_status | replace('_', ' ') }}</span>
+    {% if review_reason %}
+    <span class="dark:text-danger/80 text-danger/80"> &mdash; {{ review_reason }}</span>
+    {% endif %}
 </div>
 {% else %}
 <div class="bg-warning/10 border border-warning/20 text-warning rounded-md p-3 text-sm mb-4">
-    Held for review: {{ review_status | replace('_', ' ') }}
+    <span class="font-medium">Held for review: {{ review_status | replace('_', ' ') }}</span>
+    {% if review_reason %}
+    <span class="dark:text-warning/80 text-warning/80"> &mdash; {{ review_reason }}</span>
+    {% endif %}
 </div>
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## Summary

- Adds a `review_reason` column to `parser.matches` (Alembic 029) with a human-readable explanation of why a match was held for review
- Parser consumer generates reason strings like "No game winners resolved (3 games observed)" when setting `review_status = 'pending_review'`
- Reason follows the same lifecycle as `review_status`: cleared on conclusive reparse, preserved on admin-rejected rows
- Analytics match detail API includes `review_reason` in both user and admin endpoints
- Admin match detail template displays the reason inline with the status banner

Before: "Held for review: pending review"
After: "Held for review: pending review -- No game winners resolved (3 games observed)"

## Test plan

- [x] Pure unit tests for `_build_review_reason()` (singular/plural, various game counts)
- [x] Consumer-level: partial parse sets both `review_status` and `review_reason`
- [x] Consumer-level: conclusive parse has `review_reason = NULL`
- [x] Persistence-level: conclusive reparse clears `review_reason`
- [x] Persistence-level: admin-rejected row preserves `review_reason` across reparse
- [x] Analytics test fixtures updated for new column count
- [x] Ruff + mypy clean (no new violations)
- [x] Parser test suite: 198 passed, 24 skipped
- [x] Analytics test suite: 221 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)