### PR TITLE
Feature: admin MOTD banner with severity and expiration

### DIFF
--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -774,7 +774,7 @@ async def _read_motd(db: AsyncSession) -> MotdView:
     return MotdView(
         active=True,
         message=message,
-        severity=severity,  # type: ignore[arg-type]
+        severity=severity,
         expires_at=expires_at,
         updated_at=msg_row.updated_at,
         updated_by_user_id=msg_row.updated_by_user_id,

--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -35,10 +35,12 @@ from auth_service.schemas import (
     CreateUserRequest,
     InviteListView,
     InviteView,
+    MotdView,
     RegistrationModeView,
     ResetPasswordResponse,
     RevokeSessionsResponse,
     RotateKeyResponse,
+    SetMotdRequest,
     SetRegistrationModeRequest,
     StaleCleanupResponse,
     TunablesView,
@@ -715,3 +717,129 @@ async def update_tunables(
 
     await db.commit()
     return await _read_all_tunables(db)
+
+
+# ---------------------------------------------------------------------------
+# MOTD (Message of the Day) — admin-configurable site banner
+# ---------------------------------------------------------------------------
+
+_MOTD_MESSAGE_KEY = "motd:message"
+_MOTD_SEVERITY_KEY = "motd:severity"
+_MOTD_EXPIRES_AT_KEY = "motd:expires_at"
+
+
+async def _read_motd(db: AsyncSession) -> MotdView:
+    """Read the current MOTD from server_settings."""
+    rows = (
+        (
+            await db.execute(
+                select(ServerSetting).where(
+                    ServerSetting.key.in_(
+                        [_MOTD_MESSAGE_KEY, _MOTD_SEVERITY_KEY, _MOTD_EXPIRES_AT_KEY]
+                    )
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    by_key = {r.key: r for r in rows}
+    msg_row = by_key.get(_MOTD_MESSAGE_KEY)
+    sev_row = by_key.get(_MOTD_SEVERITY_KEY)
+    exp_row = by_key.get(_MOTD_EXPIRES_AT_KEY)
+
+    if msg_row is None or not msg_row.value:
+        return MotdView(active=False)
+
+    message = str(msg_row.value) if isinstance(msg_row.value, str) else None
+    if not message:
+        return MotdView(active=False)
+
+    severity = str(sev_row.value) if sev_row and isinstance(sev_row.value, str) else "info"
+    if severity not in ("info", "warning"):
+        severity = "info"
+
+    expires_at_str = str(exp_row.value) if exp_row and isinstance(exp_row.value, str) else None
+    expires_at: datetime | None = None
+    if expires_at_str:
+        try:
+            expires_at = datetime.fromisoformat(expires_at_str.replace("Z", "+00:00"))
+        except ValueError:
+            expires_at = None
+
+    if expires_at is not None and expires_at <= datetime.now(UTC):
+        return MotdView(active=False)
+
+    return MotdView(
+        active=True,
+        message=message,
+        severity=severity,  # type: ignore[arg-type]
+        expires_at=expires_at,
+        updated_at=msg_row.updated_at,
+        updated_by_user_id=msg_row.updated_by_user_id,
+    )
+
+
+async def read_motd_public(db: AsyncSession) -> MotdView:
+    """Public accessor for the MOTD."""
+    return await _read_motd(db)
+
+
+@router.get("/settings/motd", response_model=MotdView)
+async def get_motd(
+    _admin: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> MotdView:
+    """Read the current MOTD. Any admin may read."""
+    return await _read_motd(db)
+
+
+@router.put("/settings/motd", response_model=MotdView)
+async def set_motd(
+    body: SetMotdRequest,
+    admin: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> MotdView:
+    """Set or replace the active MOTD. Any admin may write."""
+    now = datetime.now(UTC)
+    updates: dict[str, str] = {
+        _MOTD_MESSAGE_KEY: body.message,
+        _MOTD_SEVERITY_KEY: body.severity,
+        _MOTD_EXPIRES_AT_KEY: body.expires_at,
+    }
+    for key, value in updates.items():
+        row = (
+            await db.execute(select(ServerSetting).where(ServerSetting.key == key))
+        ).scalar_one_or_none()
+        if row is None:
+            row = ServerSetting(
+                key=key,
+                value=value,
+                updated_at=now,
+                updated_by_user_id=admin.user_id,
+            )
+            db.add(row)
+        else:
+            row.value = value
+            row.updated_at = now
+            row.updated_by_user_id = admin.user_id
+
+    await db.commit()
+    return await _read_motd(db)
+
+
+@router.delete("/settings/motd", status_code=status.HTTP_204_NO_CONTENT)
+async def clear_motd(
+    admin: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Clear the active MOTD. Any admin may clear."""
+    for key in (_MOTD_MESSAGE_KEY, _MOTD_SEVERITY_KEY, _MOTD_EXPIRES_AT_KEY):
+        row = (
+            await db.execute(select(ServerSetting).where(ServerSetting.key == key))
+        ).scalar_one_or_none()
+        if row is not None:
+            await db.delete(row)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/services/auth/auth_service/admin.py
+++ b/services/auth/auth_service/admin.py
@@ -765,6 +765,8 @@ async def _read_motd(db: AsyncSession) -> MotdView:
     if expires_at_str:
         try:
             expires_at = datetime.fromisoformat(expires_at_str.replace("Z", "+00:00"))
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=UTC)
         except ValueError:
             expires_at = None
 

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -729,6 +729,15 @@ async def public_registration_mode(
     return {"mode": await _read_registration_mode(db)}
 
 
+@app.get("/auth/motd")
+async def public_motd(
+    db: AsyncSession = Depends(get_session),
+) -> dict[str, object]:
+    """Public read of the active MOTD."""
+    motd = await admin.read_motd_public(db)
+    return motd.model_dump()
+
+
 @app.post(
     "/auth/register",
     response_model=RegisterResponse,

--- a/services/auth/auth_service/schemas.py
+++ b/services/auth/auth_service/schemas.py
@@ -283,3 +283,27 @@ class UpdateTunablesRequest(BaseModel):
         ):
             raise ValueError("at_least_one_field_required")
         return self
+
+
+# ---------------------------------------------------------------------------
+# MOTD (Message of the Day) — site-wide banner
+# ---------------------------------------------------------------------------
+
+
+class MotdView(BaseModel):
+    """Current state of the MOTD banner."""
+
+    active: bool
+    message: str | None = None
+    severity: str | None = None
+    expires_at: datetime | None = None
+    updated_at: datetime | None = None
+    updated_by_user_id: int | None = None
+
+
+class SetMotdRequest(BaseModel):
+    """Admin request to set or replace the active MOTD."""
+
+    message: str = Field(min_length=1, max_length=1000)
+    severity: Literal["info", "warning"] = "info"
+    expires_at: str = Field(min_length=1, max_length=64)

--- a/services/auth/tests/test_admin_motd.py
+++ b/services/auth/tests/test_admin_motd.py
@@ -1,0 +1,139 @@
+"""Admin MOTD endpoints — set, read, clear, expiration behavior.
+
+Covers the admin-configurable site banner (MOTD) stored in
+auth.server_settings with keys ``motd:message``, ``motd:severity``,
+and ``motd:expires_at``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from auth_service.models import User
+from auth_service.passwords import hash_password
+
+
+async def _login(client: Any, email: str, password: str) -> str:
+    resp = await client.post("/auth/login", json={"email": email, "password": password})
+    assert resp.status_code == 200
+    return str(resp.json()["access_token"])
+
+
+async def _create_admin(db: Any) -> tuple[str, str]:
+    """Insert an admin user and return (email, plaintext_password)."""
+    email = "admin@local"
+    pw = "supersecurepassword123"
+    user = User(email=email, password_hash=hash_password(pw), role="admin")
+    db.add(user)
+    await db.commit()
+    return email, pw
+
+
+@pytest.mark.asyncio
+async def test_get_motd_no_banner(client: Any, db_session: Any) -> None:
+    """GET /admin/settings/motd returns active=False when no banner is set."""
+    email, pw = await _create_admin(db_session)
+    token = await _login(client, email, pw)
+    resp = await client.get("/admin/settings/motd", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["active"] is False
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_motd(client: Any, db_session: Any) -> None:
+    """PUT then GET returns the active banner."""
+    email, pw = await _create_admin(db_session)
+    token = await _login(client, email, pw)
+    expires = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
+    resp = await client.put(
+        "/admin/settings/motd",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"message": "Maintenance tonight", "severity": "warning", "expires_at": expires},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["active"] is True
+    assert data["message"] == "Maintenance tonight"
+    assert data["severity"] == "warning"
+
+    # GET confirms it
+    resp2 = await client.get("/admin/settings/motd", headers={"Authorization": f"Bearer {token}"})
+    assert resp2.status_code == 200
+    assert resp2.json()["active"] is True
+    assert resp2.json()["message"] == "Maintenance tonight"
+
+
+@pytest.mark.asyncio
+async def test_clear_motd(client: Any, db_session: Any) -> None:
+    """DELETE clears the active banner."""
+    email, pw = await _create_admin(db_session)
+    token = await _login(client, email, pw)
+    expires = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
+    await client.put(
+        "/admin/settings/motd",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"message": "Test", "severity": "info", "expires_at": expires},
+    )
+    resp = await client.delete("/admin/settings/motd", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 204
+
+    resp2 = await client.get("/admin/settings/motd", headers={"Authorization": f"Bearer {token}"})
+    assert resp2.json()["active"] is False
+
+
+@pytest.mark.asyncio
+async def test_motd_expired_returns_inactive(client: Any, db_session: Any) -> None:
+    """An expired MOTD shows as inactive."""
+    email, pw = await _create_admin(db_session)
+    token = await _login(client, email, pw)
+    # Set expires_at to the past
+    expires = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    await client.put(
+        "/admin/settings/motd",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"message": "Old news", "severity": "info", "expires_at": expires},
+    )
+    resp = await client.get("/admin/settings/motd", headers={"Authorization": f"Bearer {token}"})
+    assert resp.json()["active"] is False
+
+
+@pytest.mark.asyncio
+async def test_public_motd_endpoint(client: Any, db_session: Any) -> None:
+    """GET /auth/motd returns the active MOTD without auth."""
+    email, pw = await _create_admin(db_session)
+    token = await _login(client, email, pw)
+    expires = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
+    await client.put(
+        "/admin/settings/motd",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"message": "Public notice", "severity": "info", "expires_at": expires},
+    )
+    # No auth header
+    resp = await client.get("/auth/motd")
+    assert resp.status_code == 200
+    assert resp.json()["active"] is True
+    assert resp.json()["message"] == "Public notice"
+
+
+@pytest.mark.asyncio
+async def test_set_motd_replaces_previous(client: Any, db_session: Any) -> None:
+    """Setting a new MOTD replaces the old one."""
+    email, pw = await _create_admin(db_session)
+    token = await _login(client, email, pw)
+    expires = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
+    await client.put(
+        "/admin/settings/motd",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"message": "First", "severity": "info", "expires_at": expires},
+    )
+    await client.put(
+        "/admin/settings/motd",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"message": "Second", "severity": "warning", "expires_at": expires},
+    )
+    resp = await client.get("/admin/settings/motd", headers={"Authorization": f"Bearer {token}"})
+    assert resp.json()["message"] == "Second"
+    assert resp.json()["severity"] == "warning"

--- a/services/web/tests/test_motd.py
+++ b/services/web/tests/test_motd.py
@@ -1,0 +1,467 @@
+"""MOTD (Message of the Day) banner tests.
+
+Covers:
+- Setting/clearing MOTD via admin routes
+- MOTD appears when active and non-expired
+- MOTD does not appear when expired
+- Severity affects banner styling
+- MOTD injection into all template renders via middleware
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from web_service import auth_client
+
+
+@pytest_asyncio.fixture
+async def app_client() -> AsyncIterator[httpx.AsyncClient]:
+    from web_service import deps as _deps
+    from web_service import main as _main
+    from web_service import settings as _settings
+
+    _settings._settings = None
+    _deps.reset_verifier()
+    _main._reset_motd_cache()
+
+    transport = httpx.ASGITransport(app=_main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    _main._reset_motd_cache()
+
+
+def _override_admin(user_id: int = 1, token: str = "admin-tok") -> Any:
+    from web_service import deps as _deps
+
+    fake_admin = _deps.BrowserUser(
+        user_id=user_id,
+        email="admin@local",
+        role="admin",
+        must_change_password=False,
+        scope=None,
+        token=token,
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_admin
+
+    return _dep, fake_admin
+
+
+def _override_non_admin(user_id: int = 42) -> Any:
+    from web_service import deps as _deps
+
+    fake_user = _deps.BrowserUser(
+        user_id=user_id,
+        email="u@example.com",
+        role="user",
+        must_change_password=False,
+        scope=None,
+        token="user-tok",
+    )
+
+    async def _dep() -> _deps.BrowserUser:
+        return fake_user
+
+    return _dep, fake_user
+
+
+def _sample_mode(mode: str = "invite_only") -> Any:
+    return auth_client.RegistrationMode(
+        mode=mode,
+        updated_at=datetime(2026, 5, 26, 12, 0, tzinfo=UTC),
+        updated_by_user_id=None,
+    )
+
+
+def _sample_tunables() -> Any:
+    return auth_client.TunablesResult(
+        backfill_batch_size=100,
+        backfill_interval_seconds=300,
+        scryfall_sync_interval_days=7,
+        mtgo_scraper_interval_hours=24,
+        parser_version="0.9.0",
+        reparse_min_version="0.9.0",
+        min_agent_version="0.5.0",
+    )
+
+
+def _active_motd(
+    message: str = "Maintenance tonight at 10 PM UTC",
+    severity: str = "info",
+    hours_until_expiry: int = 24,
+) -> auth_client.MotdResult:
+    return auth_client.MotdResult(
+        active=True,
+        message=message,
+        severity=severity,
+        expires_at=datetime.now(UTC) + timedelta(hours=hours_until_expiry),
+        updated_at=datetime.now(UTC),
+        updated_by_user_id=1,
+    )
+
+
+def _inactive_motd() -> auth_client.MotdResult:
+    return auth_client.MotdResult(active=False)
+
+
+def _patch_settings_deps(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    motd: auth_client.MotdResult | None = None,
+) -> None:
+    """Monkeypatch common dependencies for admin settings page."""
+    from web_service import analytics_client
+
+    async def fake_mode(_url: str, _token: str) -> auth_client.RegistrationMode:
+        return _sample_mode()
+
+    async def fake_tunables(_url: str, _token: str) -> auth_client.TunablesResult:
+        return _sample_tunables()
+
+    async def fake_motd_admin(_url: str, _token: str) -> auth_client.MotdResult:
+        return motd if motd is not None else _inactive_motd()
+
+    async def fake_motd_public(_url: str) -> auth_client.MotdResult:
+        return motd if motd is not None else _inactive_motd()
+
+    async def _empty_cards(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("noop")
+
+    async def _empty_scrapers(*_a: Any, **_kw: Any) -> Any:
+        raise analytics_client.AnalyticsClientError("noop")
+
+    monkeypatch.setattr(auth_client, "admin_get_registration_mode", fake_mode)
+    monkeypatch.setattr(auth_client, "admin_get_tunables", fake_tunables)
+    monkeypatch.setattr(auth_client, "admin_get_motd", fake_motd_admin)
+    monkeypatch.setattr(auth_client, "public_get_motd", fake_motd_public)
+    monkeypatch.setattr(analytics_client, "admin_get_cards_status", _empty_cards)
+    monkeypatch.setattr(analytics_client, "admin_get_all_scraper_health", _empty_scrapers)
+
+
+# ---------------------------------------------------------------------------
+# Admin settings page renders MOTD section
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_settings_shows_no_active_banner(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    _patch_settings_deps(monkeypatch, motd=_inactive_motd())
+    dep, _ = _override_admin(user_id=1)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/admin/settings")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Site banner (MOTD)" in r.text
+    assert "No active banner" in r.text
+
+
+@pytest.mark.asyncio
+async def test_admin_settings_shows_active_info_banner(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    motd = _active_motd(message="Servers will restart at midnight", severity="info")
+    _patch_settings_deps(monkeypatch, motd=motd)
+    dep, _ = _override_admin(user_id=1)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/admin/settings")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Servers will restart at midnight" in r.text
+    assert "Current banner (info)" in r.text
+    assert "Clear banner" in r.text
+
+
+@pytest.mark.asyncio
+async def test_admin_settings_shows_active_warning_banner(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    motd = _active_motd(message="Data loss detected", severity="warning")
+    _patch_settings_deps(monkeypatch, motd=motd)
+    dep, _ = _override_admin(user_id=1)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.get("/admin/settings")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 200
+    assert "Data loss detected" in r.text
+    assert "Current banner (warning)" in r.text
+    # Warning severity uses red styling
+    assert "bg-red" in r.text
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/settings/motd — set banner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_motd_success_redirects(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    captured: dict[str, Any] = {}
+
+    async def fake_set(
+        _url: str,
+        _token: str,
+        *,
+        message: str,
+        severity: str,
+        expires_at: str,
+    ) -> tuple[auth_client.MotdResult | None, str | None]:
+        captured["message"] = message
+        captured["severity"] = severity
+        captured["expires_at"] = expires_at
+        return _active_motd(message=message, severity=severity), None
+
+    monkeypatch.setattr(auth_client, "admin_set_motd", fake_set)
+    dep, _ = _override_admin(user_id=1)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(
+            "/admin/settings/motd",
+            data={
+                "motd_message": "Test banner",
+                "motd_severity": "warning",
+                "motd_expires_at": "2026-06-01T12:00",
+            },
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 303
+    assert "motd_saved=1" in r.headers["location"]
+    assert captured["message"] == "Test banner"
+    assert captured["severity"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_post_motd_empty_message_returns_error(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    _patch_settings_deps(monkeypatch)
+    dep, _ = _override_admin(user_id=1)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(
+            "/admin/settings/motd",
+            data={
+                "motd_message": "   ",
+                "motd_severity": "info",
+                "motd_expires_at": "2026-06-01T12:00",
+            },
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 400
+    assert "Banner message is required" in r.text
+
+
+@pytest.mark.asyncio
+async def test_post_motd_forbidden_for_non_admin(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    dep, _ = _override_non_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post(
+            "/admin/settings/motd",
+            data={
+                "motd_message": "Test",
+                "motd_severity": "info",
+                "motd_expires_at": "2026-06-01T12:00",
+            },
+        )
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/settings/motd/clear — clear banner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_clear_motd_success_redirects(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    async def fake_clear(_url: str, _token: str) -> tuple[bool, str | None]:
+        return True, None
+
+    monkeypatch.setattr(auth_client, "admin_clear_motd", fake_clear)
+    dep, _ = _override_admin(user_id=1)
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post("/admin/settings/motd/clear")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 303
+    assert "motd_cleared=1" in r.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_post_clear_motd_forbidden_for_non_admin(
+    app_client: httpx.AsyncClient,
+) -> None:
+    from web_service import deps as _deps
+    from web_service import main as _main
+
+    dep, _ = _override_non_admin()
+    _main.app.dependency_overrides[_deps.get_current_browser_user] = dep
+    try:
+        r = await app_client.post("/admin/settings/motd/clear")
+    finally:
+        _main.app.dependency_overrides.clear()
+
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Banner displays on user-facing pages via middleware
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_motd_banner_visible_on_landing_page(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MOTD banner should appear on the public landing page."""
+    from web_service import main as _main
+
+    motd = _active_motd(message="Platform upgrade in progress", severity="info")
+
+    async def fake_public_motd(_url: str) -> auth_client.MotdResult:
+        return motd
+
+    async def fake_reg_mode(_url: str) -> str:
+        return "invite_only"
+
+    monkeypatch.setattr(auth_client, "public_get_motd", fake_public_motd)
+    monkeypatch.setattr(auth_client, "public_get_registration_mode", fake_reg_mode)
+    _main._reset_motd_cache()
+
+    r = await app_client.get("/")
+    assert r.status_code == 200
+    assert "Platform upgrade in progress" in r.text
+    assert "motd-banner" in r.text
+
+
+@pytest.mark.asyncio
+async def test_motd_banner_not_visible_when_inactive(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No banner should render when MOTD is inactive."""
+    from web_service import main as _main
+
+    async def fake_public_motd(_url: str) -> auth_client.MotdResult:
+        return _inactive_motd()
+
+    async def fake_reg_mode(_url: str) -> str:
+        return "invite_only"
+
+    monkeypatch.setattr(auth_client, "public_get_motd", fake_public_motd)
+    monkeypatch.setattr(auth_client, "public_get_registration_mode", fake_reg_mode)
+    _main._reset_motd_cache()
+
+    r = await app_client.get("/")
+    assert r.status_code == 200
+    assert "motd-banner" not in r.text
+
+
+@pytest.mark.asyncio
+async def test_motd_info_severity_uses_green_styling(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import main as _main
+
+    motd = _active_motd(message="Good news everyone", severity="info")
+
+    async def fake_public_motd(_url: str) -> auth_client.MotdResult:
+        return motd
+
+    async def fake_reg_mode(_url: str) -> str:
+        return "invite_only"
+
+    monkeypatch.setattr(auth_client, "public_get_motd", fake_public_motd)
+    monkeypatch.setattr(auth_client, "public_get_registration_mode", fake_reg_mode)
+    _main._reset_motd_cache()
+
+    r = await app_client.get("/")
+    assert r.status_code == 200
+    assert "bg-emerald" in r.text
+    assert "Good news everyone" in r.text
+
+
+@pytest.mark.asyncio
+async def test_motd_warning_severity_uses_red_styling(
+    app_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from web_service import main as _main
+
+    motd = _active_motd(message="Critical issue detected", severity="warning")
+
+    async def fake_public_motd(_url: str) -> auth_client.MotdResult:
+        return motd
+
+    async def fake_reg_mode(_url: str) -> str:
+        return "invite_only"
+
+    monkeypatch.setattr(auth_client, "public_get_motd", fake_public_motd)
+    monkeypatch.setattr(auth_client, "public_get_registration_mode", fake_reg_mode)
+    _main._reset_motd_cache()
+
+    r = await app_client.get("/")
+    assert r.status_code == 200
+    assert "bg-red" in r.text
+    assert "Critical issue detected" in r.text

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -1148,3 +1148,142 @@ async def admin_update_tunables(
     raise AuthClientError(
         f"auth PATCH /admin/settings/tunables returned {resp.status_code}: {resp.text}"
     )
+
+
+# ---------------------------------------------------------------------------
+# MOTD (Message of the Day) — site-wide banner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MotdResult:
+    """MOTD state returned by the auth service."""
+
+    active: bool
+    message: str | None = None
+    severity: str | None = None
+    expires_at: datetime | None = None
+    updated_at: datetime | None = None
+    updated_by_user_id: int | None = None
+
+
+async def public_get_motd(base_url: str) -> MotdResult:
+    """Public read of the active MOTD."""
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(f"{base_url}/auth/motd")
+    except httpx.HTTPError:
+        return MotdResult(active=False)
+    if resp.status_code != 200:
+        return MotdResult(active=False)
+    try:
+        data = resp.json()
+    except ValueError:
+        return MotdResult(active=False)
+    if not data.get("active"):
+        return MotdResult(active=False)
+    return MotdResult(
+        active=True,
+        message=data.get("message"),
+        severity=data.get("severity", "info"),
+        expires_at=_parse_dt(data.get("expires_at")),
+        updated_at=_parse_dt(data.get("updated_at")),
+        updated_by_user_id=(
+            int(data["updated_by_user_id"]) if data.get("updated_by_user_id") is not None else None
+        ),
+    )
+
+
+async def admin_get_motd(base_url: str, token: str) -> MotdResult:
+    """Admin-only: read the current MOTD via the admin endpoint."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/admin/settings/motd",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AuthClientError(f"auth GET /admin/settings/motd transport error: {exc}") from exc
+    if resp.status_code in (401, 403):
+        raise AuthForbidden(f"auth GET /admin/settings/motd returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise AuthClientError(
+            f"auth GET /admin/settings/motd returned {resp.status_code}: {resp.text}"
+        )
+    data = resp.json()
+    return MotdResult(
+        active=bool(data.get("active")),
+        message=data.get("message"),
+        severity=data.get("severity"),
+        expires_at=_parse_dt(data.get("expires_at")),
+        updated_at=_parse_dt(data.get("updated_at")),
+        updated_by_user_id=(
+            int(data["updated_by_user_id"]) if data.get("updated_by_user_id") is not None else None
+        ),
+    )
+
+
+async def admin_set_motd(
+    base_url: str,
+    token: str,
+    *,
+    message: str,
+    severity: str,
+    expires_at: str,
+) -> tuple[MotdResult | None, str | None]:
+    """Admin-only: set or replace the active MOTD."""
+    body_payload: dict[str, str] = {
+        "message": message,
+        "severity": severity,
+        "expires_at": expires_at,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.put(
+                f"{base_url}/admin/settings/motd",
+                headers={"Authorization": f"Bearer {token}"},
+                json=body_payload,
+            )
+    except httpx.HTTPError as exc:
+        raise AuthClientError(f"auth PUT /admin/settings/motd transport error: {exc}") from exc
+    if resp.status_code == 200:
+        data = resp.json()
+        return MotdResult(
+            active=bool(data.get("active")),
+            message=data.get("message"),
+            severity=data.get("severity"),
+            expires_at=_parse_dt(data.get("expires_at")),
+            updated_at=_parse_dt(data.get("updated_at")),
+            updated_by_user_id=(
+                int(data["updated_by_user_id"])
+                if data.get("updated_by_user_id") is not None
+                else None
+            ),
+        ), None
+    if resp.status_code in (401, 403):
+        raise AuthForbidden(f"auth PUT /admin/settings/motd returned {resp.status_code}")
+    if resp.status_code in (400, 422):
+        return None, "validation_error"
+    raise AuthClientError(f"auth PUT /admin/settings/motd returned {resp.status_code}: {resp.text}")
+
+
+async def admin_clear_motd(
+    base_url: str,
+    token: str,
+) -> tuple[bool, str | None]:
+    """Admin-only: clear the active MOTD."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.delete(
+                f"{base_url}/admin/settings/motd",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        raise AuthClientError(f"auth DELETE /admin/settings/motd transport error: {exc}") from exc
+    if resp.status_code == 204:
+        return True, None
+    if resp.status_code in (401, 403):
+        raise AuthForbidden(f"auth DELETE /admin/settings/motd returned {resp.status_code}")
+    raise AuthClientError(
+        f"auth DELETE /admin/settings/motd returned {resp.status_code}: {resp.text}"
+    )

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import time
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -53,6 +54,77 @@ app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
 # Browser-auth redirect handler — converts BrowserAuthRedirect into a
 # 302 to /login (or /settings/password for password-change scope).
 app.add_exception_handler(BrowserAuthRedirect, browser_auth_redirect_handler)
+
+
+# ---------------------------------------------------------------------------
+# MOTD cache — short TTL so updates propagate quickly
+# ---------------------------------------------------------------------------
+
+_motd_cache: auth_client.MotdResult | None = None
+_motd_cache_ts: float = 0.0
+_MOTD_CACHE_TTL_SECONDS = 30.0
+
+
+async def _get_cached_motd(settings_obj: WebSettings) -> auth_client.MotdResult:
+    """Return the current MOTD, using a 30-second in-memory cache."""
+    global _motd_cache, _motd_cache_ts
+    now = time.monotonic()
+    if _motd_cache is not None and (now - _motd_cache_ts) < _MOTD_CACHE_TTL_SECONDS:
+        return _motd_cache
+    result = await auth_client.public_get_motd(settings_obj.auth_service_url)
+    _motd_cache = result
+    _motd_cache_ts = now
+    return result
+
+
+def _reset_motd_cache() -> None:
+    """Test hook + post-update invalidation."""
+    global _motd_cache, _motd_cache_ts
+    _motd_cache = None
+    _motd_cache_ts = 0.0
+
+
+@app.middleware("http")
+async def inject_motd_middleware(request: Request, call_next: Any) -> Response:
+    """Fetch the MOTD once per request and stash it on request.state."""
+    path = request.url.path
+    if path.startswith("/static") or path.endswith("/healthz") or path == "/metrics":
+        return await call_next(request)
+    try:
+        motd = await _get_cached_motd(get_settings())
+    except Exception:  # noqa: BLE001
+        motd = auth_client.MotdResult(active=False)
+    request.state.motd = motd
+    return await call_next(request)
+
+
+# Patch Jinja2Templates to auto-inject ``motd`` into every render context.
+_original_template_response = templates.TemplateResponse
+
+
+def _patched_template_response(
+    request_or_name: Any,
+    name_or_context: Any = None,
+    context: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> Response:
+    """Wrapper that injects ``motd`` into every template context."""
+    if isinstance(request_or_name, Request):
+        req = request_or_name
+        tpl_name = name_or_context
+        ctx = context or {}
+    else:
+        tpl_name = request_or_name
+        ctx = name_or_context if isinstance(name_or_context, dict) else (context or {})
+        req = ctx.get("request")
+    if req is not None and hasattr(req, "state") and hasattr(req.state, "motd"):
+        ctx.setdefault("motd", req.state.motd)
+    else:
+        ctx.setdefault("motd", None)
+    return _original_template_response(req, tpl_name, ctx, **kwargs)
+
+
+templates.TemplateResponse = _patched_template_response  # type: ignore[assignment]
 
 
 @app.get("/healthz")
@@ -2493,6 +2565,10 @@ def _render_admin_settings(
     cards_status: dict[str, Any] | None = None,
     scraper_health: dict[str, Any] | None = None,
     scraper_healths: list[dict[str, Any]] | None = None,
+    admin_motd: auth_client.MotdResult | None = None,
+    motd_saved: bool = False,
+    motd_cleared: bool = False,
+    motd_error: str | None = None,
     error: str | None,
     saved: bool,
     tunables_saved: bool = False,
@@ -2520,6 +2596,10 @@ def _render_admin_settings(
             "cards_status": cards_status,
             "scraper_health": mtgo_health,
             "mtgtop8_health": mtgtop8_health,
+            "admin_motd": admin_motd,
+            "motd_saved": motd_saved,
+            "motd_cleared": motd_cleared,
+            "motd_error": motd_error,
             "is_root_admin": user.user_id == _ROOT_ADMIN_USER_ID,
             "lock_tooltip": _REGISTRATION_MODE_LOCK_TOOLTIP,
             "error": error,
@@ -2540,6 +2620,8 @@ async def admin_settings(
     settings: WebSettings = Depends(get_settings),
     saved: Annotated[int, Query(ge=0, le=1)] = 0,
     tunables_saved: Annotated[int, Query(ge=0, le=1)] = 0,
+    motd_saved: Annotated[int, Query(ge=0, le=1)] = 0,
+    motd_cleared: Annotated[int, Query(ge=0, le=1)] = 0,
     scrape_mtgo_triggered: Annotated[int, Query(ge=0, le=1)] = 0,
     scrape_mtgtop8_triggered: Annotated[int, Query(ge=0, le=1)] = 0,
 ) -> Response:
@@ -2549,6 +2631,7 @@ async def admin_settings(
 
     mode: auth_client.RegistrationMode | None = None
     tunables: auth_client.TunablesResult | None = None
+    admin_motd: auth_client.MotdResult | None = None
     cards_status: dict[str, Any] | None = None
     scraper_healths: list[dict[str, Any]] | None = None
     error: str | None = None
@@ -2573,6 +2656,11 @@ async def admin_settings(
             error = "Authentication service unavailable. Please try again."
 
     try:
+        admin_motd = await auth_client.admin_get_motd(settings.auth_service_url, user.token)
+    except (auth_client.AuthForbidden, auth_client.AuthClientError):
+        _log.debug("admin.settings.motd unavailable")
+
+    try:
         cards_status = await analytics_client.admin_get_cards_status(
             settings.analytics_service_url, user.token
         )
@@ -2592,11 +2680,14 @@ async def admin_settings(
         user,
         mode=mode,
         tunables=tunables,
+        admin_motd=admin_motd,
         cards_status=cards_status,
         scraper_healths=scraper_healths,
         error=error,
         saved=saved == 1,
         tunables_saved=tunables_saved == 1,
+        motd_saved=motd_saved == 1,
+        motd_cleared=motd_cleared == 1,
         scrape_mtgo_triggered=scrape_mtgo_triggered == 1,
         scrape_mtgtop8_triggered=scrape_mtgtop8_triggered == 1,
         status_code=code,
@@ -2735,6 +2826,128 @@ async def admin_settings_tunables(
         saved=False,
         tunables_error="Invalid tunable values. Check ranges and try again.",
         status_code=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+@app.post("/admin/settings/motd")
+async def admin_settings_set_motd(
+    request: Request,
+    motd_message: Annotated[str, Form()],
+    motd_severity: Annotated[str, Form()],
+    motd_expires_at: Annotated[str, Form()],
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    message = motd_message.strip()
+    severity = motd_severity.strip()
+    expires_at_raw = motd_expires_at.strip()
+
+    if not message:
+        admin_motd_err: auth_client.MotdResult | None = None
+        with contextlib.suppress(auth_client.AuthForbidden, auth_client.AuthClientError):
+            admin_motd_err = await auth_client.admin_get_motd(settings.auth_service_url, user.token)
+        mode_err: auth_client.RegistrationMode | None = None
+        with contextlib.suppress(auth_client.AuthForbidden, auth_client.AuthClientError):
+            mode_err = await auth_client.admin_get_registration_mode(
+                settings.auth_service_url, user.token
+            )
+        return _render_admin_settings(
+            request,
+            user,
+            mode=mode_err,
+            admin_motd=admin_motd_err,
+            error=None,
+            saved=False,
+            motd_error="Banner message is required.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if severity not in ("info", "warning"):
+        severity = "info"
+
+    if (
+        expires_at_raw
+        and "T" in expires_at_raw
+        and "+" not in expires_at_raw
+        and "Z" not in expires_at_raw
+    ):
+        expires_at_iso = expires_at_raw + ":00+00:00"
+    else:
+        expires_at_iso = expires_at_raw
+
+    try:
+        result, err = await auth_client.admin_set_motd(
+            settings.auth_service_url,
+            user.token,
+            message=message,
+            severity=severity,
+            expires_at=expires_at_iso,
+        )
+    except auth_client.AuthForbidden:
+        _log.info("admin.settings.motd.set.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except auth_client.AuthClientError:
+        _log.exception("auth PUT /admin/settings/motd call failed")
+        return Response(
+            content="Authentication service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if result is not None:
+        _reset_motd_cache()
+        return RedirectResponse(
+            url="/admin/settings?motd_saved=1", status_code=status.HTTP_303_SEE_OTHER
+        )
+
+    admin_motd_re: auth_client.MotdResult | None = None
+    with contextlib.suppress(auth_client.AuthForbidden, auth_client.AuthClientError):
+        admin_motd_re = await auth_client.admin_get_motd(settings.auth_service_url, user.token)
+    mode_re: auth_client.RegistrationMode | None = None
+    with contextlib.suppress(auth_client.AuthForbidden, auth_client.AuthClientError):
+        mode_re = await auth_client.admin_get_registration_mode(
+            settings.auth_service_url, user.token
+        )
+    return _render_admin_settings(
+        request,
+        user,
+        mode=mode_re,
+        admin_motd=admin_motd_re,
+        error=None,
+        saved=False,
+        motd_error="Could not set the banner. Check the expiration date.",
+        status_code=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+@app.post("/admin/settings/motd/clear")
+async def admin_settings_clear_motd(
+    request: Request,
+    user: BrowserUser = Depends(get_current_browser_user),
+    settings: WebSettings = Depends(get_settings),
+) -> Response:
+    blocked = _require_admin_or_403(request, user)
+    if blocked is not None:
+        return blocked
+
+    try:
+        await auth_client.admin_clear_motd(settings.auth_service_url, user.token)
+    except auth_client.AuthForbidden:
+        _log.info("admin.settings.motd.clear.forbidden", extra={"user_id": user.user_id})
+        return _admin_forbidden(request, user)
+    except auth_client.AuthClientError:
+        _log.exception("auth DELETE /admin/settings/motd call failed")
+        return Response(
+            content="Authentication service unavailable. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    _reset_motd_cache()
+    return RedirectResponse(
+        url="/admin/settings?motd_cleared=1", status_code=status.HTTP_303_SEE_OTHER
     )
 
 

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -116,7 +116,7 @@ def _patched_template_response(
     else:
         tpl_name = request_or_name
         ctx = name_or_context if isinstance(name_or_context, dict) else (context or {})
-        req = ctx.get("request")
+        req = ctx.get("request")  # type: ignore[assignment]
     if req is not None and hasattr(req, "state") and hasattr(req.state, "motd"):
         ctx.setdefault("motd", req.state.motd)
     else:

--- a/services/web/web_service/templates/admin_settings.html
+++ b/services/web/web_service/templates/admin_settings.html
@@ -43,6 +43,58 @@
     {% endif %}
 </div>
 
+{# MOTD Banner #}
+{% if motd_saved %}<div class="bg-accent-muted border border-accent/20 text-accent rounded-md p-3 text-sm mb-4" role="status">Site banner updated.</div>{% endif %}
+{% if motd_cleared %}<div class="bg-accent-muted border border-accent/20 text-accent rounded-md p-3 text-sm mb-4" role="status">Site banner cleared.</div>{% endif %}
+{% if motd_error %}<div class="bg-danger-muted border border-danger/20 text-danger rounded-md p-3 text-sm mb-4" role="alert">{{ motd_error }}</div>{% endif %}
+
+<div class="dark:bg-surface bg-surface-light border dark:border-border border-border-light rounded-md p-6 mb-6">
+    <h2 class="text-sm font-semibold dark:text-txt-primary text-txt-primary-light mb-2">Site banner (MOTD)</h2>
+    <p class="text-xs dark:text-txt-secondary text-txt-secondary-light mb-4">Display a broadcast message at the top of every page. Only one banner at a time; setting a new one replaces the old one.</p>
+
+    {% if admin_motd and admin_motd.active %}
+    <div class="mb-4 p-3 rounded-md border text-sm
+        {% if admin_motd.severity == 'warning' %}
+        dark:bg-red-900/30 bg-red-50 dark:border-red-700/40 border-red-300 dark:text-red-200 text-red-800
+        {% else %}
+        dark:bg-emerald-900/30 bg-emerald-50 dark:border-emerald-700/40 border-emerald-300 dark:text-emerald-200 text-emerald-800
+        {% endif %}">
+        <p class="text-xs font-semibold uppercase tracking-wider mb-1 opacity-70">Current banner ({{ admin_motd.severity }})</p>
+        <p>{{ admin_motd.message }}</p>
+        {% if admin_motd.expires_at %}<p class="text-xs mt-1 opacity-70">Expires: {{ admin_motd.expires_at.strftime("%Y-%m-%d %H:%M") }} UTC</p>{% endif %}
+    </div>
+    <form method="post" action="/admin/settings/motd/clear" class="mb-4" onsubmit="return confirm('Clear the current site banner?');">
+        <button type="submit" class="border dark:border-danger/40 border-danger/40 text-danger hover:dark:bg-danger-muted hover:bg-danger-muted rounded-md px-3 py-1.5 text-xs font-medium transition-colors">Clear banner</button>
+    </form>
+    {% else %}
+    <p class="text-sm dark:text-txt-secondary text-txt-secondary-light mb-4">No active banner.</p>
+    {% endif %}
+
+    <form method="post" action="/admin/settings/motd" class="space-y-3">
+        <label class="flex flex-col gap-1">
+            <span class="text-xs font-medium dark:text-txt-secondary text-txt-secondary-light">Message</span>
+            <input type="text" name="motd_message" maxlength="1000" required placeholder="Enter banner message..."
+                   class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none w-full max-w-xl">
+        </label>
+        <div class="flex flex-wrap gap-4">
+            <label class="flex flex-col gap-1">
+                <span class="text-xs font-medium dark:text-txt-secondary text-txt-secondary-light">Severity</span>
+                <select name="motd_severity"
+                        class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none w-40">
+                    <option value="info">Info (green)</option>
+                    <option value="warning">Warning (red)</option>
+                </select>
+            </label>
+            <label class="flex flex-col gap-1">
+                <span class="text-xs font-medium dark:text-txt-secondary text-txt-secondary-light">Expires at (UTC)</span>
+                <input type="datetime-local" name="motd_expires_at" required
+                       class="dark:bg-surface-3 bg-surface-light-3 border dark:border-border border-border-light rounded-md px-3 py-1.5 text-sm dark:text-txt-primary text-txt-primary-light focus:ring-2 focus:ring-accent focus:border-accent outline-none w-56">
+            </label>
+        </div>
+        <button type="submit" class="bg-accent text-white hover:bg-accent-hover rounded-md px-4 py-1.5 text-sm font-medium transition-colors">Set banner</button>
+    </form>
+</div>
+
 {# System tunables #}
 {% if tunables_saved %}<div class="bg-accent-muted border border-accent/20 text-accent rounded-md p-3 text-sm mb-4" role="status">System tunables updated.</div>{% endif %}
 {% if tunables_error %}<div class="bg-danger-muted border border-danger/20 text-danger rounded-md p-3 text-sm mb-4" role="alert">{{ tunables_error }}</div>{% endif %}

--- a/services/web/web_service/templates/base.html
+++ b/services/web/web_service/templates/base.html
@@ -134,6 +134,38 @@
         </div>
     </header>
 
+    {# -- MOTD Banner -- #}
+    {% if motd and motd.active %}
+    <div x-data="{ dismissed: false }" x-show="!dismissed" x-cloak
+         class="fixed top-12 left-0 right-0 z-40 border-b text-sm px-4 py-2.5 flex items-center justify-between gap-3
+                {% if motd.severity == 'warning' %}
+                dark:bg-red-900/40 bg-red-50 dark:border-red-700/50 border-red-300 dark:text-red-200 text-red-800
+                {% else %}
+                dark:bg-emerald-900/40 bg-emerald-50 dark:border-emerald-700/50 border-emerald-300 dark:text-emerald-200 text-emerald-800
+                {% endif %}"
+         id="motd-banner">
+        <div class="flex items-center gap-2 min-w-0">
+            {% if motd.severity == 'warning' %}
+            <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"/>
+            </svg>
+            {% else %}
+            <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+            {% endif %}
+            <span class="truncate">{{ motd.message }}</span>
+        </div>
+        <button @click="dismissed = true"
+                class="flex-shrink-0 p-0.5 rounded hover:opacity-70 transition-opacity"
+                aria-label="Dismiss banner">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+        </button>
+    </div>
+    {% endif %}
+
     {% block body_layout %}
     {% if user %}
     {# ── Authenticated: sidebar + main ── #}


### PR DESCRIPTION
## Summary
- Adds an admin-configurable Message of the Day (MOTD) banner that displays at the top of every page across the site
- Admins can set a message with info (green) or warning (red) severity and an expiration date; banner auto-hides after expiration
- Only one active banner at a time; setting a new one replaces the old one; admin can also clear it manually
- MOTD stored in `auth.server_settings` (no migration needed), with a 30-second TTL cache in the web service

## Test plan
- [x] 12 new tests covering: admin settings page renders active/inactive MOTD, set/clear MOTD via POST, severity affects banner styling, banner visible on landing page, banner hidden when inactive, access control for non-admins
- [x] All 291 existing web service tests pass
- [x] ruff check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)