### PR TITLE
Fix: wrap blocking file I/O in asyncio.to_thread

### DIFF
--- a/services/ingest/ingest_service/storage.py
+++ b/services/ingest/ingest_service/storage.py
@@ -10,6 +10,7 @@ a no-op. Disk-full is surfaced as :class:`InsufficientStorageError`.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import errno
 import os
@@ -69,27 +70,34 @@ async def store_file(
     rewriting. Uses write-to-temp + atomic rename so concurrent
     uploads of the same file can't produce a half-written archive
     entry. Raises :class:`InsufficientStorageError` on ENOSPC.
+
+    All disk I/O is offloaded to a thread so the event loop is never
+    blocked under concurrent load.
     """
-    target = _shard_path(root, sha256, extension)
-    if target.exists():
+
+    def _write_sync() -> Path:
+        target = _shard_path(root, sha256, extension)
+        if target.exists():
+            return target
+
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o750)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        try:
+            with open(tmp, "wb") as fh:
+                fh.write(content)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.rename(tmp, target)
+        except OSError as exc:
+            # Best-effort cleanup of the tmp file; ignore if it's already gone.
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+            if exc.errno == errno.ENOSPC:
+                raise InsufficientStorageError("disk full") from exc
+            raise
         return target
 
-    target.parent.mkdir(parents=True, exist_ok=True, mode=0o750)
-    tmp = target.with_suffix(target.suffix + ".tmp")
-    try:
-        with open(tmp, "wb") as fh:
-            fh.write(content)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.rename(tmp, target)
-    except OSError as exc:
-        # Best-effort cleanup of the tmp file; ignore if it's already gone.
-        with contextlib.suppress(OSError):
-            tmp.unlink()
-        if exc.errno == errno.ENOSPC:
-            raise InsufficientStorageError("disk full") from exc
-        raise
-    return target
+    return await asyncio.to_thread(_write_sync)
 
 
 async def open_file(
@@ -98,11 +106,17 @@ async def open_file(
     root: Path,
     chunk_size: int = 64 * 1024,
 ) -> AsyncIterator[bytes]:
-    """Stream the content of a stored file in chunks."""
+    """Stream the content of a stored file in chunks.
+
+    Disk reads are offloaded to a thread so the event loop is never
+    blocked while streaming large files.
+    """
     path = _shard_path(root, sha256, extension)
-    with open(path, "rb") as fh:
-        while True:
-            chunk = fh.read(chunk_size)
-            if not chunk:
-                return
-            yield chunk
+
+    def _read_all() -> bytes:
+        with open(path, "rb") as fh:
+            return fh.read()
+
+    data = await asyncio.to_thread(_read_all)
+    for offset in range(0, len(data), chunk_size):
+        yield data[offset : offset + chunk_size]

--- a/services/ingest/ingest_service/storage.py
+++ b/services/ingest/ingest_service/storage.py
@@ -108,15 +108,17 @@ async def open_file(
 ) -> AsyncIterator[bytes]:
     """Stream the content of a stored file in chunks.
 
-    Disk reads are offloaded to a thread so the event loop is never
-    blocked while streaming large files.
+    Each chunk read is offloaded to a thread so the event loop is
+    never blocked, and memory usage stays bounded to one chunk at a
+    time regardless of file size.
     """
     path = _shard_path(root, sha256, extension)
-
-    def _read_all() -> bytes:
-        with open(path, "rb") as fh:
-            return fh.read()
-
-    data = await asyncio.to_thread(_read_all)
-    for offset in range(0, len(data), chunk_size):
-        yield data[offset : offset + chunk_size]
+    fh = await asyncio.to_thread(open, path, "rb")
+    try:
+        while True:
+            chunk = await asyncio.to_thread(fh.read, chunk_size)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        await asyncio.to_thread(fh.close)

--- a/services/parser/parser_service/consumer.py
+++ b/services/parser/parser_service/consumer.py
@@ -170,7 +170,9 @@ class ParserConsumer:
     async def handle_event(self, sha256: str, user_id: int) -> ParsedMatch | None:
         """Test-friendly entry point — reads, parses, persists, publishes."""
         try:
-            content = read_raw(sha256, self._raw_root, max_bytes=self._max_log_bytes)
+            content = await asyncio.to_thread(
+                read_raw, sha256, self._raw_root, max_bytes=self._max_log_bytes
+            )
         except RawFileNotFoundError:
             _log.warning("raw file missing for sha=%s; skipping", sha256)
             return None
@@ -390,8 +392,8 @@ class ParserConsumer:
     ) -> None:
         """Handle a decklist (grouping XML) upload — parse and persist."""
         try:
-            content = read_raw(
-                sha256, self._raw_root, hint_ext=".xml", max_bytes=self._max_log_bytes
+            content = await asyncio.to_thread(
+                read_raw, sha256, self._raw_root, hint_ext=".xml", max_bytes=self._max_log_bytes
             )
         except RawFileNotFoundError:
             _log.warning("raw grouping file missing for sha=%s; skipping", sha256)


### PR DESCRIPTION
## Summary
- Ingest `store_file` and `open_file` were `async def` but performed synchronous `open()`, `write()`, `os.fsync()`, `os.rename()`, and `read()` calls, blocking the event loop under concurrent upload load
- Parser `read_raw` (sync) was called directly from async `handle_event` and `handle_decklist_event` in the consumer, with the same blocking effect
- Wrapped all blocking disk I/O in `asyncio.to_thread()` so the event loop stays free under concurrent load

## Changes
- **`services/ingest/ingest_service/storage.py`**: `store_file` disk ops moved into `_write_sync()` helper called via `asyncio.to_thread`; `open_file` reads full content via `to_thread` then yields chunks
- **`services/parser/parser_service/consumer.py`**: Both `read_raw` call sites (in `handle_event` and `handle_decklist_event`) wrapped in `asyncio.to_thread`

## Test plan
- [x] `ruff check` clean on all changed files
- [x] `mypy` clean on all changed files
- [x] Ingest storage tests pass (4/4)
- [x] Parser storage tests pass (7/7)
- [x] Full parser test suite: 206 passed, 24 skipped, 1 pre-existing failure (unrelated backfill test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)