### PR TITLE
Feature: IP-based rate limiting on auth endpoints

### DIFF
--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -30,6 +30,12 @@ from auth_service.jwt_issue import (
 from auth_service.models import AgentRegistration, InviteToken, ServerSetting, User
 from auth_service.models import Session as SessionRow
 from auth_service.passwords import hash_password, verify_password
+from auth_service.rate_limit import (
+    check_agent_register_creds_rate,
+    check_login_rate,
+    check_register_rate,
+    reset_rate_limiter,
+)
 from auth_service.registration import (
     consume_registration_code,
     generate_api_token,
@@ -82,6 +88,7 @@ def reset_redis() -> None:
     """Test hook: clear the cached Redis client after env changes."""
     global _redis_client
     _redis_client = None
+    reset_rate_limiter()
 
 
 _log = logging.getLogger("auth.main")
@@ -140,13 +147,12 @@ async def healthz() -> dict[str, str]:
     return {"status": "ok", "service": SERVICE_NAME}
 
 
-@app.post("/auth/login", response_model=TokenResponse)
+@app.post("/auth/login", response_model=TokenResponse, dependencies=[Depends(check_login_rate)])
 async def login(
     body: LoginRequest,
     request: Request,
     db: AsyncSession = Depends(get_session),
 ) -> TokenResponse:
-    # Rate limiting deferred to W7 gateway.
     # Body carries a plaintext password — any unhandled exception escaping
     # this handler could be logged with the request body by FastAPI/uvicorn,
     # leaking the password. Catch broadly and re-raise a sanitized 500.
@@ -545,7 +551,6 @@ async def mint_registration_code(
     user: AuthenticatedUser = Depends(require_user_role),
     redis: Redis = Depends(get_redis),
 ) -> AgentRegistrationCodeResponse:
-    # Rate limiting deferred to gateway W7.
     code = generate_registration_code()
     await store_registration_code(
         redis, code, user.user_id, ttl_seconds=_REGISTRATION_CODE_TTL_SECONDS
@@ -604,6 +609,7 @@ async def register_agent(
     "/auth/agent/register-with-credentials",
     response_model=AgentRegisterResponse,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(check_agent_register_creds_rate)],
 )
 async def register_agent_with_credentials(
     body: AgentRegisterWithCredentialsRequest,
@@ -744,6 +750,7 @@ async def public_motd(
     "/auth/register",
     response_model=RegisterResponse,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(check_register_rate)],
 )
 async def register(
     body: RegisterRequest,

--- a/services/auth/auth_service/rate_limit.py
+++ b/services/auth/auth_service/rate_limit.py
@@ -43,11 +43,12 @@ class RateLimiter:
     _CLEANUP_INTERVAL: float = 60.0
 
     def _cleanup(self, now: float, rules: dict[str, RateLimitRule]) -> None:
-        """Remove entries older than the longest window."""
-        max_window = max((r.window_seconds for r in rules.values()), default=0)
-        cutoff = now - max_window - 1
+        """Remove entries older than each bucket's own window."""
         dead_keys: list[tuple[str, str]] = []
         for key, timestamps in self._store.items():
+            bucket = key[0]
+            rule = rules.get(bucket)
+            cutoff = now - (rule.window_seconds if rule else 3600) - 1
             timestamps[:] = [t for t in timestamps if t > cutoff]
             if not timestamps:
                 dead_keys.append(key)
@@ -73,7 +74,7 @@ class RateLimiter:
 
         with self._lock:
             if now - self._last_cleanup > self._CLEANUP_INTERVAL:
-                self._cleanup(now, all_rules or {bucket: rule})
+                self._cleanup(now, all_rules or RULES)
 
             timestamps = self._store.setdefault(key, [])
             cutoff = now - rule.window_seconds

--- a/services/auth/auth_service/rate_limit.py
+++ b/services/auth/auth_service/rate_limit.py
@@ -1,0 +1,147 @@
+"""In-memory IP-based sliding-window rate limiter.
+
+No external dependencies — uses a dict of timestamps, cleaned up
+periodically on each check call to prevent unbounded growth.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastapi import HTTPException, Request, status
+
+
+@dataclass(frozen=True)
+class RateLimitRule:
+    """Defines a rate limit: ``max_requests`` within ``window_seconds``."""
+
+    max_requests: int
+    window_seconds: int
+
+
+@dataclass
+class RateLimiter:
+    """Sliding-window counter keyed by client IP.
+
+    Thread-safe via a ``threading.Lock``; the async FastAPI path is
+    single-threaded per worker so the lock is contention-free in
+    production but makes the class safe for sync test helpers too.
+
+    ``_store`` maps ``(bucket, ip)`` → list of request timestamps.
+    ``_last_cleanup`` tracks the last time we purged expired entries
+    so we don't scan on every call.
+    """
+
+    _store: dict[tuple[str, str], list[float]] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _last_cleanup: float = field(default_factory=time.monotonic)
+
+    # Purge expired entries at most once every 60 s.
+    _CLEANUP_INTERVAL: float = 60.0
+
+    def _cleanup(self, now: float, rules: dict[str, RateLimitRule]) -> None:
+        """Remove entries older than the longest window."""
+        max_window = max((r.window_seconds for r in rules.values()), default=0)
+        cutoff = now - max_window - 1
+        dead_keys: list[tuple[str, str]] = []
+        for key, timestamps in self._store.items():
+            timestamps[:] = [t for t in timestamps if t > cutoff]
+            if not timestamps:
+                dead_keys.append(key)
+        for key in dead_keys:
+            del self._store[key]
+        self._last_cleanup = now
+
+    def check(
+        self,
+        bucket: str,
+        ip: str,
+        rule: RateLimitRule,
+        all_rules: dict[str, RateLimitRule] | None = None,
+    ) -> None:
+        """Record a request and raise ``HTTPException(429)`` if over limit.
+
+        ``bucket`` is a string identifying the endpoint (e.g. ``"login"``).
+        ``all_rules`` is the full rule map, passed for cleanup; if omitted
+        cleanup uses only the current rule.
+        """
+        now = time.monotonic()
+        key = (bucket, ip)
+
+        with self._lock:
+            if now - self._last_cleanup > self._CLEANUP_INTERVAL:
+                self._cleanup(now, all_rules or {bucket: rule})
+
+            timestamps = self._store.setdefault(key, [])
+            cutoff = now - rule.window_seconds
+            timestamps[:] = [t for t in timestamps if t > cutoff]
+
+            if len(timestamps) >= rule.max_requests:
+                # Oldest surviving timestamp determines when the window
+                # opens up again.
+                oldest = min(timestamps)
+                retry_after = int(oldest + rule.window_seconds - now) + 1
+                if retry_after < 1:
+                    retry_after = 1
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail={
+                        "detail": "rate_limit_exceeded",
+                        "retry_after_seconds": retry_after,
+                    },
+                )
+
+            timestamps.append(now)
+
+    def reset(self) -> None:
+        """Clear all state — useful in tests."""
+        with self._lock:
+            self._store.clear()
+
+
+# ---------------------------------------------------------------------------
+# Singleton + rules
+# ---------------------------------------------------------------------------
+
+_limiter = RateLimiter()
+
+RULES: dict[str, RateLimitRule] = {
+    "login": RateLimitRule(max_requests=10, window_seconds=60),
+    "register": RateLimitRule(max_requests=3, window_seconds=3600),
+    "agent_register_with_credentials": RateLimitRule(max_requests=5, window_seconds=60),
+}
+
+
+def reset_rate_limiter() -> None:
+    """Test hook: clear accumulated state between tests."""
+    _limiter.reset()
+
+
+def _get_client_ip(request: Request) -> str:
+    """Extract client IP from X-Forwarded-For (Caddy) or fall back to peer."""
+    fwd = request.headers.get("x-forwarded-for")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    if request.client is not None:
+        return request.client.host
+    return "unknown"
+
+
+def _make_dependency(bucket: str) -> Any:
+    """Build a FastAPI dependency that enforces the named rate limit."""
+    rule = RULES[bucket]
+
+    async def _check_rate_limit(request: Request) -> None:
+        ip = _get_client_ip(request)
+        _limiter.check(bucket, ip, rule, all_rules=RULES)
+
+    return _check_rate_limit
+
+
+# Pre-built FastAPI dependencies — add via ``Depends(...)`` on endpoints.
+check_login_rate = _make_dependency("login")
+check_register_rate = _make_dependency("register")
+check_agent_register_creds_rate = _make_dependency("agent_register_with_credentials")

--- a/services/auth/tests/conftest.py
+++ b/services/auth/tests/conftest.py
@@ -209,6 +209,26 @@ async def client(_truncate: None, redis_client: Any) -> AsyncIterator[Any]:
 
     _main.reset_redis()
 
+    from auth_service.rate_limit import (
+        check_agent_register_creds_rate,
+        check_login_rate,
+        check_register_rate,
+        reset_rate_limiter,
+    )
+
+    reset_rate_limiter()
+
+    async def _noop() -> None:
+        pass
+
+    _main.app.dependency_overrides[check_login_rate] = _noop
+    _main.app.dependency_overrides[check_register_rate] = _noop
+    _main.app.dependency_overrides[check_agent_register_creds_rate] = _noop
+
     transport = ASGITransport(app=_main.app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
+    _main.app.dependency_overrides.pop(check_login_rate, None)
+    _main.app.dependency_overrides.pop(check_register_rate, None)
+    _main.app.dependency_overrides.pop(check_agent_register_creds_rate, None)
+    reset_rate_limiter()

--- a/services/auth/tests/test_rate_limit.py
+++ b/services/auth/tests/test_rate_limit.py
@@ -9,6 +9,31 @@ from auth_service.models import User
 from auth_service.passwords import hash_password
 from sqlalchemy.ext.asyncio import AsyncSession
 
+
+@pytest.fixture(autouse=True)
+def _enable_rate_limiting() -> Any:
+    """Re-enable rate limiting for this test module.
+
+    The global conftest disables rate-limit dependencies so other tests
+    (e.g., invite tests that make many register calls) aren't affected.
+    This fixture removes those overrides so rate limiting is active.
+    """
+    from auth_service import main as _main
+    from auth_service.rate_limit import (
+        check_agent_register_creds_rate,
+        check_login_rate,
+        check_register_rate,
+        reset_rate_limiter,
+    )
+
+    _main.app.dependency_overrides.pop(check_login_rate, None)
+    _main.app.dependency_overrides.pop(check_register_rate, None)
+    _main.app.dependency_overrides.pop(check_agent_register_creds_rate, None)
+    reset_rate_limiter()
+    yield
+    reset_rate_limiter()
+
+
 # ---------------------------------------------------------------------------
 # /auth/login — 10 per minute per IP
 # ---------------------------------------------------------------------------

--- a/services/auth/tests/test_rate_limit.py
+++ b/services/auth/tests/test_rate_limit.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @pytest.fixture(autouse=True)
-def _enable_rate_limiting() -> Any:
+def _enable_rate_limiting(client: Any) -> Any:
     """Re-enable rate limiting for this test module.
 
     The global conftest disables rate-limit dependencies so other tests

--- a/services/auth/tests/test_rate_limit.py
+++ b/services/auth/tests/test_rate_limit.py
@@ -1,0 +1,212 @@
+"""Tests for IP-based rate limiting on auth endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from auth_service.models import User
+from auth_service.passwords import hash_password
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# ---------------------------------------------------------------------------
+# /auth/login — 10 per minute per IP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_rate_limit_blocks_after_10(client: Any) -> None:
+    """11th login attempt within 1 minute from the same IP returns 429."""
+    payload = {"email": "nobody@example.com", "password": "wrong"}
+    for _ in range(10):
+        r = await client.post("/auth/login", json=payload)
+        assert r.status_code in (200, 401), f"unexpected {r.status_code}"
+
+    r = await client.post("/auth/login", json=payload)
+    assert r.status_code == 429
+    body = r.json()
+    assert body["detail"]["detail"] == "rate_limit_exceeded"
+    assert body["detail"]["retry_after_seconds"] > 0
+
+
+@pytest.mark.asyncio
+async def test_login_rate_limit_different_ips_independent(client: Any) -> None:
+    """Requests from different IPs don't share rate-limit buckets."""
+    payload = {"email": "nobody@example.com", "password": "wrong"}
+
+    # Exhaust limit for IP-A.
+    for _ in range(10):
+        r = await client.post("/auth/login", json=payload, headers={"X-Forwarded-For": "1.2.3.4"})
+        assert r.status_code in (200, 401)
+
+    # IP-A is blocked.
+    r = await client.post("/auth/login", json=payload, headers={"X-Forwarded-For": "1.2.3.4"})
+    assert r.status_code == 429
+
+    # IP-B still allowed.
+    r = await client.post("/auth/login", json=payload, headers={"X-Forwarded-For": "5.6.7.8"})
+    assert r.status_code in (200, 401)
+
+
+@pytest.mark.asyncio
+async def test_login_under_limit_succeeds(client: Any, db_session: AsyncSession) -> None:
+    """A valid login under the rate limit returns 200, not 429."""
+    u = User(email="rl-user@example.com", password_hash=hash_password("pw"))
+    db_session.add(u)
+    await db_session.commit()
+
+    r = await client.post("/auth/login", json={"email": "rl-user@example.com", "password": "pw"})
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /auth/register — 3 per hour per IP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_rate_limit_blocks_after_3(client: Any) -> None:
+    """4th registration attempt within 1 hour returns 429."""
+    for i in range(3):
+        r = await client.post(
+            "/auth/register",
+            json={
+                "email": f"reg-{i}@example.com",
+                "password": "strong-password-123",
+            },
+            headers={"X-Forwarded-For": "10.0.0.1"},
+        )
+        # Could be 201, 403 (invite required), etc. — not 429.
+        assert r.status_code != 429, f"unexpected 429 on attempt {i + 1}"
+
+    r = await client.post(
+        "/auth/register",
+        json={"email": "reg-extra@example.com", "password": "strong-password-123"},
+        headers={"X-Forwarded-For": "10.0.0.1"},
+    )
+    assert r.status_code == 429
+    body = r.json()
+    assert body["detail"]["detail"] == "rate_limit_exceeded"
+    assert body["detail"]["retry_after_seconds"] > 0
+
+
+@pytest.mark.asyncio
+async def test_register_different_ips_independent(client: Any) -> None:
+    """Registration limits are per-IP — different IPs don't interfere."""
+    for i in range(3):
+        await client.post(
+            "/auth/register",
+            json={
+                "email": f"regA-{i}@example.com",
+                "password": "strong-password-123",
+            },
+            headers={"X-Forwarded-For": "10.0.0.2"},
+        )
+
+    # IP-A blocked.
+    r = await client.post(
+        "/auth/register",
+        json={"email": "regA-extra@example.com", "password": "strong-password-123"},
+        headers={"X-Forwarded-For": "10.0.0.2"},
+    )
+    assert r.status_code == 429
+
+    # IP-B still fine.
+    r = await client.post(
+        "/auth/register",
+        json={"email": "regB-0@example.com", "password": "strong-password-123"},
+        headers={"X-Forwarded-For": "10.0.0.3"},
+    )
+    assert r.status_code != 429
+
+
+# ---------------------------------------------------------------------------
+# /auth/agent/register-with-credentials — 5 per minute per IP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_register_creds_rate_limit_blocks_after_5(client: Any) -> None:
+    """6th agent registration attempt within 1 minute returns 429."""
+    payload = {
+        "email": "nobody@example.com",
+        "password": "wrong",
+        "agent_name": "test",
+        "client_version": "0.0.1",
+    }
+    for _ in range(5):
+        r = await client.post(
+            "/auth/agent/register-with-credentials",
+            json=payload,
+            headers={"X-Forwarded-For": "192.168.1.1"},
+        )
+        assert r.status_code != 429
+
+    r = await client.post(
+        "/auth/agent/register-with-credentials",
+        json=payload,
+        headers={"X-Forwarded-For": "192.168.1.1"},
+    )
+    assert r.status_code == 429
+    body = r.json()
+    assert body["detail"]["detail"] == "rate_limit_exceeded"
+    assert body["detail"]["retry_after_seconds"] > 0
+
+
+@pytest.mark.asyncio
+async def test_agent_register_creds_different_ips_independent(client: Any) -> None:
+    """Agent-registration limits are per-IP."""
+    payload = {
+        "email": "nobody@example.com",
+        "password": "wrong",
+        "agent_name": "test",
+        "client_version": "0.0.1",
+    }
+
+    # Exhaust IP-A.
+    for _ in range(5):
+        await client.post(
+            "/auth/agent/register-with-credentials",
+            json=payload,
+            headers={"X-Forwarded-For": "192.168.1.2"},
+        )
+
+    # IP-A blocked.
+    r = await client.post(
+        "/auth/agent/register-with-credentials",
+        json=payload,
+        headers={"X-Forwarded-For": "192.168.1.2"},
+    )
+    assert r.status_code == 429
+
+    # IP-B still allowed.
+    r = await client.post(
+        "/auth/agent/register-with-credentials",
+        json=payload,
+        headers={"X-Forwarded-For": "192.168.1.3"},
+    )
+    assert r.status_code != 429
+
+
+# ---------------------------------------------------------------------------
+# Unit test: RateLimiter directly
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limiter_reset_clears_state() -> None:
+    """``reset()`` wipes accumulated counters."""
+    from auth_service.rate_limit import RateLimiter, RateLimitRule
+
+    limiter = RateLimiter()
+    rule = RateLimitRule(max_requests=1, window_seconds=60)
+    limiter.check("test", "127.0.0.1", rule)
+
+    # Second call should fail.
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        limiter.check("test", "127.0.0.1", rule)
+
+    limiter.reset()
+    # After reset, the first call should succeed again.
+    limiter.check("test", "127.0.0.1", rule)


### PR DESCRIPTION
## Summary

- Adds in-memory sliding-window IP-based rate limiting to three unauthenticated auth endpoints that perform Argon2id hashing (64 MiB per call), mitigating CPU/memory DoS
- `/auth/login`: 10 requests/minute per IP
- `/auth/register`: 3 requests/hour per IP
- `/auth/agent/register-with-credentials`: 5 requests/minute per IP
- Returns HTTP 429 with `{"detail": "rate_limit_exceeded", "retry_after_seconds": N}` when exceeded
- Client IP extracted from `X-Forwarded-For` (Caddy) with fallback to `request.client.host`
- Zero new dependencies — pure stdlib dict with timestamps, periodic cleanup

## Test plan

- [ ] Unit test: `test_rate_limiter_reset_clears_state` — verifies the core sliding-window logic and reset
- [ ] Integration tests: exceed limit returns 429, under limit passes through, different IPs are independent (for each of the three endpoints)
- [ ] ruff + mypy clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)