### PR TITLE
Feature: deep healthz with DB and Redis dependency checks

### DIFF
--- a/common/health.py
+++ b/common/health.py
@@ -1,0 +1,123 @@
+"""Shared dependency health-check helpers.
+
+Every service's ``/healthz`` endpoint uses these to verify that its
+backing stores (Postgres, Redis) are actually reachable, rather than
+unconditionally returning ``{"status": "ok"}``.
+
+Each probe has a **2-second timeout** so a hung backend doesn't make
+the health endpoint hang indefinitely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import redis.asyncio as aioredis
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_log = logging.getLogger("common.health")
+
+_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass
+class CheckResult:
+    """Result of a single dependency check."""
+
+    name: str
+    ok: bool
+    detail: str = "ok"
+
+
+@dataclass
+class HealthReport:
+    """Aggregate health report for a service."""
+
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def healthy(self) -> bool:
+        return all(c.ok for c in self.checks)
+
+    @property
+    def status(self) -> str:
+        return "ok" if self.healthy else "degraded"
+
+    @property
+    def http_status(self) -> int:
+        return 200 if self.healthy else 503
+
+    def to_dict(self, service: str) -> dict[str, str]:
+        result: dict[str, str] = {"status": self.status, "service": service}
+        for c in self.checks:
+            result[c.name] = c.detail
+        return result
+
+
+async def check_db(sessionmaker: async_sessionmaker[AsyncSession]) -> CheckResult:
+    """Ping Postgres with ``SELECT 1``; 2-second timeout."""
+    try:
+        async with asyncio.timeout(_TIMEOUT_SECONDS):
+            async with sessionmaker() as session:
+                await session.execute(text("SELECT 1"))
+        return CheckResult(name="db", ok=True)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("healthz db check failed: %s", exc)
+        return CheckResult(name="db", ok=False, detail="error")
+
+
+async def check_redis(redis_client: aioredis.Redis) -> CheckResult:
+    """Ping Redis; 2-second timeout."""
+    try:
+        async with asyncio.timeout(_TIMEOUT_SECONDS):
+            await redis_client.ping()  # type: ignore[misc]
+        return CheckResult(name="redis", ok=True)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("healthz redis check failed: %s", exc)
+        return CheckResult(name="redis", ok=False, detail="error")
+
+
+async def check_http(
+    url: str,
+    service_name: str,
+    *,
+    label: str | None = None,
+) -> CheckResult:
+    """GET a URL and expect 200; 2-second timeout.
+
+    Used by the web service to verify that upstream services (auth,
+    analytics) are reachable.
+    """
+    check_label = label or service_name
+    try:
+        async with asyncio.timeout(_TIMEOUT_SECONDS):
+            async with httpx.AsyncClient() as client:
+                r = await client.get(url)
+                if r.status_code == 200:
+                    return CheckResult(name=check_label, ok=True)
+                return CheckResult(name=check_label, ok=False, detail="error")
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("healthz http check %s failed: %s", check_label, exc)
+        return CheckResult(name=check_label, ok=False, detail="error")
+
+
+async def evaluate(checks: list[Any]) -> HealthReport:
+    """Run all checks concurrently and return an aggregate report.
+
+    ``checks`` is a list of coroutines (from the ``check_*`` functions
+    above). They execute concurrently via ``asyncio.gather``.
+    """
+    results = await asyncio.gather(*checks, return_exceptions=True)
+    report = HealthReport()
+    for r in results:
+        if isinstance(r, CheckResult):
+            report.checks.append(r)
+        else:
+            # A check raised unexpectedly — treat as failure.
+            report.checks.append(CheckResult(name="unknown", ok=False, detail="error"))
+    return report

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic>=2.7",
     "pydantic-settings>=2.3",
     "sqlalchemy>=2.0",
+    "httpx>=0.27",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -31,3 +32,4 @@ bypass-selection = true
 "token_utils.py" = "common/token_utils.py"
 "format_inference.py" = "common/format_inference.py"
 "cache.py" = "common/cache.py"
+"health.py" = "common/health.py"

--- a/services/analytics/analytics_service/main.py
+++ b/services/analytics/analytics_service/main.py
@@ -1387,10 +1387,12 @@ async def healthz() -> JSONResponse:
     from common.health import check_db, check_redis, evaluate
 
     redis_client = await get_redis(get_settings().redis_url)
-    report = await evaluate([
-        check_db(get_sessionmaker()),
-        check_redis(redis_client),
-    ])
+    report = await evaluate(
+        [
+            check_db(get_sessionmaker()),
+            check_redis(redis_client),
+        ]
+    )
     return JSONResponse(
         content=report.to_dict(SERVICE_NAME),
         status_code=report.http_status,

--- a/services/analytics/analytics_service/main.py
+++ b/services/analytics/analytics_service/main.py
@@ -10,6 +10,7 @@ from datetime import UTC, date, datetime, timedelta
 from typing import Annotated, Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, HTTPException, Query, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -1382,5 +1383,15 @@ app.include_router(admin_router)
 
 @app.get("/healthz")
 @app.get("/analytics/healthz")
-async def healthz() -> dict[str, str]:
-    return {"status": "ok", "service": SERVICE_NAME}
+async def healthz() -> JSONResponse:
+    from common.health import check_db, check_redis, evaluate
+
+    redis_client = await get_redis(get_settings().redis_url)
+    report = await evaluate([
+        check_db(get_sessionmaker()),
+        check_redis(redis_client),
+    ])
+    return JSONResponse(
+        content=report.to_dict(SERVICE_NAME),
+        status_code=report.http_status,
+    )

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, status
+from fastapi.responses import JSONResponse
 from redis.asyncio import Redis
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
@@ -136,8 +137,18 @@ def _client_ip(request: Request) -> str | None:
 
 @app.get("/healthz")
 @app.get("/auth/healthz")
-async def healthz() -> dict[str, str]:
-    return {"status": "ok", "service": SERVICE_NAME}
+async def healthz() -> Response:
+    from auth_service.db import get_sessionmaker as _get_sm
+    from common.health import check_db, check_redis, evaluate
+
+    report = await evaluate([
+        check_db(_get_sm()),
+        check_redis(_get_or_create_redis()),
+    ])
+    return JSONResponse(
+        content=report.to_dict(SERVICE_NAME),
+        status_code=report.http_status,
+    )
 
 
 @app.post("/auth/login", response_model=TokenResponse)

--- a/services/auth/auth_service/main.py
+++ b/services/auth/auth_service/main.py
@@ -141,10 +141,12 @@ async def healthz() -> Response:
     from auth_service.db import get_sessionmaker as _get_sm
     from common.health import check_db, check_redis, evaluate
 
-    report = await evaluate([
-        check_db(_get_sm()),
-        check_redis(_get_or_create_redis()),
-    ])
+    report = await evaluate(
+        [
+            check_db(_get_sm()),
+            check_redis(_get_or_create_redis()),
+        ]
+    )
     return JSONResponse(
         content=report.to_dict(SERVICE_NAME),
         status_code=report.http_status,

--- a/services/ingest/ingest_service/main.py
+++ b/services/ingest/ingest_service/main.py
@@ -162,10 +162,12 @@ async def healthz() -> JSONResponse:
     from ingest_service.db import get_sessionmaker as _get_sm
 
     redis_client = await get_redis(get_settings().redis_url)
-    report = await evaluate([
-        check_db(_get_sm()),
-        check_redis(redis_client),
-    ])
+    report = await evaluate(
+        [
+            check_db(_get_sm()),
+            check_redis(redis_client),
+        ]
+    )
     return JSONResponse(
         content=report.to_dict(SERVICE_NAME),
         status_code=report.http_status,

--- a/services/ingest/ingest_service/main.py
+++ b/services/ingest/ingest_service/main.py
@@ -157,8 +157,19 @@ def reset_publisher() -> None:
 
 @app.get("/healthz")
 @app.get("/ingest/healthz")
-async def healthz() -> dict[str, str]:
-    return {"status": "ok", "service": SERVICE_NAME}
+async def healthz() -> JSONResponse:
+    from common.health import check_db, check_redis, evaluate
+    from ingest_service.db import get_sessionmaker as _get_sm
+
+    redis_client = await get_redis(get_settings().redis_url)
+    report = await evaluate([
+        check_db(_get_sm()),
+        check_redis(redis_client),
+    ])
+    return JSONResponse(
+        content=report.to_dict(SERVICE_NAME),
+        status_code=report.http_status,
+    )
 
 
 def _too_large() -> HTTPException:

--- a/services/parser/parser_service/main.py
+++ b/services/parser/parser_service/main.py
@@ -126,10 +126,12 @@ async def healthz() -> JSONResponse:
     from common.health import check_db, check_redis, evaluate
 
     redis_client = await get_redis(get_settings().redis_url)
-    report = await evaluate([
-        check_db(get_sessionmaker()),
-        check_redis(redis_client),
-    ])
+    report = await evaluate(
+        [
+            check_db(get_sessionmaker()),
+            check_redis(redis_client),
+        ]
+    )
     return JSONResponse(
         content=report.to_dict(SERVICE_NAME),
         status_code=report.http_status,

--- a/services/parser/parser_service/main.py
+++ b/services/parser/parser_service/main.py
@@ -14,6 +14,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
 from common.logging import configure_logging
 from common.metrics import mount_metrics
@@ -121,5 +122,15 @@ app.include_router(_reparse_router)
 
 @app.get("/healthz")
 @app.get("/parser/healthz")
-async def healthz() -> dict[str, str]:
-    return {"status": "ok", "service": SERVICE_NAME}
+async def healthz() -> JSONResponse:
+    from common.health import check_db, check_redis, evaluate
+
+    redis_client = await get_redis(get_settings().redis_url)
+    report = await evaluate([
+        check_db(get_sessionmaker()),
+        check_redis(redis_client),
+    ])
+    return JSONResponse(
+        content=report.to_dict(SERVICE_NAME),
+        status_code=report.http_status,
+    )

--- a/services/parser/tests/test_healthz.py
+++ b/services/parser/tests/test_healthz.py
@@ -1,8 +1,7 @@
-"""Smoke test for the parser /healthz + /parser/healthz endpoints.
+"""Tests for the parser /healthz + /parser/healthz endpoints.
 
-The parser app starts a Redis consumer task on lifespan startup;
-the test patches the start hook to a no-op so this stays a pure HTTP
-smoke test (no live Redis or Postgres required).
+Covers both the happy path (all deps healthy) and degraded states
+(DB failure, Redis failure) via mocked check helpers.
 """
 
 from __future__ import annotations
@@ -10,10 +9,13 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+
+from common.health import CheckResult, HealthReport
 
 
 def _stub_env(repo_root: Path) -> None:
@@ -38,8 +40,6 @@ async def client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
     async def _noop() -> None:
         return None
 
-    # Skip the live Redis/Postgres bring-up; just run lifespan with stubs
-    # so the FastAPI app boots cleanly.
     monkeypatch.setattr(_main, "_start_consumer", _noop)
     monkeypatch.setattr(_main, "_stop_consumer", _noop)
 
@@ -48,15 +48,66 @@ async def client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
         yield ac
 
 
+def _healthy_report() -> HealthReport:
+    return HealthReport(checks=[
+        CheckResult(name="db", ok=True),
+        CheckResult(name="redis", ok=True),
+    ])
+
+
+def _db_down_report() -> HealthReport:
+    return HealthReport(checks=[
+        CheckResult(name="db", ok=False, detail="error"),
+        CheckResult(name="redis", ok=True),
+    ])
+
+
+def _redis_down_report() -> HealthReport:
+    return HealthReport(checks=[
+        CheckResult(name="db", ok=True),
+        CheckResult(name="redis", ok=False, detail="error"),
+    ])
+
+
 @pytest.mark.asyncio
-async def test_healthz_alias(client: AsyncClient) -> None:
-    r = await client.get("/healthz")
+async def test_healthz_all_healthy(client: AsyncClient) -> None:
+    with patch("common.health.evaluate", new_callable=AsyncMock, return_value=_healthy_report()):
+        r = await client.get("/healthz")
     assert r.status_code == 200
-    assert r.json() == {"status": "ok", "service": "parser"}
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "parser"
+    assert body["db"] == "ok"
+    assert body["redis"] == "ok"
 
 
 @pytest.mark.asyncio
 async def test_parser_healthz_canonical(client: AsyncClient) -> None:
-    r = await client.get("/parser/healthz")
+    with patch("common.health.evaluate", new_callable=AsyncMock, return_value=_healthy_report()):
+        r = await client.get("/parser/healthz")
     assert r.status_code == 200
-    assert r.json() == {"status": "ok", "service": "parser"}
+    assert r.json()["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_healthz_db_failure(client: AsyncClient) -> None:
+    with patch("common.health.evaluate", new_callable=AsyncMock, return_value=_db_down_report()):
+        r = await client.get("/healthz")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["status"] == "degraded"
+    assert body["db"] == "error"
+    assert body["redis"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_healthz_redis_failure(client: AsyncClient) -> None:
+    with patch(
+        "common.health.evaluate", new_callable=AsyncMock, return_value=_redis_down_report()
+    ):
+        r = await client.get("/healthz")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["status"] == "degraded"
+    assert body["db"] == "ok"
+    assert body["redis"] == "error"

--- a/services/parser/tests/test_healthz.py
+++ b/services/parser/tests/test_healthz.py
@@ -49,24 +49,30 @@ async def client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
 
 
 def _healthy_report() -> HealthReport:
-    return HealthReport(checks=[
-        CheckResult(name="db", ok=True),
-        CheckResult(name="redis", ok=True),
-    ])
+    return HealthReport(
+        checks=[
+            CheckResult(name="db", ok=True),
+            CheckResult(name="redis", ok=True),
+        ]
+    )
 
 
 def _db_down_report() -> HealthReport:
-    return HealthReport(checks=[
-        CheckResult(name="db", ok=False, detail="error"),
-        CheckResult(name="redis", ok=True),
-    ])
+    return HealthReport(
+        checks=[
+            CheckResult(name="db", ok=False, detail="error"),
+            CheckResult(name="redis", ok=True),
+        ]
+    )
 
 
 def _redis_down_report() -> HealthReport:
-    return HealthReport(checks=[
-        CheckResult(name="db", ok=True),
-        CheckResult(name="redis", ok=False, detail="error"),
-    ])
+    return HealthReport(
+        checks=[
+            CheckResult(name="db", ok=True),
+            CheckResult(name="redis", ok=False, detail="error"),
+        ]
+    )
 
 
 @pytest.mark.asyncio
@@ -102,9 +108,7 @@ async def test_healthz_db_failure(client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_healthz_redis_failure(client: AsyncClient) -> None:
-    with patch(
-        "common.health.evaluate", new_callable=AsyncMock, return_value=_redis_down_report()
-    ):
+    with patch("common.health.evaluate", new_callable=AsyncMock, return_value=_redis_down_report()):
         r = await client.get("/healthz")
     assert r.status_code == 503
     body = r.json()

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -129,8 +129,18 @@ templates.TemplateResponse = _patched_template_response  # type: ignore[assignme
 
 @app.get("/healthz")
 @app.get("/web/healthz")
-async def healthz() -> dict[str, str]:
-    return {"status": "ok", "service": SERVICE_NAME}
+async def healthz() -> JSONResponse:
+    from common.health import check_http, evaluate
+
+    settings = get_settings()
+    report = await evaluate([
+        check_http(f"{settings.auth_service_url}/healthz", "auth"),
+        check_http(f"{settings.analytics_service_url}/healthz", "analytics"),
+    ])
+    return JSONResponse(
+        content=report.to_dict(SERVICE_NAME),
+        status_code=report.http_status,
+    )
 
 
 _ADMIN_LANDING_PATH = "/admin/users"

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -133,10 +133,12 @@ async def healthz() -> JSONResponse:
     from common.health import check_http, evaluate
 
     settings = get_settings()
-    report = await evaluate([
-        check_http(f"{settings.auth_service_url}/healthz", "auth"),
-        check_http(f"{settings.analytics_service_url}/healthz", "analytics"),
-    ])
+    report = await evaluate(
+        [
+            check_http(f"{settings.auth_service_url}/healthz", "auth"),
+            check_http(f"{settings.analytics_service_url}/healthz", "analytics"),
+        ]
+    )
     return JSONResponse(
         content=report.to_dict(SERVICE_NAME),
         status_code=report.http_status,

--- a/services/web/web_service/main.py
+++ b/services/web/web_service/main.py
@@ -137,6 +137,7 @@ async def healthz() -> JSONResponse:
         [
             check_http(f"{settings.auth_service_url}/healthz", "auth"),
             check_http(f"{settings.analytics_service_url}/healthz", "analytics"),
+            check_http(f"{settings.parser_service_url}/healthz", "parser"),
         ]
     )
     return JSONResponse(

--- a/tests/common/test_health.py
+++ b/tests/common/test_health.py
@@ -26,30 +26,36 @@ from common.health import (
 
 
 def test_health_report_all_ok() -> None:
-    report = HealthReport(checks=[
-        CheckResult(name="db", ok=True),
-        CheckResult(name="redis", ok=True),
-    ])
+    report = HealthReport(
+        checks=[
+            CheckResult(name="db", ok=True),
+            CheckResult(name="redis", ok=True),
+        ]
+    )
     assert report.healthy is True
     assert report.status == "ok"
     assert report.http_status == 200
 
 
 def test_health_report_one_failed() -> None:
-    report = HealthReport(checks=[
-        CheckResult(name="db", ok=False, detail="error"),
-        CheckResult(name="redis", ok=True),
-    ])
+    report = HealthReport(
+        checks=[
+            CheckResult(name="db", ok=False, detail="error"),
+            CheckResult(name="redis", ok=True),
+        ]
+    )
     assert report.healthy is False
     assert report.status == "degraded"
     assert report.http_status == 503
 
 
 def test_health_report_to_dict() -> None:
-    report = HealthReport(checks=[
-        CheckResult(name="db", ok=True),
-        CheckResult(name="redis", ok=False, detail="error"),
-    ])
+    report = HealthReport(
+        checks=[
+            CheckResult(name="db", ok=True),
+            CheckResult(name="redis", ok=False, detail="error"),
+        ]
+    )
     d = report.to_dict("auth")
     assert d == {
         "status": "degraded",

--- a/tests/common/test_health.py
+++ b/tests/common/test_health.py
@@ -1,0 +1,231 @@
+"""Unit tests for the common.health dependency-check helpers.
+
+These tests mock DB sessions and Redis clients to verify the check
+logic without any live infrastructure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from common.health import (
+    CheckResult,
+    HealthReport,
+    check_db,
+    check_http,
+    check_redis,
+    evaluate,
+)
+
+# ---------------------------------------------------------------------------
+# CheckResult / HealthReport unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_health_report_all_ok() -> None:
+    report = HealthReport(checks=[
+        CheckResult(name="db", ok=True),
+        CheckResult(name="redis", ok=True),
+    ])
+    assert report.healthy is True
+    assert report.status == "ok"
+    assert report.http_status == 200
+
+
+def test_health_report_one_failed() -> None:
+    report = HealthReport(checks=[
+        CheckResult(name="db", ok=False, detail="error"),
+        CheckResult(name="redis", ok=True),
+    ])
+    assert report.healthy is False
+    assert report.status == "degraded"
+    assert report.http_status == 503
+
+
+def test_health_report_to_dict() -> None:
+    report = HealthReport(checks=[
+        CheckResult(name="db", ok=True),
+        CheckResult(name="redis", ok=False, detail="error"),
+    ])
+    d = report.to_dict("auth")
+    assert d == {
+        "status": "degraded",
+        "service": "auth",
+        "db": "ok",
+        "redis": "error",
+    }
+
+
+# ---------------------------------------------------------------------------
+# check_db
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_db_success() -> None:
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock()
+
+    mock_sm = MagicMock()
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_sm.return_value = mock_ctx
+
+    result = await check_db(mock_sm)
+    assert result.ok is True
+    assert result.name == "db"
+    assert result.detail == "ok"
+
+
+@pytest.mark.asyncio
+async def test_check_db_failure() -> None:
+    mock_sm = MagicMock()
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(side_effect=ConnectionRefusedError("connection refused"))
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_sm.return_value = mock_ctx
+
+    result = await check_db(mock_sm)
+    assert result.ok is False
+    assert result.name == "db"
+    assert result.detail == "error"
+
+
+@pytest.mark.asyncio
+async def test_check_db_timeout() -> None:
+    """A DB that hangs beyond 2 seconds should be reported as failed."""
+
+    async def _hang(*_args, **_kwargs):
+        await asyncio.sleep(10)
+
+    mock_session = AsyncMock()
+    mock_session.execute = _hang
+
+    mock_sm = MagicMock()
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_sm.return_value = mock_ctx
+
+    # Patch the timeout to be very short for test speed
+    with patch("common.health._TIMEOUT_SECONDS", 0.05):
+        result = await check_db(mock_sm)
+    assert result.ok is False
+    assert result.detail == "error"
+
+
+# ---------------------------------------------------------------------------
+# check_redis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_redis_success() -> None:
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(return_value=True)
+
+    result = await check_redis(mock_redis)
+    assert result.ok is True
+    assert result.name == "redis"
+
+
+@pytest.mark.asyncio
+async def test_check_redis_failure() -> None:
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    result = await check_redis(mock_redis)
+    assert result.ok is False
+    assert result.name == "redis"
+    assert result.detail == "error"
+
+
+@pytest.mark.asyncio
+async def test_check_redis_timeout() -> None:
+    """A Redis that hangs beyond 2 seconds should be reported as failed."""
+
+    async def _hang(*_args, **_kwargs):
+        await asyncio.sleep(10)
+
+    mock_redis = AsyncMock()
+    mock_redis.ping = _hang
+
+    with patch("common.health._TIMEOUT_SECONDS", 0.05):
+        result = await check_redis(mock_redis)
+    assert result.ok is False
+    assert result.detail == "error"
+
+
+# ---------------------------------------------------------------------------
+# check_http
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_http_success() -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("common.health.httpx.AsyncClient", return_value=mock_client):
+        result = await check_http("http://auth:8000/healthz", "auth")
+    assert result.ok is True
+    assert result.name == "auth"
+
+
+@pytest.mark.asyncio
+async def test_check_http_failure() -> None:
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=ConnectionError("refused"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("common.health.httpx.AsyncClient", return_value=mock_client):
+        result = await check_http("http://auth:8000/healthz", "auth")
+    assert result.ok is False
+    assert result.name == "auth"
+    assert result.detail == "error"
+
+
+# ---------------------------------------------------------------------------
+# evaluate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_all_healthy() -> None:
+    async def _ok_db():
+        return CheckResult(name="db", ok=True)
+
+    async def _ok_redis():
+        return CheckResult(name="redis", ok=True)
+
+    report = await evaluate([_ok_db(), _ok_redis()])
+    assert report.healthy is True
+    assert report.http_status == 200
+    assert len(report.checks) == 2
+
+
+@pytest.mark.asyncio
+async def test_evaluate_one_degraded() -> None:
+    async def _ok_db():
+        return CheckResult(name="db", ok=True)
+
+    async def _bad_redis():
+        return CheckResult(name="redis", ok=False, detail="error")
+
+    report = await evaluate([_ok_db(), _bad_redis()])
+    assert report.healthy is False
+    assert report.http_status == 503
+    d = report.to_dict("parser")
+    assert d["status"] == "degraded"
+    assert d["db"] == "ok"
+    assert d["redis"] == "error"


### PR DESCRIPTION
## Summary

- Add `common/health.py` with shared dependency-check helpers (`check_db`, `check_redis`, `check_http`, `evaluate`) that run probes with a 2-second timeout and return structured `HealthReport` results
- Update healthz endpoints in **auth**, **ingest**, **parser**, and **analytics** to check both Postgres (SELECT 1) and Redis (PING), returning `{"status": "degraded", ...}` with HTTP 503 when any dependency is down
- Update **web** service healthz to check upstream auth and analytics services via HTTP rather than DB/Redis directly (web has no direct DB connection)
- Gateway left unchanged (Caddy handles its own health probing)
- Response format: `{"status": "ok"|"degraded", "service": "<name>", "db": "ok"|"error", "redis": "ok"|"error"}`

## Test plan

- [x] 13 unit tests for `common/health.py` covering: CheckResult/HealthReport data structures, DB success/failure/timeout, Redis success/failure/timeout, HTTP success/failure, evaluate aggregation
- [x] 4 integration tests for parser healthz: all healthy (200), DB failure (503), Redis failure (503), canonical path alias
- [x] Route prefix convention tests pass (all 5 services)
- [x] ruff clean, mypy clean (no new issues)
- [ ] CI compose-smoke E2E gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)