### PR TITLE
Security: restrict metrics endpoints and add CSP header

### DIFF
--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -14,6 +14,7 @@
         X-Frame-Options DENY
         Referrer-Policy strict-origin-when-cross-origin
         Permissions-Policy "camera=(), microphone=(), geolocation=()"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://unpkg.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'"
     }
 
     handle /health {
@@ -26,7 +27,10 @@
     }
 
     # Per-service Prometheus metrics — path rewritten before forwarding.
+    # Restricted to RFC 1918 ranges + loopback; public requests get 403.
     handle /auth/metrics {
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        respond @denied 403
         rewrite * /metrics
         reverse_proxy auth:8000 {
             transport http {
@@ -37,6 +41,8 @@
     }
 
     handle /ingest/metrics {
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        respond @denied 403
         rewrite * /metrics
         reverse_proxy ingest:8000 {
             transport http {
@@ -47,6 +53,8 @@
     }
 
     handle /analytics/metrics {
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        respond @denied 403
         rewrite * /metrics
         reverse_proxy analytics:8000 {
             transport http {
@@ -57,6 +65,8 @@
     }
 
     handle /parser/metrics {
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        respond @denied 403
         rewrite * /metrics
         reverse_proxy parser:8000 {
             transport http {
@@ -67,11 +77,15 @@
     }
 
     handle /postgres/metrics {
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        respond @denied 403
         rewrite * /metrics
         reverse_proxy postgres-exporter:9187
     }
 
     handle /redis/metrics {
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        respond @denied 403
         rewrite * /metrics
         reverse_proxy redis-exporter:9121
     }

--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -29,7 +29,7 @@
     # Per-service Prometheus metrics — path rewritten before forwarding.
     # Restricted to RFC 1918 ranges + loopback; public requests get 403.
     handle /auth/metrics {
-        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
         respond @denied 403
         rewrite * /metrics
         reverse_proxy auth:8000 {
@@ -41,7 +41,7 @@
     }
 
     handle /ingest/metrics {
-        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
         respond @denied 403
         rewrite * /metrics
         reverse_proxy ingest:8000 {
@@ -53,7 +53,7 @@
     }
 
     handle /analytics/metrics {
-        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
         respond @denied 403
         rewrite * /metrics
         reverse_proxy analytics:8000 {
@@ -65,7 +65,7 @@
     }
 
     handle /parser/metrics {
-        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
         respond @denied 403
         rewrite * /metrics
         reverse_proxy parser:8000 {
@@ -77,14 +77,14 @@
     }
 
     handle /postgres/metrics {
-        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
         respond @denied 403
         rewrite * /metrics
         reverse_proxy postgres-exporter:9187
     }
 
     handle /redis/metrics {
-        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12
+        @denied not remote_ip 127.0.0.1 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
         respond @denied 403
         rewrite * /metrics
         reverse_proxy redis-exporter:9121


### PR DESCRIPTION
## Summary
- Restrict all per-service `/*/metrics` endpoints (auth, ingest, analytics, parser, postgres, redis) to RFC 1918 ranges (`10.0.0.0/8`, `172.16.0.0/12`) and loopback (`127.0.0.1`). Public requests now receive 403. The gateway-level `/metrics` endpoint was already protected by fleet-caddy IP restriction.
- Add a `Content-Security-Policy` header to the global header block, whitelisting CDN origins used by the frontend (Tailwind CSS, htmx, Alpine.js, Google Fonts).

## Test plan
- [ ] Deploy to edge.int and verify Prometheus scrape still works from the internal monitoring stack
- [ ] Confirm public requests to `/auth/metrics`, `/ingest/metrics`, etc. return 403
- [ ] Confirm `/metrics` (gateway-level) still works from lab IPs
- [ ] Verify the web dashboard loads correctly with the new CSP header (no console errors for blocked resources)
- [ ] Check browser DevTools Network tab to confirm CSP header is present on responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)