### PR TITLE
Fix: CAST(:oracle_id AS uuid) syntax in card_game_stats INSERT

### DIFF
--- a/services/parser/parser_service/consumer.py
+++ b/services/parser/parser_service/consumer.py
@@ -702,7 +702,7 @@ async def _materialize_card_game_stats(
                     "(match_id, game_id, oracle_id, card_name, is_local, "
                     ' seen, "cast", played, is_postboard, won, quantity, game_number, '
                     " first_cast_turn) "
-                    "VALUES (:match_id, :game_id, :oracle_id::uuid, :card_name, :is_local, "
+                    "VALUES (:match_id, :game_id, CAST(:oracle_id AS uuid), :card_name, :is_local, "
                     " :seen, :cast, :played, :is_postboard, :won, :quantity, :game_number, "
                     " :first_cast_turn) "
                     "ON CONFLICT (game_id, card_name, is_local) DO UPDATE SET "


### PR DESCRIPTION
## Summary
- Every card_game_stats materialization fails in production with `syntax error at or near ":" at character 190`
- The `:oracle_id::uuid` cast conflicts with asyncpg parameter parsing
- Same pattern fixed in the ingest version gate tests

## Test plan
- [ ] Verify Loki stops showing the syntax errors after deploy
- [ ] Verify card_game_stats rows are being populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)