### PR TITLE
Refactor: consolidate HTTP client boilerplate into shared helper

### DIFF
--- a/services/web/web_service/analytics_client.py
+++ b/services/web/web_service/analytics_client.py
@@ -13,7 +13,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
-import httpx
+from web_service.http_helper import parse_dt as _parse_dt
+from web_service.http_helper import raw_request, request
 
 
 @dataclass
@@ -35,13 +36,9 @@ class AnalyticsForbidden(Exception):
     """Analytics rejected the request as 401/403."""
 
 
-def _parse_dt(raw: Any) -> datetime | None:
-    if not raw:
-        return None
-    try:
-        return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
-    except ValueError:
-        return None
+# Shorthand kwargs for all analytics helpers.
+_ERR = {"error_cls": AnalyticsClientError, "forbidden_cls": AnalyticsForbidden}
+_ERR_RAW = {"error_cls": AnalyticsClientError}
 
 
 def _to_item(payload: dict[str, Any]) -> ArchetypeItem:
@@ -60,20 +57,13 @@ async def admin_list_archetypes(
     base_url: str,
     token: str,
 ) -> tuple[list[ArchetypeItem], int]:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/archetypes",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics GET /archetypes transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /archetypes returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /archetypes returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/archetypes",
+        token=token,
+        error_prefix="analytics GET /archetypes ",
+        **_ERR,
+    )
     data = resp.json()
     items = [_to_item(a) for a in data.get("archetypes", [])]
     return items, int(data.get("total", len(items)))
@@ -85,16 +75,13 @@ async def admin_get_archetype(
     archetype_id: str,
 ) -> ArchetypeItem | None:
     """Fetch a single archetype. Returns None on 404."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/archetypes/{archetype_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /archetypes/{{id}} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "GET",
+        f"{base_url}/analytics/archetypes/{archetype_id}",
+        token=token,
+        error_prefix="analytics GET /archetypes/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 404:
         return None
     if resp.status_code in (401, 403):
@@ -120,15 +107,14 @@ async def admin_create_archetype(
         "format": format_,
         "defining_cards": defining_cards,
     }
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/analytics/archetypes",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body,
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics POST /archetypes transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/analytics/archetypes",
+        token=token,
+        json=body,
+        error_prefix="analytics POST /archetypes ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (200, 201):
         return _to_item(resp.json()), None
     if resp.status_code in (401, 403):
@@ -154,17 +140,14 @@ async def admin_update_archetype(
         "format": format_,
         "defining_cards": defining_cards,
     }
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.put(
-                f"{base_url}/analytics/archetypes/{archetype_id}",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body,
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics PUT /archetypes/{{id}} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "PUT",
+        f"{base_url}/analytics/archetypes/{archetype_id}",
+        token=token,
+        json=body,
+        error_prefix="analytics PUT /archetypes/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         return _to_item(resp.json()), None
     if resp.status_code in (401, 403):
@@ -184,16 +167,13 @@ async def admin_delete_archetype(
     archetype_id: str,
 ) -> tuple[bool, str | None]:
     """Delete. (True, None) on 204, (False, code) on 404."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.delete(
-                f"{base_url}/analytics/archetypes/{archetype_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics DELETE /archetypes/{{id}} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "DELETE",
+        f"{base_url}/analytics/archetypes/{archetype_id}",
+        token=token,
+        error_prefix="analytics DELETE /archetypes/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):
@@ -308,21 +288,14 @@ async def get_stats_summary(
         params["date_from"] = date_from
     if date_to:
         params["date_to"] = date_to
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/summary",
-                params=params,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics GET /stats/summary transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /stats/summary returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/summary returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/summary",
+        token=token,
+        params=params,
+        error_prefix="analytics GET /stats/summary ",
+        **_ERR,
+    )
     return _to_summary(resp.json())
 
 
@@ -338,23 +311,14 @@ async def get_stats_by_format(
         params["date_from"] = date_from
     if date_to:
         params["date_to"] = date_to
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/by-format",
-                params=params,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/by-format transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /stats/by-format returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/by-format returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/by-format",
+        token=token,
+        params=params,
+        error_prefix="analytics GET /stats/by-format ",
+        **_ERR,
+    )
     return [_to_format_stat(row) for row in resp.json()]
 
 
@@ -385,19 +349,14 @@ def _to_card(payload: dict[str, Any]) -> CardItem:
 
 
 async def search_cards(base_url: str, token: str, q: str) -> list[CardItem]:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/cards",
-                params={"q": q},
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics GET /cards transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /cards returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(f"analytics GET /cards returned {resp.status_code}: {resp.text}")
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/cards",
+        token=token,
+        params={"q": q},
+        error_prefix="analytics GET /cards ",
+        **_ERR,
+    )
     return [_to_card(row) for row in resp.json()]
 
 
@@ -407,22 +366,13 @@ async def search_cards(base_url: str, token: str, q: str) -> list[CardItem]:
 
 
 async def admin_get_cards_status(base_url: str, token: str) -> dict[str, Any]:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/admin/cards-status",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/cards-status transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /admin/cards-status returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/cards-status returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/admin/cards-status",
+        token=token,
+        error_prefix="analytics GET /admin/cards-status ",
+        **_ERR,
+    )
     payload = resp.json()
     return {
         "card_count": int(payload.get("card_count") or 0),
@@ -434,23 +384,14 @@ async def admin_get_scraper_health(
     base_url: str, token: str, scraper_name: str = "mtgo"
 ) -> dict[str, Any]:
     """Fetch health for a single scraper by name."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/admin/scraper-health",
-                params={"scraper_name": scraper_name},
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/scraper-health transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /admin/scraper-health returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/scraper-health returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/admin/scraper-health",
+        token=token,
+        params={"scraper_name": scraper_name},
+        error_prefix="analytics GET /admin/scraper-health ",
+        **_ERR,
+    )
     return _parse_scraper_health(resp.json())
 
 
@@ -468,22 +409,13 @@ def _parse_scraper_health(payload: dict[str, Any]) -> dict[str, Any]:
 
 async def admin_get_all_scraper_health(base_url: str, token: str) -> list[dict[str, Any]]:
     """Fetch health for all registered scrapers (v0.9.4+)."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/admin/scraper-health",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/scraper-health transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /admin/scraper-health returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/scraper-health returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/admin/scraper-health",
+        token=token,
+        error_prefix="analytics GET /admin/scraper-health ",
+        **_ERR,
+    )
     payload = resp.json()
     scrapers = payload.get("scrapers")
     if isinstance(scrapers, list):
@@ -494,16 +426,13 @@ async def admin_get_all_scraper_health(base_url: str, token: str) -> list[dict[s
 
 async def admin_trigger_mtgtop8_scrape(base_url: str, token: str) -> bool:
     """Trigger an mtgtop8 results scrape. Returns True on 202."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/analytics/admin/scrape-mtgtop8",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics POST /admin/scrape-mtgtop8 transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/analytics/admin/scrape-mtgtop8",
+        token=token,
+        error_prefix="analytics POST /admin/scrape-mtgtop8 ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 202:
         return True
     if resp.status_code in (401, 403):
@@ -519,40 +448,26 @@ async def admin_reset_scraper_health(
     base_url: str, token: str, scraper_name: str
 ) -> dict[str, Any]:
     """Reset a scraper's failure counters."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/analytics/admin/scraper-health/reset",
-                params={"scraper_name": scraper_name},
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics POST /admin/scraper-health/reset transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics POST /admin/scraper-health/reset returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics POST /admin/scraper-health/reset returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "POST",
+        f"{base_url}/analytics/admin/scraper-health/reset",
+        token=token,
+        params={"scraper_name": scraper_name},
+        error_prefix="analytics POST /admin/scraper-health/reset ",
+        **_ERR,
+    )
     return _parse_scraper_health(resp.json())
 
 
 async def admin_trigger_sync(base_url: str, token: str) -> bool:
     """Kick off a card sync. Returns True on 202 (sync scheduled)."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/analytics/admin/sync-cards",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics POST /admin/sync-cards transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/analytics/admin/sync-cards",
+        token=token,
+        error_prefix="analytics POST /admin/sync-cards ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 202:
         return True
     if resp.status_code in (401, 403):
@@ -564,16 +479,13 @@ async def admin_trigger_sync(base_url: str, token: str) -> bool:
 
 async def admin_trigger_mtgo_scrape(base_url: str, token: str) -> bool:
     """Trigger an MTGO results scrape. Returns True on 202."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/analytics/admin/scrape-mtgo",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics POST /admin/scrape-mtgo transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/analytics/admin/scrape-mtgo",
+        token=token,
+        error_prefix="analytics POST /admin/scrape-mtgo ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 202:
         return True
     if resp.status_code in (401, 403):
@@ -638,14 +550,13 @@ def _to_match_detail(payload: dict[str, Any]) -> MatchDetail:
 
 async def get_match_detail(base_url: str, token: str, match_id: str) -> MatchDetail | None:
     """Fetch a single match. Returns None on 404."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/matches/{match_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics GET /matches/{{id}} transport error: {exc}") from exc
+    resp = await raw_request(
+        "GET",
+        f"{base_url}/analytics/matches/{match_id}",
+        token=token,
+        error_prefix="analytics GET /matches/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 404:
         return None
     if resp.status_code in (401, 403):
@@ -659,16 +570,13 @@ async def get_match_detail(base_url: str, token: str, match_id: str) -> MatchDet
 
 async def admin_get_match_detail(base_url: str, token: str, match_id: str) -> MatchDetail | None:
     """Admin: fetch any match regardless of owner/review status. Returns None on 404."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/matches/admin/{match_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /matches/admin/{{id}} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "GET",
+        f"{base_url}/analytics/matches/admin/{match_id}",
+        token=token,
+        error_prefix="analytics GET /matches/admin/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 404:
         return None
     if resp.status_code in (401, 403):
@@ -682,15 +590,14 @@ async def admin_get_match_detail(base_url: str, token: str, match_id: str) -> Ma
 
 async def update_match_format(base_url: str, token: str, match_id: str, format_: str) -> bool:
     """PATCH the format on a match. Returns True on success."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.patch(
-                f"{base_url}/analytics/matches/{match_id}/format",
-                headers={"Authorization": f"Bearer {token}"},
-                json={"format": format_},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics PATCH /matches/{{id}}/format error: {exc}") from exc
+    resp = await raw_request(
+        "PATCH",
+        f"{base_url}/analytics/matches/{match_id}/format",
+        token=token,
+        json={"format": format_},
+        error_prefix="analytics PATCH /matches/{id}/format ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True
     if resp.status_code in (401, 403):
@@ -754,21 +661,14 @@ async def get_match_list(
         params["date_from"] = date_from
     if date_to:
         params["date_to"] = date_to
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/matches",
-                params=params,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics GET /stats/matches transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /stats/matches returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/matches returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/matches",
+        token=token,
+        params=params,
+        error_prefix="analytics GET /stats/matches ",
+        **_ERR,
+    )
     data = resp.json()
     return MatchListResponse(
         matches=[_to_match_list_item(m) for m in data.get("matches", [])],
@@ -785,24 +685,13 @@ class UsernameSuggestionItem:
 
 
 async def get_username_suggestions(base_url: str, token: str) -> list[UsernameSuggestionItem]:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/username-suggestion",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/username-suggestion transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics GET /stats/username-suggestion returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/username-suggestion returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/username-suggestion",
+        token=token,
+        error_prefix="analytics GET /stats/username-suggestion ",
+        **_ERR,
+    )
     return [
         UsernameSuggestionItem(
             username=str(row.get("username", "")),
@@ -813,22 +702,13 @@ async def get_username_suggestions(base_url: str, token: str) -> list[UsernameSu
 
 
 async def get_stats_by_opponent(base_url: str, token: str) -> list[OpponentStatItem]:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/by-opponent",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/by-opponent transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /stats/by-opponent returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/by-opponent returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/by-opponent",
+        token=token,
+        error_prefix="analytics GET /stats/by-opponent ",
+        **_ERR,
+    )
     return [_to_opponent_stat(row) for row in resp.json()]
 
 
@@ -904,21 +784,14 @@ async def admin_list_matches(
         params["date_to"] = date_to
     if review_status and review_status.lower() != "all":
         params["review_status"] = review_status
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/admin/matches",
-                params=params,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics GET /admin/matches transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /admin/matches returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/matches returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/admin/matches",
+        token=token,
+        params=params,
+        error_prefix="analytics GET /admin/matches ",
+        **_ERR,
+    )
     data = resp.json()
     return AdminMatchListResponse(
         matches=[_to_admin_match(m) for m in data.get("matches", [])],
@@ -942,17 +815,14 @@ async def admin_set_match_review_status(
     or ``(None, "invalid_review_status")`` on 422.
     """
     body = {"review_status": review_status}
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/analytics/admin/matches/{match_id}/review",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body,
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics POST /admin/matches/{{id}}/review transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/analytics/admin/matches/{match_id}/review",
+        token=token,
+        json=body,
+        error_prefix="analytics POST /admin/matches/{id}/review ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         return _to_admin_match(resp.json()), None
     if resp.status_code in (401, 403):
@@ -1001,23 +871,14 @@ async def get_play_draw_stats(
         params["date_from"] = date_from
     if date_to:
         params["date_to"] = date_to
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/play-draw",
-                params=params,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/play-draw transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /stats/play-draw returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/play-draw returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/play-draw",
+        token=token,
+        params=params,
+        error_prefix="analytics GET /stats/play-draw ",
+        **_ERR,
+    )
     d = resp.json()
     on_play = d.get("on_play") or {}
     on_draw = d.get("on_draw") or {}
@@ -1059,25 +920,14 @@ async def get_preboard_postboard_stats(
         params["date_from"] = date_from
     if date_to:
         params["date_to"] = date_to
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/preboard-postboard",
-                params=params,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/preboard-postboard transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics GET /stats/preboard-postboard returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/preboard-postboard returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/preboard-postboard",
+        token=token,
+        params=params,
+        error_prefix="analytics GET /stats/preboard-postboard ",
+        **_ERR,
+    )
     d = resp.json()
     preboard = d.get("preboard") or {}
     postboard = d.get("postboard") or {}
@@ -1122,23 +972,14 @@ async def get_mulligan_stats(
         params["date_from"] = date_from
     if date_to:
         params["date_to"] = date_to
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/mulligans",
-                params=params,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/mulligans transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /stats/mulligans returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/mulligans returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/mulligans",
+        token=token,
+        params=params,
+        error_prefix="analytics GET /stats/mulligans ",
+        **_ERR,
+    )
     # The analytics endpoint returns a bare JSON array of MulliganBucket
     # objects (not wrapped in {"buckets": [...]}). Each bucket uses
     # "total" for the game count, which we map to our client's "games".
@@ -1162,22 +1003,13 @@ class GameLengthStats:
 
 
 async def get_game_length_stats(base_url: str, token: str) -> GameLengthStats:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/game-length",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/game-length transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /stats/game-length returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/game-length returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/game-length",
+        token=token,
+        error_prefix="analytics GET /stats/game-length ",
+        **_ERR,
+    )
     d = resp.json()
     return GameLengthStats(buckets=d.get("buckets", []))
 
@@ -1223,21 +1055,14 @@ async def get_card_stats(
         params["date_from"] = date_from
     if date_to:
         params["date_to"] = date_to
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/cards",
-                params=params,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics GET /stats/cards transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /stats/cards returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /stats/cards returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/cards",
+        token=token,
+        params=params,
+        error_prefix="analytics GET /stats/cards ",
+        **_ERR,
+    )
     d = resp.json()
     cards = [
         CardStatItem(
@@ -1342,25 +1167,13 @@ async def get_game_turns(
     match_id: str,
     game_number: int,
 ) -> GameTurnsResponse:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/stats/matches/{match_id}/games/{game_number}/turns",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /matches/{{id}}/games/{{n}}/turns transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics GET /matches/{{id}}/games/{{n}}/turns returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /matches/{{id}}/games/{{n}}/turns "
-            f"returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/stats/matches/{match_id}/games/{game_number}/turns",
+        token=token,
+        error_prefix="analytics GET /matches/{id}/games/{n}/turns ",
+        **_ERR,
+    )
     d = resp.json()
     # The analytics endpoint returns either a bare JSON array of turn
     # objects or a wrapped object with match_id/game_number/turns keys.
@@ -1388,22 +1201,13 @@ async def get_game_turns(
 
 async def get_metagame_formats(base_url: str, token: str) -> list[dict[str, Any]]:
     """Fetch available metagame formats."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/metagame/formats",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /metagame/formats transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /metagame/formats returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /metagame/formats returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/metagame/formats",
+        token=token,
+        error_prefix="analytics GET /metagame/formats ",
+        **_ERR,
+    )
     data = resp.json()
     return list(data.get("formats", []))
 
@@ -1412,25 +1216,14 @@ async def get_metagame_tiers(
     base_url: str, token: str, format_: str, window: str = "30d"
 ) -> dict[str, Any]:
     """Fetch archetype tier list for a format."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/metagame/{format_}/tiers",
-                params={"window": window},
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /metagame/{{format}}/tiers transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics GET /metagame/{{format}}/tiers returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /metagame/{{format}}/tiers returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/metagame/{format_}/tiers",
+        token=token,
+        params={"window": window},
+        error_prefix="analytics GET /metagame/{format}/tiers ",
+        **_ERR,
+    )
     return dict(resp.json())
 
 
@@ -1438,25 +1231,14 @@ async def get_metagame_events(
     base_url: str, token: str, format_: str, page: int = 1, per_page: int = 20
 ) -> dict[str, Any]:
     """Fetch paginated events for a format."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/metagame/{format_}/events",
-                params={"page": page, "per_page": per_page},
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /metagame/{{format}}/events transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics GET /metagame/{{format}}/events returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /metagame/{{format}}/events returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/metagame/{format_}/events",
+        token=token,
+        params={"page": page, "per_page": per_page},
+        error_prefix="analytics GET /metagame/{format}/events ",
+        **_ERR,
+    )
     return dict(resp.json())
 
 
@@ -1464,16 +1246,13 @@ async def get_metagame_event_detail(
     base_url: str, token: str, format_: str, source: str, event_id: int
 ) -> dict[str, Any]:
     """Fetch a single event with results and decklists."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/metagame/{format_}/events/{source}/{event_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /metagame/{{format}}/events/{{source}}/{{id}} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "GET",
+        f"{base_url}/analytics/metagame/{format_}/events/{source}/{event_id}",
+        token=token,
+        error_prefix="analytics GET /metagame/{format}/events/{source}/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (401, 403):
         raise AnalyticsForbidden(
             f"analytics GET /metagame/event detail returned {resp.status_code}"
@@ -1491,25 +1270,14 @@ async def get_metagame_trends(
     base_url: str, token: str, format_: str, window: str = "30d"
 ) -> dict[str, Any]:
     """Fetch trend data for charting archetype popularity over time."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/metagame/{format_}/trends",
-                params={"window": window},
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /metagame/{{format}}/trends transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics GET /metagame/{{format}}/trends returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /metagame/{{format}}/trends returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/metagame/{format_}/trends",
+        token=token,
+        params={"window": window},
+        error_prefix="analytics GET /metagame/{format}/trends ",
+        **_ERR,
+    )
     return dict(resp.json())
 
 
@@ -1520,20 +1288,13 @@ async def get_metagame_trends(
 
 async def admin_get_scrapers(base_url: str, token: str) -> list[dict[str, Any]]:
     """Fetch all scrapers with config + health."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/admin/scrapers",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics GET /admin/scrapers transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /admin/scrapers returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/scrapers returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/admin/scrapers",
+        token=token,
+        error_prefix="analytics GET /admin/scrapers ",
+        **_ERR,
+    )
     data = resp.json()
     scrapers = data.get("scrapers", [])
     # Normalize datetime strings
@@ -1557,25 +1318,14 @@ async def admin_update_scraper(
         body["enabled"] = enabled
     if interval_hours is not None:
         body["interval_hours"] = interval_hours
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.patch(
-                f"{base_url}/analytics/admin/scrapers/{name}",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body,
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics PATCH /admin/scrapers/{{name}} transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics PATCH /admin/scrapers/{{name}} returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics PATCH /admin/scrapers/{{name}} returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "PATCH",
+        f"{base_url}/analytics/admin/scrapers/{name}",
+        token=token,
+        json=body,
+        error_prefix="analytics PATCH /admin/scrapers/{name} ",
+        **_ERR,
+    )
     return dict(resp.json())
 
 
@@ -1587,26 +1337,14 @@ async def admin_get_scraper_events(
     per_page: int = 20,
 ) -> dict[str, Any]:
     """Fetch paginated events for a specific scraper."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/admin/scrapers/{name}/events",
-                params={"page": page, "per_page": per_page},
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/scrapers/{{name}}/events transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics GET /admin/scrapers/{{name}}/events returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/scrapers/{{name}}/events "
-            f"returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/admin/scrapers/{name}/events",
+        token=token,
+        params={"page": page, "per_page": per_page},
+        error_prefix="analytics GET /admin/scrapers/{name}/events ",
+        **_ERR,
+    )
     return dict(resp.json())
 
 
@@ -1642,20 +1380,13 @@ async def admin_list_bnr_events(
     base_url: str,
     token: str,
 ) -> tuple[list[BnrEventItem], int]:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/bnr-events",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics GET /bnr-events transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /bnr-events returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /bnr-events returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/bnr-events",
+        token=token,
+        error_prefix="analytics GET /bnr-events ",
+        **_ERR,
+    )
     data = resp.json()
     items = [_to_bnr_event(e) for e in data.get("events", [])]
     return items, int(data.get("total", len(items)))
@@ -1667,16 +1398,13 @@ async def admin_get_bnr_event(
     event_id: str,
 ) -> BnrEventItem | None:
     """Fetch a single B&R event. Returns None on 404."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/bnr-events/{event_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /bnr-events/{{id}} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "GET",
+        f"{base_url}/analytics/bnr-events/{event_id}",
+        token=token,
+        error_prefix="analytics GET /bnr-events/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 404:
         return None
     if resp.status_code in (401, 403):
@@ -1704,15 +1432,14 @@ async def admin_create_bnr_event(
         "description": description,
         "card_actions": card_actions,
     }
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/analytics/bnr-events",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body,
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(f"analytics POST /bnr-events transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/analytics/bnr-events",
+        token=token,
+        json=body,
+        error_prefix="analytics POST /bnr-events ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (200, 201):
         return _to_bnr_event(resp.json()), None
     if resp.status_code in (401, 403):
@@ -1740,17 +1467,14 @@ async def admin_update_bnr_event(
         "description": description,
         "card_actions": card_actions,
     }
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.put(
-                f"{base_url}/analytics/bnr-events/{event_id}",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body,
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics PUT /bnr-events/{{id}} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "PUT",
+        f"{base_url}/analytics/bnr-events/{event_id}",
+        token=token,
+        json=body,
+        error_prefix="analytics PUT /bnr-events/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         return _to_bnr_event(resp.json()), None
     if resp.status_code in (401, 403):
@@ -1770,16 +1494,13 @@ async def admin_delete_bnr_event(
     event_id: str,
 ) -> tuple[bool, str | None]:
     """Delete. (True, None) on 204, (False, code) on 404."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.delete(
-                f"{base_url}/analytics/bnr-events/{event_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics DELETE /bnr-events/{{id}} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "DELETE",
+        f"{base_url}/analytics/bnr-events/{event_id}",
+        token=token,
+        error_prefix="analytics DELETE /bnr-events/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):
@@ -1793,46 +1514,27 @@ async def admin_delete_bnr_event(
 
 async def admin_import_bnr_wiki(base_url: str, token: str) -> dict[str, Any]:
     """Trigger wiki import. Returns WikiImportResult as dict."""
-    try:
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            resp = await client.post(
-                f"{base_url}/analytics/bnr-events/import-wiki",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics POST /bnr-events/import-wiki transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(
-            f"analytics POST /bnr-events/import-wiki returned {resp.status_code}"
-        )
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics POST /bnr-events/import-wiki returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "POST",
+        f"{base_url}/analytics/bnr-events/import-wiki",
+        token=token,
+        timeout=60.0,
+        error_prefix="analytics POST /bnr-events/import-wiki ",
+        **_ERR,
+    )
     return dict(resp.json())
 
 
 async def get_bnr_events_by_format(base_url: str, token: str, format_: str) -> list[BnrEventItem]:
     """Non-admin: fetch BNR events for a specific format (dashboard use)."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/bnr-events/by-format",
-                params={"format": format_},
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /bnr-events/by-format transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AnalyticsForbidden(f"analytics GET /bnr-events/by-format returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AnalyticsClientError(
-            f"analytics GET /bnr-events/by-format returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/analytics/bnr-events/by-format",
+        token=token,
+        params={"format": format_},
+        error_prefix="analytics GET /bnr-events/by-format ",
+        **_ERR,
+    )
     data = resp.json()
     return [_to_bnr_event(e) for e in data.get("events", [])]
 
@@ -1844,16 +1546,13 @@ async def admin_get_scraper_event_detail(
     event_id: int,
 ) -> dict[str, Any]:
     """Fetch a single event with results for a scraper."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/analytics/admin/scrapers/{name}/events/{event_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AnalyticsClientError(
-            f"analytics GET /admin/scrapers/{{name}}/events/{{id}} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "GET",
+        f"{base_url}/analytics/admin/scrapers/{name}/events/{event_id}",
+        token=token,
+        error_prefix="analytics GET /admin/scrapers/{name}/events/{id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (401, 403):
         raise AnalyticsForbidden(
             f"analytics GET /admin/scrapers/{{name}}/events/{{id}} returned {resp.status_code}"

--- a/services/web/web_service/auth_client.py
+++ b/services/web/web_service/auth_client.py
@@ -14,6 +14,9 @@ from typing import Any
 
 import httpx
 
+from web_service.http_helper import parse_dt as _parse_dt
+from web_service.http_helper import raw_request, request
+
 
 @dataclass
 class LoginResult:
@@ -113,24 +116,19 @@ class EmailAlreadyTaken(Exception):
     """
 
 
-def _parse_dt(raw: Any) -> datetime | None:
-    if not raw:
-        return None
-    try:
-        return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
-    except ValueError:
-        return None
+# Shorthand kwargs for all auth helpers.
+_ERR = {"error_cls": AuthClientError, "forbidden_cls": AuthForbidden}
+_ERR_RAW = {"error_cls": AuthClientError}
 
 
 async def login(base_url: str, email: str, password: str) -> LoginResult:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/auth/login",
-                json={"email": email, "password": password},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /login transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/auth/login",
+        json={"email": email, "password": password},
+        error_prefix="auth /login ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 401:
         raise InvalidCredentials()
     if resp.status_code >= 400:
@@ -158,15 +156,14 @@ async def change_password(
     longer accepted by auth (revoked, expired, or current password
     rejected) and the caller must re-authenticate.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/auth/password/change",
-                headers={"Authorization": f"Bearer {token}"},
-                json={"current_password": current_password, "new_password": new_password},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /password/change transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/auth/password/change",
+        token=token,
+        json={"current_password": current_password, "new_password": new_password},
+        error_prefix="auth /password/change ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):
@@ -195,28 +192,26 @@ async def logout(base_url: str, token: str) -> None:
     the browser's perspective, and auth /logout is idempotent.
     """
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            await client.post(
-                f"{base_url}/auth/logout",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError:
+        await raw_request(
+            "POST",
+            f"{base_url}/auth/logout",
+            token=token,
+            timeout=5.0,
+            error_prefix="auth /logout ",
+            **_ERR_RAW,
+        )
+    except (AuthClientError, httpx.HTTPError):
         return
 
 
 async def get_me(base_url: str, token: str) -> MeResult:
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/auth/me",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /me transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AuthForbidden(f"auth /me returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AuthClientError(f"auth /me returned {resp.status_code}: {resp.text}")
+    resp = await request(
+        "GET",
+        f"{base_url}/auth/me",
+        token=token,
+        error_prefix="auth /me ",
+        **_ERR,
+    )
     data = resp.json()
     return MeResult(
         user_id=int(data["user_id"]),
@@ -239,19 +234,14 @@ async def list_my_agents(
     controls. ``total`` is the unfiltered count of the caller's agents
     (matches the auth-side ``AgentListView.total``).
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/auth/me/agents",
-                headers={"Authorization": f"Bearer {token}"},
-                params={"limit": limit, "offset": offset},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /me/agents transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AuthForbidden(f"auth /me/agents returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AuthClientError(f"auth /me/agents returned {resp.status_code}: {resp.text}")
+    resp = await request(
+        "GET",
+        f"{base_url}/auth/me/agents",
+        token=token,
+        params={"limit": limit, "offset": offset},
+        error_prefix="auth /me/agents ",
+        **_ERR,
+    )
     data = resp.json()
     items = [
         AgentItem(
@@ -283,8 +273,8 @@ async def update_me(
     JWT claim and the caller's existing token is now stale.
 
     Maps known error responses to UI-stable error codes:
-      - 409 (email_already_exists) → ``UpdateMeResult(ok=False, error="email_taken")``
-      - 400/422 → ``UpdateMeResult(ok=False, error="invalid_email")``
+      - 409 (email_already_exists) -> ``UpdateMeResult(ok=False, error="email_taken")``
+      - 400/422 -> ``UpdateMeResult(ok=False, error="invalid_email")``
 
     401/403 raise :class:`AuthForbidden`; 5xx / transport raise
     :class:`AuthClientError`.
@@ -292,15 +282,14 @@ async def update_me(
     body: dict[str, object] = {"email": email}
     if mtgo_usernames is not None:
         body["mtgo_usernames"] = mtgo_usernames
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.patch(
-                f"{base_url}/auth/me",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body,
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /me PATCH transport error: {exc}") from exc
+    resp = await raw_request(
+        "PATCH",
+        f"{base_url}/auth/me",
+        token=token,
+        json=body,
+        error_prefix="auth /me PATCH ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         data = resp.json()
         return UpdateMeResult(
@@ -325,20 +314,19 @@ async def revoke_my_agent(
 ) -> tuple[bool, str | None]:
     """Try to revoke one of the caller's own agents. Returns (ok, error_code).
 
-    - 204 → (True, None)
-    - 404 → (False, "not_found")
+    - 204 -> (True, None)
+    - 404 -> (False, "not_found")
 
     401/403 raise :class:`AuthForbidden`; 5xx / transport raise
     :class:`AuthClientError`.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/auth/me/agents/{agent_id}/revoke",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /me/agents revoke transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/auth/me/agents/{agent_id}/revoke",
+        token=token,
+        error_prefix="auth /me/agents revoke ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):
@@ -361,19 +349,14 @@ async def admin_list_users(
     :class:`AuthClientError` on transport / 5xx / other non-2xx so the
     web layer can render an admin-denied page vs. a service-outage page.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/admin/users",
-                headers={"Authorization": f"Bearer {token}"},
-                params={"limit": limit, "offset": offset},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /admin/users transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AuthForbidden(f"auth /admin/users returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AuthClientError(f"auth /admin/users returned {resp.status_code}: {resp.text}")
+    resp = await request(
+        "GET",
+        f"{base_url}/admin/users",
+        token=token,
+        params={"limit": limit, "offset": offset},
+        error_prefix="auth /admin/users ",
+        **_ERR,
+    )
     data = resp.json()
     items = [
         UserItem(
@@ -398,18 +381,17 @@ async def admin_delete_user(
 ) -> tuple[bool, str | None]:
     """Admin-only: delete a user via the auth service.
 
-    - 204 → (True, None)
-    - 400 with detail.error ∈ {cannot_delete_self, cannot_delete_last_admin} → (False, code)
-    - 404 → (False, "user_not_found")
+    - 204 -> (True, None)
+    - 400 with detail.error in {cannot_delete_self, cannot_delete_last_admin} -> (False, code)
+    - 404 -> (False, "user_not_found")
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.delete(
-                f"{base_url}/admin/users/{user_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth DELETE /admin/users transport error: {exc}") from exc
+    resp = await raw_request(
+        "DELETE",
+        f"{base_url}/admin/users/{user_id}",
+        token=token,
+        error_prefix="auth DELETE /admin/users ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):
@@ -437,19 +419,14 @@ async def admin_list_agents(
     :class:`AuthClientError` on transport / 5xx so the web layer can
     distinguish the admin-denied page from a service-outage page.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/admin/agents",
-                headers={"Authorization": f"Bearer {token}"},
-                params={"limit": limit, "offset": offset},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /admin/agents transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AuthForbidden(f"auth /admin/agents returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AuthClientError(f"auth /admin/agents returned {resp.status_code}: {resp.text}")
+    resp = await request(
+        "GET",
+        f"{base_url}/admin/agents",
+        token=token,
+        params={"limit": limit, "offset": offset},
+        error_prefix="auth /admin/agents ",
+        **_ERR,
+    )
     data = resp.json()
     items = [
         AdminAgentItem(
@@ -477,20 +454,19 @@ async def admin_revoke_agent(
 ) -> tuple[bool, str | None]:
     """Admin-only: revoke any agent regardless of ownership.
 
-    - 204 → (True, None)
-    - 404 → (False, "agent_not_found")
+    - 204 -> (True, None)
+    - 404 -> (False, "agent_not_found")
 
     401/403 raise :class:`AuthForbidden`; transport / 5xx raise
     :class:`AuthClientError`.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/agents/{agent_id}/revoke",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /admin/agents revoke transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/agents/{agent_id}/revoke",
+        token=token,
+        error_prefix="auth /admin/agents revoke ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):
@@ -513,20 +489,19 @@ async def admin_rotate_agent_key(
 ) -> tuple[RotateKeyResult | None, str | None]:
     """Admin-only: rotate an agent's API token. Returns (result, error_code).
 
-    - 200 → (RotateKeyResult, None)
-    - 404 → (None, "agent_not_found")
+    - 200 -> (RotateKeyResult, None)
+    - 404 -> (None, "agent_not_found")
 
     401/403 raise :class:`AuthForbidden`; transport / 5xx raise
     :class:`AuthClientError`.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/agents/{agent_id}/rotate-key",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /admin/agents rotate-key transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/agents/{agent_id}/rotate-key",
+        token=token,
+        error_prefix="auth /admin/agents rotate-key ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         data = resp.json()
         return RotateKeyResult(
@@ -547,20 +522,19 @@ async def admin_delete_agent(
 ) -> tuple[bool, str | None]:
     """Admin-only: permanently delete an agent registration.
 
-    - 204 → (True, None)
-    - 404 → (False, "agent_not_found")
+    - 204 -> (True, None)
+    - 404 -> (False, "agent_not_found")
 
     401/403 raise :class:`AuthForbidden`; transport / 5xx raise
     :class:`AuthClientError`.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.delete(
-                f"{base_url}/admin/agents/{agent_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth DELETE /admin/agents transport error: {exc}") from exc
+    resp = await raw_request(
+        "DELETE",
+        f"{base_url}/admin/agents/{agent_id}",
+        token=token,
+        error_prefix="auth DELETE /admin/agents ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):
@@ -582,14 +556,13 @@ async def mint_registration_code(base_url: str, token: str) -> RegistrationCodeR
     401/403 raise :class:`AuthForbidden`; transport / 5xx / other
     non-2xx raise :class:`AuthClientError`.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/auth/agent/registration-code",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /agent/registration-code transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/auth/agent/registration-code",
+        token=token,
+        error_prefix="auth /agent/registration-code ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (401, 403):
         raise AuthForbidden(f"auth /agent/registration-code returned {resp.status_code}")
     if resp.status_code != 201:
@@ -621,22 +594,13 @@ async def admin_get_registration_mode(
     transport / 5xx so the web layer can distinguish the admin-denied
     page from a service-outage page.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/admin/settings/registration-mode",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(
-            f"auth /admin/settings/registration-mode transport error: {exc}"
-        ) from exc
-    if resp.status_code in (401, 403):
-        raise AuthForbidden(f"auth /admin/settings/registration-mode returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AuthClientError(
-            f"auth /admin/settings/registration-mode returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/admin/settings/registration-mode",
+        token=token,
+        error_prefix="auth /admin/settings/registration-mode ",
+        **_ERR,
+    )
     data = resp.json()
     return RegistrationMode(
         mode=str(data["mode"]),
@@ -654,26 +618,23 @@ async def admin_set_registration_mode(
 ) -> tuple[RegistrationMode | None, str | None]:
     """Root-admin-only: flip the registration mode. Returns (view, error_code).
 
-    - 200 → (RegistrationMode, None)
-    - 403 with detail.error == "not_root_admin" → (None, "not_root_admin")
+    - 200 -> (RegistrationMode, None)
+    - 403 with detail.error == "not_root_admin" -> (None, "not_root_admin")
       (caller is admin but not UID=1 — surfaces inline rather than
       bouncing to /login; the page still renders for read-only admins)
-    - 422 / other 4xx with a validation-style detail → (None, "invalid_mode")
+    - 422 / other 4xx with a validation-style detail -> (None, "invalid_mode")
 
     Any other 401/403 raises :class:`AuthForbidden`; 5xx / transport
     raise :class:`AuthClientError`.
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.put(
-                f"{base_url}/admin/settings/registration-mode",
-                headers={"Authorization": f"Bearer {token}"},
-                json={"mode": mode},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(
-            f"auth PUT /admin/settings/registration-mode transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "PUT",
+        f"{base_url}/admin/settings/registration-mode",
+        token=token,
+        json={"mode": mode},
+        error_prefix="auth PUT /admin/settings/registration-mode ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         data = resp.json()
         return RegistrationMode(
@@ -744,15 +705,14 @@ async def admin_create_invite(
         "max_uses": max_uses,
         "role": role,
     }
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/invites",
-                headers={"Authorization": f"Bearer {token}"},
-                json=payload,
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth POST /admin/invites transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/invites",
+        token=token,
+        json=payload,
+        error_prefix="auth POST /admin/invites ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (401, 403):
         raise AuthForbidden(f"auth POST /admin/invites returned {resp.status_code}")
     if resp.status_code != 201:
@@ -775,19 +735,14 @@ async def admin_list_invites(
     per_page: int = 50,
 ) -> tuple[list[InviteItem], int]:
     """Admin-only: list pending (unused, unexpired) invites."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/admin/invites",
-                headers={"Authorization": f"Bearer {token}"},
-                params={"page": page, "per_page": per_page},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth GET /admin/invites transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AuthForbidden(f"auth GET /admin/invites returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AuthClientError(f"auth GET /admin/invites returned {resp.status_code}: {resp.text}")
+    resp = await request(
+        "GET",
+        f"{base_url}/admin/invites",
+        token=token,
+        params={"page": page, "per_page": per_page},
+        error_prefix="auth GET /admin/invites ",
+        **_ERR,
+    )
     data = resp.json()
     items = [
         InviteItem(
@@ -813,14 +768,13 @@ async def admin_revoke_invite(
     invite_id: str,
 ) -> tuple[bool, str | None]:
     """Admin-only: revoke a pending invite. Returns (ok, error_code)."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.delete(
-                f"{base_url}/admin/invites/{invite_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth DELETE /admin/invites transport error: {exc}") from exc
+    resp = await raw_request(
+        "DELETE",
+        f"{base_url}/admin/invites/{invite_id}",
+        token=token,
+        error_prefix="auth DELETE /admin/invites ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):
@@ -839,9 +793,14 @@ async def public_get_registration_mode(base_url: str) -> str:
     sign up.
     """
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(f"{base_url}/auth/registration-mode")
-    except httpx.HTTPError:
+        resp = await raw_request(
+            "GET",
+            f"{base_url}/auth/registration-mode",
+            timeout=5.0,
+            error_prefix="auth /registration-mode ",
+            **_ERR_RAW,
+        )
+    except AuthClientError:
         return "invite_only"
     if resp.status_code != 200:
         return "invite_only"
@@ -874,11 +833,13 @@ async def public_register(
     payload: dict[str, Any] = {"email": email, "password": password}
     if invite_token:
         payload["token"] = invite_token
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(f"{base_url}/auth/register", json=payload)
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth POST /auth/register transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/auth/register",
+        json=payload,
+        error_prefix="auth POST /auth/register ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 201:
         return True, None
     if resp.status_code in (400, 403, 409, 422):
@@ -909,15 +870,14 @@ async def admin_create_user(
         "role": role,
         "must_change_password": must_change_password,
     }
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/users",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body,
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth POST /admin/users transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/users",
+        token=token,
+        json=body,
+        error_prefix="auth POST /admin/users ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 201:
         u = resp.json()
         return UserItem(
@@ -953,15 +913,14 @@ async def admin_update_user(
         body["role"] = role
     if disabled is not None:
         body["disabled"] = disabled
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.patch(
-                f"{base_url}/admin/users/{user_id}",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body,
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth PATCH /admin/users/{user_id} transport error: {exc}") from exc
+    resp = await raw_request(
+        "PATCH",
+        f"{base_url}/admin/users/{user_id}",
+        token=token,
+        json=body,
+        error_prefix=f"auth PATCH /admin/users/{user_id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         u = resp.json()
         return UserItem(
@@ -996,14 +955,13 @@ async def admin_revoke_user_sessions(
     user_id: int,
 ) -> tuple[int | None, str | None]:
     """Admin-only: revoke all sessions for a user."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/users/{user_id}/revoke-sessions",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth POST revoke-sessions transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/users/{user_id}/revoke-sessions",
+        token=token,
+        error_prefix="auth POST revoke-sessions ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         return int(resp.json().get("revoked_count", 0)), None
     if resp.status_code in (401, 403):
@@ -1019,15 +977,15 @@ async def admin_cleanup_stale_agents(
     stale_days: int = 90,
 ) -> tuple[int | None, str | None]:
     """Admin-only: revoke agents not seen for stale_days."""
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/agents/cleanup-stale",
-                headers={"Authorization": f"Bearer {token}"},
-                params={"stale_days": stale_days},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth POST cleanup-stale transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/agents/cleanup-stale",
+        token=token,
+        timeout=30.0,
+        params={"stale_days": stale_days},
+        error_prefix="auth POST cleanup-stale ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         return int(resp.json().get("revoked_count", 0)), None
     if resp.status_code in (401, 403):
@@ -1052,14 +1010,13 @@ async def admin_reingest_agent(
     - 200 -> (affected_count, None)
     - 404 -> (0, "agent_not_found")
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/agents/{agent_id}/reingest",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth POST reingest-agent transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/agents/{agent_id}/reingest",
+        token=token,
+        error_prefix="auth POST reingest-agent ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         return int(resp.json().get("affected_count", 0)), None
     if resp.status_code in (401, 403):
@@ -1079,14 +1036,13 @@ async def admin_reingest_user_agents(
     - 200 -> (affected_count, None)
     - 404 -> (0, "user_not_found")
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/users/{user_id}/reingest",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth POST reingest-user transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/users/{user_id}/reingest",
+        token=token,
+        error_prefix="auth POST reingest-user ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         return int(resp.json().get("affected_count", 0)), None
     if resp.status_code in (401, 403):
@@ -1104,14 +1060,13 @@ async def admin_reingest_all_agents(
 
     - 200 -> (affected_count, None)
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/agents/reingest-all",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth POST reingest-all transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/agents/reingest-all",
+        token=token,
+        error_prefix="auth POST reingest-all ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         return int(resp.json().get("affected_count", 0)), None
     if resp.status_code in (401, 403):
@@ -1127,17 +1082,16 @@ async def admin_reset_password(
     """Admin-only: rotate another user's password.
 
     Returns ``(temporary_password, error_code)``:
-    - 200 → (temp, None)
-    - 404 → (None, "user_not_found")
+    - 200 -> (temp, None)
+    - 404 -> (None, "user_not_found")
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{base_url}/admin/users/{user_id}/reset-password",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth /admin/users reset-password transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/admin/users/{user_id}/reset-password",
+        token=token,
+        error_prefix="auth /admin/users reset-password ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         return str(resp.json()["temporary_password"]), None
     if resp.status_code in (401, 403):
@@ -1167,20 +1121,13 @@ class TunablesResult:
 
 async def admin_get_tunables(base_url: str, token: str) -> TunablesResult:
     """Admin-only: read all tunables (mutable + read-only constants)."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/admin/settings/tunables",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth GET /admin/settings/tunables transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AuthForbidden(f"auth GET /admin/settings/tunables returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AuthClientError(
-            f"auth GET /admin/settings/tunables returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/admin/settings/tunables",
+        token=token,
+        error_prefix="auth GET /admin/settings/tunables ",
+        **_ERR,
+    )
     data = resp.json()
     return TunablesResult(
         backfill_batch_size=int(data["backfill_batch_size"]),
@@ -1203,17 +1150,14 @@ async def admin_update_tunables(
     - 200 -> (TunablesResult, None)
     - 400/422 -> (None, "validation_error")
     """
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.patch(
-                f"{base_url}/admin/settings/tunables",
-                headers={"Authorization": f"Bearer {token}"},
-                json=updates,
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(
-            f"auth PATCH /admin/settings/tunables transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "PATCH",
+        f"{base_url}/admin/settings/tunables",
+        token=token,
+        json=updates,
+        error_prefix="auth PATCH /admin/settings/tunables ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         data = resp.json()
         return TunablesResult(
@@ -1254,9 +1198,14 @@ class MotdResult:
 async def public_get_motd(base_url: str) -> MotdResult:
     """Public read of the active MOTD."""
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(f"{base_url}/auth/motd")
-    except httpx.HTTPError:
+        resp = await raw_request(
+            "GET",
+            f"{base_url}/auth/motd",
+            timeout=5.0,
+            error_prefix="auth /motd ",
+            **_ERR_RAW,
+        )
+    except AuthClientError:
         return MotdResult(active=False)
     if resp.status_code != 200:
         return MotdResult(active=False)
@@ -1280,20 +1229,13 @@ async def public_get_motd(base_url: str) -> MotdResult:
 
 async def admin_get_motd(base_url: str, token: str) -> MotdResult:
     """Admin-only: read the current MOTD via the admin endpoint."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                f"{base_url}/admin/settings/motd",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth GET /admin/settings/motd transport error: {exc}") from exc
-    if resp.status_code in (401, 403):
-        raise AuthForbidden(f"auth GET /admin/settings/motd returned {resp.status_code}")
-    if resp.status_code >= 400:
-        raise AuthClientError(
-            f"auth GET /admin/settings/motd returned {resp.status_code}: {resp.text}"
-        )
+    resp = await request(
+        "GET",
+        f"{base_url}/admin/settings/motd",
+        token=token,
+        error_prefix="auth GET /admin/settings/motd ",
+        **_ERR,
+    )
     data = resp.json()
     return MotdResult(
         active=bool(data.get("active")),
@@ -1321,15 +1263,14 @@ async def admin_set_motd(
         "severity": severity,
         "expires_at": expires_at,
     }
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.put(
-                f"{base_url}/admin/settings/motd",
-                headers={"Authorization": f"Bearer {token}"},
-                json=body_payload,
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth PUT /admin/settings/motd transport error: {exc}") from exc
+    resp = await raw_request(
+        "PUT",
+        f"{base_url}/admin/settings/motd",
+        token=token,
+        json=body_payload,
+        error_prefix="auth PUT /admin/settings/motd ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 200:
         data = resp.json()
         return MotdResult(
@@ -1356,14 +1297,13 @@ async def admin_clear_motd(
     token: str,
 ) -> tuple[bool, str | None]:
     """Admin-only: clear the active MOTD."""
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.delete(
-                f"{base_url}/admin/settings/motd",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise AuthClientError(f"auth DELETE /admin/settings/motd transport error: {exc}") from exc
+    resp = await raw_request(
+        "DELETE",
+        f"{base_url}/admin/settings/motd",
+        token=token,
+        error_prefix="auth DELETE /admin/settings/motd ",
+        **_ERR_RAW,
+    )
     if resp.status_code == 204:
         return True, None
     if resp.status_code in (401, 403):

--- a/services/web/web_service/http_helper.py
+++ b/services/web/web_service/http_helper.py
@@ -1,0 +1,129 @@
+"""Shared HTTP helpers for internal-service client modules.
+
+Centralises the ``httpx.AsyncClient`` lifecycle and error-classification
+boilerplate that was copy-pasted across :mod:`analytics_client`,
+:mod:`auth_client`, and :mod:`parser_client`.
+
+Two helpers are provided:
+
+* :func:`raw_request` — opens a short-lived ``AsyncClient``, injects an
+  ``Authorization`` header when *token* is given, and wraps any
+  :class:`httpx.HTTPError` in *error_cls*.  The raw
+  :class:`httpx.Response` is returned so the caller can do its own
+  status-code handling.
+
+* :func:`request` — calls :func:`raw_request`, then applies the
+  standard "401/403 → *forbidden_cls*; ≥ 400 → *error_cls*" checks that
+  most endpoints share.  Functions with non-standard status-code logic
+  should use :func:`raw_request` directly.
+
+Both helpers also move the duplicated ``_parse_dt`` utility out of the
+individual client modules.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Shared datetime parser (was duplicated in analytics_client + auth_client)
+# ---------------------------------------------------------------------------
+
+
+def parse_dt(raw: Any) -> datetime | None:
+    """Parse an ISO-8601 datetime string, tolerating a trailing ``Z``."""
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# HTTP request helpers
+# ---------------------------------------------------------------------------
+
+
+async def raw_request(
+    method: str,
+    url: str,
+    *,
+    token: str | None = None,
+    timeout: float = 10.0,
+    error_cls: type[Exception] = Exception,
+    error_prefix: str = "",
+    **kwargs: Any,
+) -> httpx.Response:
+    """Fire a single HTTP request and return the raw response.
+
+    *error_cls* is the exception type raised when ``httpx.HTTPError``
+    occurs (transport failure, DNS, timeout).  The caller is responsible
+    for all status-code interpretation.
+
+    Any extra *kwargs* are forwarded to ``client.request`` — use this
+    for ``json=``, ``params=``, ``data=``, etc.
+    """
+    headers: dict[str, str] = dict(kwargs.pop("headers", None) or {})
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            # Use the method-specific shortcut (client.get, client.post, ...)
+            # rather than client.request so that existing test stubs that
+            # monkeypatch individual verbs continue to work.
+            verb = method.upper()
+            if verb == "GET":
+                return await client.get(url, headers=headers, **kwargs)
+            if verb == "POST":
+                return await client.post(url, headers=headers, **kwargs)
+            if verb == "PUT":
+                return await client.put(url, headers=headers, **kwargs)
+            if verb == "PATCH":
+                return await client.patch(url, headers=headers, **kwargs)
+            if verb == "DELETE":
+                return await client.delete(url, headers=headers, **kwargs)
+            return await client.request(method, url, headers=headers, **kwargs)
+    except httpx.HTTPError as exc:
+        raise error_cls(f"{error_prefix}transport error: {exc}") from exc
+
+
+async def request(
+    method: str,
+    url: str,
+    *,
+    token: str | None = None,
+    timeout: float = 10.0,
+    error_cls: type[Exception] = Exception,
+    forbidden_cls: type[Exception] = Exception,
+    error_prefix: str = "",
+    **kwargs: Any,
+) -> httpx.Response:
+    """Fire a request with standard status-code error handling.
+
+    After obtaining the response via :func:`raw_request`:
+
+    * 401 / 403 → raises *forbidden_cls*
+    * any other ≥ 400 → raises *error_cls*
+
+    If the endpoint has special handling for certain codes (404 → None,
+    409 → error tuple, etc.) use :func:`raw_request` instead and handle
+    them in the caller.
+    """
+    resp = await raw_request(
+        method,
+        url,
+        token=token,
+        timeout=timeout,
+        error_cls=error_cls,
+        error_prefix=error_prefix,
+        **kwargs,
+    )
+    if resp.status_code in (401, 403):
+        raise forbidden_cls(f"{error_prefix}returned {resp.status_code}")
+    if resp.status_code >= 400:
+        raise error_cls(f"{error_prefix}returned {resp.status_code}: {resp.text}")
+    return resp

--- a/services/web/web_service/parser_client.py
+++ b/services/web/web_service/parser_client.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import httpx
+from web_service.http_helper import raw_request
 
 
 class ParserClientError(Exception):
@@ -32,6 +32,10 @@ class ParserRateLimited(Exception):
         self.retry_at = retry_at
 
 
+# Shorthand kwargs for all parser helpers.
+_ERR_RAW = {"error_cls": ParserClientError}
+
+
 @dataclass
 class DeletedCountResult:
     deleted_count: int
@@ -51,15 +55,15 @@ async def delete_my_matches(
     params: dict[str, str] = {}
     if agent_id is not None:
         params["agent_id"] = agent_id
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.delete(
-                f"{base_url}/parser/matches",
-                headers={"Authorization": f"Bearer {token}"},
-                params=params,
-            )
-    except httpx.HTTPError as exc:
-        raise ParserClientError(f"parser DELETE /parser/matches transport error: {exc}") from exc
+    resp = await raw_request(
+        "DELETE",
+        f"{base_url}/parser/matches",
+        token=token,
+        timeout=30.0,
+        params=params,
+        error_prefix="parser DELETE /parser/matches ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (401, 403):
         raise ParserForbidden(f"parser DELETE /parser/matches returned {resp.status_code}")
     if resp.status_code >= 400:
@@ -75,16 +79,14 @@ async def admin_delete_all_matches(
     token: str,
 ) -> DeletedCountResult:
     """Admin nuclear: delete ALL parsed matches across all users."""
-    try:
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            resp = await client.delete(
-                f"{base_url}/parser/admin/matches",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise ParserClientError(
-            f"parser DELETE /parser/admin/matches transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "DELETE",
+        f"{base_url}/parser/admin/matches",
+        token=token,
+        timeout=60.0,
+        error_prefix="parser DELETE /parser/admin/matches ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (401, 403):
         raise ParserForbidden(f"parser DELETE /parser/admin/matches returned {resp.status_code}")
     if resp.status_code >= 400:
@@ -110,17 +112,15 @@ async def admin_delete_user_matches(
     params: dict[str, str] = {}
     if agent_id is not None:
         params["agent_id"] = agent_id
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.delete(
-                f"{base_url}/parser/admin/matches/{user_id}",
-                headers={"Authorization": f"Bearer {token}"},
-                params=params,
-            )
-    except httpx.HTTPError as exc:
-        raise ParserClientError(
-            f"parser DELETE /parser/admin/matches/{user_id} transport error: {exc}"
-        ) from exc
+    resp = await raw_request(
+        "DELETE",
+        f"{base_url}/parser/admin/matches/{user_id}",
+        token=token,
+        timeout=30.0,
+        params=params,
+        error_prefix=f"parser DELETE /parser/admin/matches/{user_id} ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (401, 403):
         raise ParserForbidden(
             f"parser DELETE /parser/admin/matches/{user_id} returned {resp.status_code}"
@@ -143,14 +143,14 @@ async def user_self_service_reparse(
     Raises :class:`ParserRateLimited` on 429 with retry-after metadata
     so the web layer can render a "try again at HH:MM" message.
     """
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(
-                f"{base_url}/parser/me/reparse",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        raise ParserClientError(f"parser POST /parser/me/reparse transport error: {exc}") from exc
+    resp = await raw_request(
+        "POST",
+        f"{base_url}/parser/me/reparse",
+        token=token,
+        timeout=30.0,
+        error_prefix="parser POST /parser/me/reparse ",
+        **_ERR_RAW,
+    )
     if resp.status_code in (401, 403):
         raise ParserForbidden(f"parser POST /parser/me/reparse returned {resp.status_code}")
     if resp.status_code == 429:


### PR DESCRIPTION
## Summary

- Extracts `raw_request()` and `request()` helpers into new `services/web/web_service/http_helper.py`, eliminating ~84 duplicated `httpx.AsyncClient` instantiations across `analytics_client.py`, `auth_client.py`, and `parser_client.py`
- Deduplicates `_parse_dt()` (was copy-pasted identically in analytics_client and auth_client) into the shared module
- Net reduction of ~360 lines with zero behavioral change — all function signatures, exception types, and status-code semantics are preserved

## Design

Two helper tiers:
- **`raw_request()`** — handles AsyncClient lifecycle, auth header injection, and transport-error wrapping. Returns the raw `httpx.Response` for callers with custom status-code logic (404→None, 409→error tuple, etc.)
- **`request()`** — calls `raw_request()` then applies the standard 401/403→Forbidden, ≥400→ClientError checks that ~60% of endpoints share

Each client module defines shorthand dicts (`_ERR`, `_ERR_RAW`) to pass its own exception classes through, preserving the existing error type hierarchy that callers depend on.

## What was NOT changed
- `services/parser/parser_service/analytics_client.py` — separate package with its own retry logic; no natural shared-client opportunity
- No caller code changes — `main.py` and all route handlers are untouched
- No test changes — all 302 existing tests pass unmodified

## Test plan
- [x] `ruff check services/web/` — clean
- [x] `ruff format --check services/web/` — clean
- [x] `mypy` on all changed files — clean
- [x] `pytest services/web/tests/ -v` — 302 passed, 0 failed
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)