### PR TITLE
fix: dedupe favicon.svg in wheel build

### DIFF
--- a/services/web/pyproject.toml
+++ b/services/web/pyproject.toml
@@ -20,7 +20,3 @@ dependencies = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["web_service"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"web_service/templates" = "web_service/templates"
-"web_service/static" = "web_service/static"


### PR DESCRIPTION
## Root cause

The wheel build for the `web` service failed in CI with:

```
ValueError: A second file is being added to the wheel archive at the same path: `web_service/static/favicon.svg`.
```

In `services/web/pyproject.toml`, `[tool.hatch.build.targets.wheel] packages = ["web_service"]` already tells hatchling to include the entire `web_service` directory tree (including `static/` and `templates/`). The separate `[tool.hatch.build.targets.wheel.force-include]` section then re-added `web_service/static` and `web_service/templates`, producing duplicate archive paths and the hard failure.

## Fix

Remove the redundant `[tool.hatch.build.targets.wheel.force-include]` section. The `packages = ["web_service"]` declaration already packages all static assets and templates.

## Verification

- `uv build --wheel` succeeds (exit 0), no duplicate-path error. `favicon.svg` appears exactly once and all templates/static assets are present in the wheel.
- `docker compose build web` completes cleanly.